### PR TITLE
Always restart kubelet

### DIFF
--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --container-runtime docker \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
-Restart=on-failure
+Restart=always
 RestartSec=5
 KillMode=process
 


### PR DESCRIPTION
We observed multiple instances of the kubelet just exiting without stating any reason, exit code 0.
It makes sense to restart it on all occasions, not only when it failed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
