### PR TITLE
Add max pods information for g3s.xlarge instances

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -42,6 +42,7 @@ g2.8xlarge 234
 g3.4xlarge 234
 g3.8xlarge 234
 g3.16xlarge 737
+g3s.xlarge 58
 h1.2xlarge 58
 h1.4xlarge 234
 h1.8xlarge 234


### PR DESCRIPTION
*Issue #81*

*Description of changes:*
Adds max pods information for g3s.xlarge instances

I also notice that I'm supposed to update the cloudformation template. What was a little surprising is that this template doesn't seem to have the information for any of the GPU-series nodes. Is this intentional?

Depends on https://github.com/aws/amazon-vpc-cni-k8s/pull/218


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
