### PR TITLE
added nfs-utils, and fix the way docker is installed

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -6,8 +6,7 @@
     "binary_bucket_region": "us-west-2",
     "binary_bucket_path": "1.10.3/2018-06-05/bin/linux/amd64",
     "creator": "{{env `USER`}}",
-    "instance_type": "m4.large",
-    "source_ami_id": ""
+    "instance_type": "m4.large"
   },
 
   "builders": [

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -6,7 +6,8 @@
     "binary_bucket_region": "us-west-2",
     "binary_bucket_path": "1.10.3/2018-06-05/bin/linux/amd64",
     "creator": "{{env `USER`}}",
-    "instance_type": "m4.large"
+    "instance_type": "m4.large",
+    "source_ami_id": ""
   },
 
   "builders": [

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -16,6 +16,7 @@ sudo yum update -y
 sudo yum install -y \
     aws-cfn-bootstrap \
     conntrack \
+    nfs-utils \
     curl \
     socat \
     unzip \
@@ -44,7 +45,7 @@ sudo systemctl enable iptables-restore
 ################################################################################
 
 sudo yum install -y yum-utils device-mapper-persistent-data lvm2
-sudo yum install -y docker
+sudo amazon-linux-extras install -y docker
 sudo usermod -aG docker $USER
 
 # Enable docker daemon to start on boot.

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -44,6 +44,7 @@ sudo systemctl enable iptables-restore
 ################################################################################
 
 sudo yum install -y yum-utils device-mapper-persistent-data lvm2
+sudo amazon-linux-extras enable docker
 sudo yum install -y docker
 sudo usermod -aG docker $USER
 

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -16,7 +16,6 @@ sudo yum update -y
 sudo yum install -y \
     aws-cfn-bootstrap \
     conntrack \
-    nfs-utils \
     curl \
     socat \
     unzip \
@@ -45,7 +44,7 @@ sudo systemctl enable iptables-restore
 ################################################################################
 
 sudo yum install -y yum-utils device-mapper-persistent-data lvm2
-sudo amazon-linux-extras install -y docker
+sudo yum install -y docker
 sudo usermod -aG docker $USER
 
 # Enable docker daemon to start on boot.


### PR DESCRIPTION
*Issue #, if available:* #1 

*Description of changes:*
Docker on Amazon Linux 2 is a amazon linux extra and not part of the 'core' distribution, to install docker you need to use amazon-linux-extras command.

Also added nfs-utils to the worker image as in my test I'm using EFS to store data

Also added the source_ami_id variable, as an empty one, as mention in Issue #1 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
