### PR TITLE
Added a separate 'ext4' based partion for /var/lib/docker.

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -18,7 +18,8 @@
     "cni_plugin_version": "v0.7.1",
     "aws_access_key_id": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_access_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-    "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}"
+    "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
+    "docker_ebs_name": "/dev/sdf"
   },
 
   "builders": [
@@ -52,6 +53,12 @@
           "volume_type": "gp2",
           "volume_size": 20,
           "delete_on_termination": true
+        },
+        {
+          "device_name": "{{user `docker_ebs_name`}}",
+          "volume_type": "gp2",
+          "volume_size": 64,
+          "delete_on_termination": true
         }
       ],
       "ssh_username": "ec2-user",
@@ -83,6 +90,13 @@
       "type": "file",
       "source": "./files/",
       "destination": "/tmp/worker/"
+    },
+    {
+      "type": "shell",
+      "script": "setup_docker_ebs.sh",
+      "environment_vars": [
+        "DOCKER_EBS_NAME={{user `docker_ebs_name`}}"
+      ]
     },
     {
       "type": "shell",

--- a/setup_docker_ebs.sh
+++ b/setup_docker_ebs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+function fstab_fmt() {
+  local -r narg=$#
+  for ((i=1 ; i < narg ; i++)); do
+    echo -n "$1" ; echo -n -e "\t" ; shift
+  done
+  echo -n "$1"
+}
+
+# Provision and mount EBS volume to /var/lib/docker
+sudo mkfs.ext4 -L DOCKER $DOCKER_EBS_NAME
+sudo mkdir -vp /var/lib/docker
+sudo mount $DOCKER_EBS_NAME /var/lib/docker
+fstab_opts="defaults,nofail,nodiratime,x-systemd.before=docker.service"
+fstab_fmt "$DOCKER_EBS_NAME" '/var/lib/docker' "ext4" "$fstab_opts" 0 2 | sudo tee -a /etc/fstab


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/79

*Description of changes:*
We have large images in our monolithic application. This commit attaches a separate EBS volume for docker artefacts to accomdate them.

It is possible to specify that the image gets formatted as XFS or ext4. We have been running with ext4 for some weeks now and have not had any issues. We did have issues with XFS, but did not pinpoint as the root cause because there where many other things that we fixed.

The work is mostly copied from @albertrdixon work in the [LumosLab fork](https://github.com/lumoslabs/amazon-eks-ami)
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
