### PR TITLE
Add ability to modify node root volume size + aws stack name labels

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -259,6 +259,7 @@ Resources:
           !Sub |
             #!/bin/bash
             set -o xtrace
+            export KUBELET_EXTRA_ARGS="--node-labels aws-stack-name=${AWS::StackName}"
             /etc/eks/bootstrap.sh ${ClusterName}
             /opt/aws/bin/cfn-signal --exit-code $? \
                      --stack  ${AWS::StackName} \

--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -84,6 +84,11 @@ Parameters:
     Description: Maximum size of Node Group ASG.
     Default: 3
 
+  NodeVolumeSize:
+    Type: Number
+    Description: Node volume size
+    Default: 20
+
   ClusterName:
     Description: The cluster name provided when the cluster was created. If it is incorrect, nodes will not be able to join the cluster.
     Type: String
@@ -122,6 +127,7 @@ Metadata:
           - NodeAutoScalingGroupMaxSize
           - NodeInstanceType
           - NodeImageId
+          - NodeVolumeSize
           - KeyName
       -
         Label:
@@ -242,6 +248,12 @@ Resources:
       KeyName: !Ref KeyName
       SecurityGroups:
       - !Ref NodeSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: !Ref NodeVolumeSize
+            VolumeType: gp2
+            DeleteOnTermination: true
       UserData:
         Fn::Base64:
           !Sub |

--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -259,7 +259,6 @@ Resources:
           !Sub |
             #!/bin/bash
             set -o xtrace
-            export KUBELET_EXTRA_ARGS="--node-labels aws-stack-name=${AWS::StackName}"
             /etc/eks/bootstrap.sh ${ClusterName}
             /opt/aws/bin/cfn-signal --exit-code $? \
                      --stack  ${AWS::StackName} \


### PR DESCRIPTION
*Issue #, if available:*

By default its 20 Gb which can be too low for some workloads.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
