### PR TITLE
add docker-healthcheck systemd units

### DIFF
--- a/files/docker-healthcheck/docker-healthcheck.service
+++ b/files/docker-healthcheck/docker-healthcheck.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run docker-healthcheck once
+
+[Service]
+Type=oneshot
+ExecStart=/opt/docker-healthcheck/docker-healthcheck
+
+[Install]
+WantedBy=multi-user.target

--- a/files/docker-healthcheck/docker-healthcheck.sh
+++ b/files/docker-healthcheck/docker-healthcheck.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Taken from:
+# https://github.com/kubernetes/kops/blob/e98671c010f3694b164a7eea07f6d5693256fbf3/upup/models/nodeup/docker/_systemd/_debian_family/files/opt/kubernetes/helpers/docker-healthcheck
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is intended to be run periodically, to check the health
+# of docker.  If it detects a failure, it will restart docker using systemctl.
+
+if ! systemctl is-enabled docker > /dev/null; then
+  echo "Docker is not enabled in systemd. Skipping health check"
+  exit 0
+fi
+
+if timeout 10 docker ps > /dev/null; then
+  echo "docker healthy"
+  exit 0
+fi
+
+echo "docker failed"
+echo "Giving docker 30 seconds grace before restarting"
+sleep 30
+
+if timeout 10 docker ps > /dev/null; then
+  echo "docker recovered"
+  exit 0
+fi
+
+echo "docker still down; triggering docker restart"
+timeout 300 systemctl restart docker
+
+echo "Waiting 60 seconds to give docker time to start"
+sleep 60
+
+if timeout 10 docker ps > /dev/null; then
+  echo "docker recovered"
+  exit 0
+fi
+
+echo "docker still failing"

--- a/files/docker-healthcheck/docker-healthcheck.timer
+++ b/files/docker-healthcheck/docker-healthcheck.timer
@@ -4,7 +4,7 @@ Description=Trigger docker-healthcheck periodically
 [Timer]
 # defines a timer relative to when the machine was booted up
 # this will trigger the first run of the docker-healthcheck.service
-OnBootSec=10s
+OnBootSec=2m
 # defines a timer relative to when the unit the timer is activating was last deactivate
 # this will trigger the following runs
 OnUnitInactiveSec=10s

--- a/files/docker-healthcheck/docker-healthcheck.timer
+++ b/files/docker-healthcheck/docker-healthcheck.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Trigger docker-healthcheck periodically
+
+[Timer]
+# defines a timer relative to when the machine was booted up
+# this will trigger the first run of the docker-healthcheck.service
+OnBootSec=10s
+# defines a timer relative to when the unit the timer is activating was last deactivate
+# this will trigger the following runs
+OnUnitInactiveSec=10s
+Unit=docker-healthcheck.service
+
+[Install]
+WantedBy=multi-user.target

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -132,6 +132,10 @@ sudo chmod +x "$DHC_PATH/docker-healthcheck"
 sudo mv $DHC_TEMPLATES/docker-healthcheck.service /etc/systemd/system/
 sudo mv $DHC_TEMPLATES/docker-healthcheck.timer   /etc/systemd/system/
 
+# Enable docker-healthcheck to start on boot.
+sudo systemctl daemon-reload
+sudo systemctl enable docker-healthcheck.timer
+
 
 ################################################################################
 ### EKS ########################################################################

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -119,6 +119,20 @@ sudo systemctl daemon-reload
 # Disable the kubelet until the proper dropins have been configured
 sudo systemctl disable kubelet
 
+
+################################################################################
+### Docker HealthCheck #########################################################
+################################################################################
+
+DHC_PATH="/opt/docker-healthcheck"
+DHC_TEMPLATES="$TEMPLATE_DIR/docker-healthcheck"
+sudo mkdir -p "$DHC_PATH"
+sudo mv "$DHC_TEMPLATES/docker-healthcheck.sh" "$DHC_PATH/docker-healthcheck"
+sudo chmod +x "$DHC_PATH/docker-healthcheck"
+sudo mv $DHC_TEMPLATES/docker-healthcheck.service /etc/systemd/system/
+sudo mv $DHC_TEMPLATES/docker-healthcheck.timer   /etc/systemd/system/
+
+
 ################################################################################
 ### EKS ########################################################################
 ################################################################################


### PR DESCRIPTION
*Issue #, if available:*
The docker daemons in our clusters occasionally freeze.
We found that all mature kubernetes deployments use some sort of health check script on the nodes to ensure docker is still running and restart it when required.

The script in this PR is taken from https://github.com/kubernetes/kops at https://github.com/kubernetes/kops/blob/e98671c010f3694b164a7eea07f6d5693256fbf3/upup/models/nodeup/docker/_systemd/_debian_family/files/opt/kubernetes/helpers/docker-healthcheck

*Description of changes:*
This adds systemd units `docker-healthcheck.service` and `docker-healthcheck.timer` that will together check docker periodically and restart it when it is not responsive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
