### PR TITLE
Update kubelet.service to be resilient to SIGPIPE exits

### DIFF
--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -13,7 +13,8 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --container-runtime docker \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
-Restart=on-failure
+Restart=Always
+RestartForceExitStatus=SIGPIPE
 RestartSec=5
 KillMode=process
 

--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --container-runtime docker \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
-Restart=Always
+Restart=on-failure
 RestartForceExitStatus=SIGPIPE
 RestartSec=5
 KillMode=process


### PR DESCRIPTION
Closes #122

https://github.com/awslabs/amazon-eks-ami/pull/110 should be closed in favor of this change.

*Description of changes:*

This makes Kubelet more resilient to crashing. Systemd will now restart kubelet in case it exits with a SIGPIPE as mentioned in #122

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
