### PR TITLE
Allow communication on TCP:443 from EKS Cluster to Worker nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ versions by running `aws s3 ls s3://amazon-eks/cloudformation/`.
 
 | CloudFormation Version | EKS AMI versions     |
 | ---------------------- | -------------------- |
-| 2018-08-21             | amazon-eks-node-v23+ |
+| 2018-08-30             | amazon-eks-node-v23+ |
 
 For older versions of the EKS AMI (v20-v22), you can find the CloudFormation
 templates in the same bucket under the path `s3://amazon-eks/1.10.3/2018-06-05/`.

--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Amazon EKS - Node Group - Released 2018-08-21'
+Description: 'Amazon EKS - Node Group - Released 2018-08-30'
 
 Parameters:
 
@@ -236,6 +236,28 @@ Resources:
       IpProtocol: tcp
       FromPort: 1025
       ToPort: 65535
+
+  NodeSecurityGroupFromControlPlaneOn443Ingress:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow pods running extension API servers on port 443 to receive communication from cluster control plane
+      GroupId: !Ref NodeSecurityGroup
+      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+
+  ControlPlaneEgressToNodeSecurityGroupOn443:
+    Type: AWS::EC2::SecurityGroupEgress
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow the cluster control plane to communicate with pods running extension API servers on port 443
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      DestinationSecurityGroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
 
   ClusterControlPlaneSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress


### PR DESCRIPTION
This is required since most common plugins which use aggregation layer
are deployed as services listening on port 443.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
