### PR TITLE
Explicitly set the kubelet read only port. Fixes #128.

### DIFF
--- a/files/kubelet-config.json
+++ b/files/kubelet-config.json
@@ -2,6 +2,7 @@
   "kind": "KubeletConfiguration",
   "apiVersion": "kubelet.config.k8s.io/v1beta1",
   "address": "0.0.0.0",
+  "readOnlyPort": 10255,
   "authentication": {
     "anonymous": {
       "enabled": false


### PR DESCRIPTION
*Issue #, if available:* #128 

*Description of changes:* Re-enables the kubelet read only port.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
