### PR TITLE
Addresses #136 - set +e doesn't seem to work. Will return 0 or TEN_RANGE

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -106,9 +106,7 @@ kubectl config \
 
 MAC=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1)
 CIDRS=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks)
-set +e
-TEN_RANGE=$(echo $CIDRS | grep -c '^10\..*')
-set -e
+TEN_RANGE=$(echo $CIDRS | grep -c '^10\..*' || : )
 DNS_CLUSTER_IP=10.100.0.10
 if [[ "$TEN_RANGE" != "0" ]] ; then
     DNS_CLUSTER_IP=172.20.0.10;


### PR DESCRIPTION
*Issue #, if available:*
#136 
*Description of changes:*
Gracefully handle not matching TEN_RANGE and return zero. 
See here: https://unix.stackexchange.com/questions/330660/prevent-grep-from-exiting-in-case-of-nomatch
Remove sets as the +e doesn't seem to work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
