### PR TITLE
kubelet config files should be owned by root

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -113,7 +113,9 @@ done
 sudo rm *.sha256
 
 sudo mv $TEMPLATE_DIR/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
+sudo chown root:root /var/lib/kubelet/kubeconfig
 sudo mv $TEMPLATE_DIR/kubelet.service /etc/systemd/system/kubelet.service
+sudo chown root:root /etc/systemd/system/kubelet.service
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 
 sudo systemctl daemon-reload


### PR DESCRIPTION
Previously, the ec2-user account owned these files and had permission to write to them.

*Issue #, if available:*

*Description of changes:*

Ownership of `/etc/systemd/system/kubelet.service` and `/var/lib/kubelet/kubeconfig` will now be `root:root` instead of `ec2-user:ec2-user`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
