### PR TITLE
Fixed docker installation command

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -44,7 +44,7 @@ sudo systemctl enable iptables-restore
 ################################################################################
 
 sudo yum install -y yum-utils device-mapper-persistent-data lvm2
-sudo yum install -y docker
+sudo amazon-linux-extras install docker -y
 sudo usermod -aG docker $USER
 
 # Enable docker daemon to start on boot.


### PR DESCRIPTION
amazon-linux-extras install has to be used instead of yum

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
