### PR TITLE
Add validation for CNI and CNI Plugins downloads - fixes #37

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -77,13 +77,17 @@ sudo mkdir -p /opt/cni/bin
 
 CNI_VERSION=${CNI_VERSION:-"v0.6.0"}
 wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-amd64-${CNI_VERSION}.tgz
+wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-amd64-${CNI_VERSION}.tgz.sha512
+sudo sha512sum -c cni-amd64-${CNI_VERSION}.tgz.sha512
 sudo tar -xvf cni-amd64-${CNI_VERSION}.tgz -C /opt/cni/bin
-rm cni-amd64-${CNI_VERSION}.tgz
+rm cni-amd64-${CNI_VERSION}.tgz cni-amd64-${CNI_VERSION}.tgz.sha512
 
 CNI_PLUGIN_VERSION=${CNI_PLUGIN_VERSION:-"v0.7.1"}
 wget https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-amd64-${CNI_PLUGIN_VERSION}.tgz
+wget https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-amd64-${CNI_PLUGIN_VERSION}.tgz.sha512
+sudo sha512sum -c cni-plugins-amd64-${CNI_PLUGIN_VERSION}.tgz.sha512
 sudo tar -xvf cni-plugins-amd64-${CNI_PLUGIN_VERSION}.tgz -C /opt/cni/bin
-rm cni-plugins-amd64-${CNI_PLUGIN_VERSION}.tgz
+rm cni-plugins-amd64-${CNI_PLUGIN_VERSION}.tgz cni-plugins-amd64-${CNI_PLUGIN_VERSION}.tgz.sha512
 
 echo "Downloading binaries from: s3://$BINARY_BUCKET_NAME"
 S3_DOMAIN="s3-$BINARY_BUCKET_REGION"


### PR DESCRIPTION
*Issue #, if available: 37

*Description of changes:*
Downloads `.sha512` files for CNI and CNI Plugins files, then runs `sha512sum` against them. I'm open to shifting to sha256 since its what the S3 downloads validate against, but sha512sum is installed on the base AMI and figured more sha's the better :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
