### PR TITLE
disable docker0 bridge as it is not used on EKS

### DIFF
--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -1,5 +1,5 @@
 {
-  "bip": "203.0.113.1/30",
+  "bridge": "none",
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "10m",

--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -1,4 +1,5 @@
 {
+  "bip": "203.0.113.1/30",
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "10m",


### PR DESCRIPTION
This will reduce the number of possible conflicts to deploy as docker0 is disabled.
*Issue #, if available:* None

*Description of changes:*
As many users may already have 172.17.0.0/16 in their network configuration, this cause some issues with that setup.
A solution is to disable the docker0 bridge , as it is not used should not create any impact.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
