### PR TITLE
Remove ntp again

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -21,12 +21,9 @@ sudo yum install -y \
     curl \
     jq \
     nfs-utils \
-    ntp \
     socat \
     unzip \
     wget
-
-sudo systemctl enable ntpd
 
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 sudo python get-pip.py


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Amazon Linux 2 uses chrony as its time-keeping daemon, which is installed and enabled by default. This makes ntpd superfluous.

This reverts the change from #18.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.