### PR TITLE
Use chrony for time and make sure it is enabled on startup.

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -17,16 +17,17 @@ sudo yum update -y
 # Install necessary packages
 sudo yum install -y \
     aws-cfn-bootstrap \
+    chrony \
     conntrack \
     curl \
     jq \
     nfs-utils \
-    ntp \
     socat \
     unzip \
     wget
 
-sudo systemctl enable ntpd
+# Make sure Amazon Time Sync Service starts on boot.
+sudo chkconfig chronyd on
 
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 sudo python get-pip.py


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Used chrony to set time on the Node.

We noticed with the default AMI, NTP does not actually start.

We had an alarm:

```
ALERT ClockSyncBroken
  IF          node_timex_sync_status != 1
  FOR         5m
  LABELS      { severity="warning" }
  ANNOTATIONS {
    summary = "The clock is not being synced.",
    impact = "Random things are about to break for our users",
    detail = "Node: {{$labels.node}}",
  }
```
firing all the time.

Now with the changes made, chronyd is started on boot:
```
[ec2-user@ip-10-0-0-134 ~]$ sudo systemctl status chronyd
● chronyd.service - NTP client/server
   Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
   Active: active (running) since do 2018-12-20 17:44:30 UTC; 13h ago
     Docs: man:chronyd(8)
           man:chrony.conf(5)
 Main PID: 3112 (chronyd)
    Tasks: 1
   Memory: 1.9M
   CGroup: /system.slice/chronyd.service
           └─3112 /usr/sbin/chronyd

dec 20 21:14:23 ip-10-0-0-134.eu-west-1.compute.internal chronyd[3112]: Source 2a00:1288:110:f600::10...6
dec 20 21:44:42 ip-10-0-0-134.eu-west-1.compute.internal chronyd[3112]: Source 193.1.219.116 replaced...6
Warning: Journal has been rotated since unit was started. Log output is incomplete or unavailable.
Hint: Some lines were ellipsized, use -l to show in full.
```

Used https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html to setup chrony.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
