### PR TITLE
    Add a loopback cni device to fix:

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -80,8 +80,17 @@ sudo mkdir -p /etc/kubernetes/manifests
 sudo mkdir -p /var/lib/kubernetes
 sudo mkdir -p /var/lib/kubelet
 sudo mkdir -p /opt/cni/bin
+sudo mkdir -p /etc/cni/net.d
 
 CNI_VERSION=${CNI_VERSION:-"v0.6.0"}
+# Add the CNI loopback device
+cat <<EOF | sudo tee -a /etc/cni/net.d/99-loopback.conf
+{
+	"cniVersion": "${CNI_VERSION}",
+	"name": "lo",
+	"type": "loopback"
+}
+EOF
 wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-amd64-${CNI_VERSION}.tgz
 wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-amd64-${CNI_VERSION}.tgz.sha512
 sudo sha512sum -c cni-amd64-${CNI_VERSION}.tgz.sha512


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a loopback CNI device. This removed error messages when the kubelet starts-up.

I have not dived deep into if it is needed or not. With the latest AMI (built by ourselves) we did see that the Node often went quickly into NonReady state after boot. After a reboot that did not happen.

With this change the Node booted correctly and does not go into NonReady state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
