### PR TITLE
Change make targets to be .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ SOURCE_AMI_ID ?= $(shell aws ec2 describe-images \
 
 AWS_DEFAULT_REGION = us-west-2
 
+.PHONY: all validate ami
+
 all: ami
 
 validate:


### PR DESCRIPTION
This is a Make best practice, which improves performance and safety. If
there was a file called "ami" in the same directory as the Makefile, the
`make ami` command would potentially not run.

*Issue #, if available:* N/a

*Description of changes:* See the commit message which also appears above. This is an incredibly minor change to match Make best practices , but it could save someone a little time if they happen to have files called "validate" or "ami" in their cloned repo 🙂 Also see [this stackoverflow question](https://stackoverflow.com/questions/2145590/what-is-the-purpose-of-phony-in-a-makefile) for more details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
