### PR TITLE
Feature / Docker Log Rotation

### DIFF
--- a/files/daemon.json
+++ b/files/daemon.json
@@ -1,0 +1,7 @@
+{
+    "log-driver": "json-file",
+    "log-opts": {
+        "max-size": "10m",
+        "max-file": "10"
+    }
+}

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -54,6 +54,10 @@ sudo amazon-linux-extras enable docker
 sudo yum install -y docker-17.06*
 sudo usermod -aG docker $USER
 
+# Enable docker daemon log rotation
+# https://success.docker.com/article/how-to-setup-log-rotation-post-installation
+sudo mv $TEMPLATE_DIR/daemon.json /etc/docker/daemon.json
+
 # Enable docker daemon to start on boot.
 sudo systemctl daemon-reload
 sudo systemctl enable docker


### PR DESCRIPTION
*Issue #, if available:*
Fixes #36 

*Description of changes:*
- Add `daemon.json` file to `/etc/docker/` to enable Docker daemon log rotation using default values shown in the [Docker documentation](https://success.docker.com/article/how-to-setup-log-rotation-post-installation)

The approach above comes from the Docker documentation and is only effective against newly created containers and allows for the defaults to be overridden when launching a container:
```bash
docker run \
    --log-driver json-file \
    --log-opt max-size=10m \
    --log-opt max-file=10 \
    alpine echo hello world
```

A second approach that could also be employed would be to use logrotate (which cannot be overridden from the Docker cli):

```
/var/lib/docker/containers/*/*.log {
  rotate 10
  daily
  compress
  size=10M
  missingok
  delaycompress
  copytruncate
}
```

Either of these configs should protect instances from consuming too much disk space even if in a conservative manner.

Ref:
- https://docs.docker.com/config/containers/logging/json-file/
- https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
