### PR TITLE
Move source_ami_filter owner to owners

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -21,11 +21,11 @@
         "filters": {
           "architecture": "x86_64",
           "name": "amzn2-ami-minimal-hvm-*",
-          "owner-id": "137112412989",
           "root-device-type": "ebs",
           "state": "available",
           "virtualization-type": "hvm"
         },
+        "owners": [ "137112412989" ],
         "most_recent": true
       },
       "instance_type": "{{user `instance_type`}}",


### PR DESCRIPTION
`owners` will be required when using next version of Packer, see
hashicorp/packer#6585