### PR TITLE
modify dockerd configuration

### DIFF
--- a/files/docker
+++ b/files/docker
@@ -1,1 +1,1 @@
-DOCKER_OPTS="--pidfile /var/run/docker.pid --no-new-privileges --iptables=false --log-level=warn --live-restore --userland-proxy=false"
+DOCKER_OPTS="--pidfile /var/run/docker.pid --no-new-privileges --iptables=false --log-level=info --live-restore --userland-proxy=false"

--- a/files/docker
+++ b/files/docker
@@ -1,0 +1,1 @@
+DOCKER_OPTS="--pidfile /var/run/docker.pid --no-new-privileges --iptables=false --log-level=warn --live-restore --userland-proxy=false"

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -53,6 +53,8 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 sudo amazon-linux-extras enable docker
 sudo yum install -y docker-17.06*
 sudo usermod -aG docker $USER
+sudo sed -i -- 's!ExecStart=/usr/bin/dockerd!ExecStart=/usr/bin/dockerd --host=fd:// $DOCKER_OPTS!g' /usr/lib/systemd/system/docker.service
+sudo mv $TEMPLATE_DIR/docker /etc/default/docker
 
 # Enable docker daemon to start on boot.
 sudo systemctl daemon-reload


### PR DESCRIPTION
*Issue #, if available:*

By default, `dockerd` is missing basic security parameters. I would like to add  specific `dockerd` parameters to make the daemon more secure and to build a solid and secure foundation for executing containerized workloads.

*Description of changes:*

`--no-new-privileges` Prevents LSMs like SELinux from transitioning to process labels that have access not allowed to the current process.

`--iptables=false` Docker daemon service start requires iptables rules to be enabled before it starts. Any restarts of iptables during docker daemon operation may result in losing docker-created rules.

`--live-restore` Enables full support of daemon-less containers in docker. It ensures that docker does not stop containers on shutdown or restore and properly reconnects to the container when restarted.

`--userland-proxy=false` The docker daemon starts a userland proxy service for port forwarding whenever a port is exposed. Where hairpin NAT is available, this service is generally superfluous to requirements and can be disabled.

`--log-level=info` Ensure the logging level is set to `info`.