### PR TITLE
Update eni-max-pods.txt

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -81,6 +81,12 @@ m5.2xlarge 58
 m5.4xlarge 234
 m5.12xlarge 234
 m5.24xlarge 737
+m5a.large 29
+m5a.xlarge 58
+m5a.2xlarge 58
+m5a.4xlarge 234
+m5a.12xlarge 234
+m5a.24xlarge 737
 m5d.large 29
 m5d.xlarge 58
 m5d.2xlarge 58
@@ -110,6 +116,12 @@ r5.2xlarge 58
 r5.4xlarge 234
 r5.12xlarge 234
 r5.24xlarge 737
+r5a.large 29
+r5a.xlarge 58
+r5a.2xlarge 58
+r5a.4xlarge 234
+r5a.12xlarge 234
+r5a.24xlarge 737
 r5d.large 29
 r5d.xlarge 58
 r5d.2xlarge 58


### PR DESCRIPTION
add m5a and r5a instance families

*Issue #, if available:*

*Description of changes:*

add m5a and r5a instance families
https://aws.amazon.com/blogs/aws/new-lower-cost-amd-powered-ec2-instances/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
