### PR TITLE
Increase ulimits for docker containers.

### DIFF
--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -3,5 +3,12 @@
   "log-opts": {
     "max-size": "10m",
     "max-file": "10"
+  },
+  "default-ulimits": {
+    "nofile": {
+      "Name": "nofile",
+      "Soft": 2048,
+      "Hard": 8192
+    }
   }
 }

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -54,6 +54,9 @@ sudo amazon-linux-extras enable docker
 sudo yum install -y docker-17.06*
 sudo usermod -aG docker $USER
 
+# Remove all options from sysconfig docker.
+sudo sed -i '/OPTIONS/d' /etc/sysconfig/docker
+
 sudo mkdir -p /etc/docker
 sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
 sudo chown root:root /etc/docker/daemon.json


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Increase the default ulimits for containers.

We see that on some of our (monolith) apps we run out of file-descriptors. This increases the limit from 1024 to 2048 for soft-limits. The values for the limits are just chosen, we did not research what they should be. We have not had issues with file-descriptors since making the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
