### PR TITLE
Optional support for KMS encryption of boot volume

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -7,7 +7,9 @@
     "binary_bucket_path": "1.10.3/2018-07-26/bin/linux/amd64",
     "creator": "{{env `USER`}}",
     "instance_type": "m4.large",
-    "source_ami_id": ""
+    "source_ami_id": "",
+    "encrypted": "false",
+    "kms_key_id": ""
   },
 
   "builders": [
@@ -37,6 +39,8 @@
       ],
       "ssh_username": "ec2-user",
       "ssh_pty": true,
+      "encrypt_boot": "{{user `encrypted`}}",
+      "kms_key_id": "{{user `kms_key_id`}}",
       "run_tags": {
           "creator": "{{user `creator`}}"
       },


### PR DESCRIPTION
*Issue #, if available:* None.

*Description of changes:* Adds optional KMS encryption of boot volume, which is disabled by default. Tested builds with KMS both enabled and disabled with no ill effects observed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
