### PR TITLE
Swap order of `sed` and `kubectl config`

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -94,13 +94,13 @@ fi
 
 echo $B64_CLUSTER_CA | base64 -d > $CA_CERTIFICATE_FILE_PATH
 
+sed -i s,CLUSTER_NAME,$CLUSTER_NAME,g /var/lib/kubelet/kubeconfig
 kubectl config \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     set-cluster \
     kubernetes \
     --certificate-authority=/etc/kubernetes/pki/ca.crt \
     --server=$APISERVER_ENDPOINT
-sed -i s,CLUSTER_NAME,$CLUSTER_NAME,g /var/lib/kubelet/kubeconfig
 
 ### kubelet.service configuration
 


### PR DESCRIPTION
Issue #102

Swaps the order of the `kubectl config` command and the `sed` command.  The reason is because kubectl will strip off unnecessary quotes.  However, if the name of the cluster is a number, then the quotes should not be stripped off.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.