### PR TITLE
Make sure ntp is installed and enabled

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -25,7 +25,7 @@ sudo yum install -y \
     unzip \
     wget
 
-systemctl enable ntpd
+sudo systemctl enable ntpd
 
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 sudo python get-pip.py

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -20,9 +20,12 @@ sudo yum install -y \
     conntrack \
     curl \
     nfs-utils \
+    ntp \
     socat \
     unzip \
     wget
+
+systemctl enable ntpd
 
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 sudo python get-pip.py


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Given how important NTP is to the functioning of so many services, including just about anything time-aware running in Kubernetes, the AMI should install and enable it by default. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
