### PR TITLE
Add p3dn.24xlarge to node group instance types

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -79,6 +79,7 @@ Parameters:
     - p3.2xlarge
     - p3.8xlarge
     - p3.16xlarge
+    - p3dn.24xlarge
     - r5.large
     - r5.xlarge
     - r5.2xlarge


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For p3dn.24xlarge instance support along with https://github.com/awslabs/amazon-eks-ami/pull/114

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
