### PR TITLE
Add back the allow-privileged kubelet flag

### DIFF
--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -8,6 +8,7 @@ Requires=docker.service
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
 ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
+    --allow-privileged=true \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime docker \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS


### PR DESCRIPTION
The flag is deprecated and is not being added to the kubelet config
file. Privileged access is required for the CNI and kube proxy
containers.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
