### PR TITLE
Enable RTC sync in chronyd.

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -29,6 +29,15 @@ sudo yum install -y \
 # Make sure Amazon Time Sync Service starts on boot.
 sudo chkconfig chronyd on
 
+# Make sure that chronyd syncs RTC clock to the kernel.
+cat <<EOF | sudo tee -a /etc/chrony.conf
+
+# This directive enables kernel synchronisation (every 11 minutes) of the
+# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
+rtcsync
+
+EOF
+
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 sudo python get-pip.py
 rm get-pip.py

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -31,11 +31,9 @@ sudo chkconfig chronyd on
 
 # Make sure that chronyd syncs RTC clock to the kernel.
 cat <<EOF | sudo tee -a /etc/chrony.conf
-
 # This directive enables kernel synchronisation (every 11 minutes) of the
 # real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
 rtcsync
-
 EOF
 
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"


### PR DESCRIPTION
*Issue #, if available:*
The chronyd service was running but not syncing the RTC clock.

This alarm was still firing:
```
ALERT ClockSyncBroken
  IF          node_timex_sync_status != 1
  FOR         5m
  LABELS      { severity="warning" }
  ANNOTATIONS {
    summary = "The clock is not being synced.",
    impact = "Random things are about to break for our users",
    detail = "Node: {{$labels.node}}",
  }

```
as described in https://github.com/awslabs/amazon-eks-ami/pull/130

***Description of changes:***
After comparing the configuration between an Ubuntu AMI and the AL2 AMI I saw that the chrony.conf differerd.

AL2 was configured to not sync the RTC clock.

After making the changes it does sync and the alarm disappeared:

```
[ec2-user@ip-10-0-19-151 ~]$ sudo systemctl start chronyd
[ec2-user@ip-10-0-19-151 ~]$ ./adjtimex 
    mode:         0
-o  offset:       0 us
-f  freq.adjust:  2155554 (65536 = 1ppm)
    maxerror:     1098
    esterror:     564
    status:       0 ()
-p  timeconstant: 7
    precision:    1 us
    tolerance:    32768000
-t  tick:         9994 us
    time.tv_sec:  1547032282
    time.tv_usec: 176261
    return value: 0 (clock synchronized)
```
Links:
- [Chrony Configuration](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/sect-understanding_chrony_and-its_configuration)
- [Prometheus Node Exporter timex metric](https://github.com/prometheus/node_exporter/blob/master/collector/timex.go)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
