### PR TITLE
Adding simple dockerd config file to rotate logs from containers

### DIFF
--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -1,0 +1,7 @@
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "10"
+  }
+}

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -54,6 +54,8 @@ sudo amazon-linux-extras enable docker
 sudo yum install -y docker-17.06*
 sudo usermod -aG docker $USER
 
+sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
+
 # Enable docker daemon to start on boot.
 sudo systemctl daemon-reload
 sudo systemctl enable docker


### PR DESCRIPTION
Related issue is here: https://github.com/awslabs/amazon-eks-ami/issues/36

I myself have seen pods evicted due to disk pressure. Similar configuration is in place on other managed Kubernetes services already.