### PR TITLE
Add NodeSecurityGroup to outputs.

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -322,3 +322,6 @@ Outputs:
   NodeInstanceRole:
     Description: The node instance role
     Value: !GetAtt NodeInstanceRole.Arn
+  NodeSecurityGroup:
+    Description: The security group for the node group
+    Value: !Ref NodeSecurityGroup


### PR DESCRIPTION
Having the security group as an output is useful for scenarios where one
needs to add additional ingress rules to the node group.

*Issue #, if available:*

*Description of changes:*
This adds the NodeSecurityGroup to the list of outputs. My particular use case for this, is that I'm using this template (multiple times) in a nested stack. We're using it with the https://github.com/zalando-incubator/kube-ingress-aws-controller project.

For each nested stack we need to, in the parent stack, create an extra ingress rule that allows the application load balancer security group to have access to the NodeGroups. This is much easier if we have an export, as alternatively, we're forced into complicated custom resource solutions, for looking up the security group id by logical resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.