### PR TITLE
Scrub temporary build-time keypair

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -136,6 +136,9 @@ sudo rm -rf \
 
 # Clean up files to reduce confusion during debug
 sudo rm -rf \
+    /etc/machine-id \
+    /etc/ssh/ssh_host* \
+    /root/.ssh/authorized_keys \
     /home/ec2-user/.ssh/authorized_keys \
     /var/log/secure \
     /var/log/wtmp \
@@ -145,3 +148,5 @@ sudo rm -rf \
     /var/lib/cloud/instances \
     /var/log/cloud-init.log \
     /var/log/cloud-init-output.log
+
+sudo touch /etc/machine-id


### PR DESCRIPTION
This keypair is an artifact of the build process- it's a temporary key and does not represent a secrity risk. However, it is a best practice to remove these keys before publishing, so we've added a step to remove it for all future AMI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
