### PR TITLE
Fix kube-proxy logrotate

### DIFF
--- a/files/logrotate-kube-proxy
+++ b/files/logrotate-kube-proxy
@@ -1,4 +1,5 @@
 /var/log/kube-proxy.log {
+    missingok
     rotate 5
     daily
     compress

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -65,6 +65,7 @@ sudo systemctl enable docker
 # kubelet uses journald which has built-in rotation and capped size.
 # See man 5 journald.conf
 sudo mv $TEMPLATE_DIR/logrotate-kube-proxy /etc/logrotate.d/kube-proxy
+sudo chown root:root /etc/logrotate.d/kube-proxy
 sudo mkdir -p /var/log/journal
 
 ################################################################################


### PR DESCRIPTION
Actually rotate kube-proxy log.
Does not error if log is missing.

Current behaviour:
```
# logrotate -v /etc/logrotate.conf 
including /etc/logrotate.d
Ignoring kube-proxy because the file owner is wrong (should be root).
```

New behaviour:
```
# logrotate -v /etc/logrotate.conf
including /etc/logrotate.d 
reading config file kube-proxy

rotating pattern: /var/log/kube-proxy.log  after 1 days (5 rotations)
empty log files are rotated, old logs are removed
considering log /var/log/kube-proxy.log
  log /var/log/kube-proxy.log does not exist -- skipping
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
