### PR TITLE
Feature/specify docker version cni version

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -5,11 +5,14 @@
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
     "binary_bucket_path": "1.11.5/2018-12-06/bin/linux/amd64",
+    "docker_version": "18",
     "creator": "{{env `USER`}}",
     "instance_type": "m4.large",
     "source_ami_id": "",
     "encrypted": "false",
-    "kms_key_id": ""
+    "kms_key_id": "",
+    "cni_version": "v0.6.0",
+    "cni_plugin_version": "v0.7.4"
   },
 
   "builders": [
@@ -45,10 +48,14 @@
           "creator": "{{user `creator`}}"
       },
       "tags": {
-          "created": "{{timestamp}}"
+          "created": "{{timestamp}}",
+          "docker_version": "{{ user `docker_version`}}",
+          "kubernetes": "{{ user `binary_bucket_path`}}",
+          "cni_version": "{{ user `cni_version`}}",
+          "cni_plugin_version": "{{ user `cni_plugin_version`}}"
       },
       "ami_name": "{{user `ami_name`}}",
-      "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image"
+      "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image (k8s: {{ user `binary_bucket_path`}}, docker:{{ user `docker_version`}})"
     }
   ],
 
@@ -69,7 +76,10 @@
         "AMI_NAME={{user `ami_name`}}",
         "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",
         "BINARY_BUCKET_PATH={{user `binary_bucket_path`}}",
-        "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}"
+        "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}",
+        "DOCKER_VERSION={{user `docker_version`}}",
+        "CNI_VERSION={{user `cni_version`}}",
+        "CNI_PLUGIN_VERSION={{user `cni_plugin_version`}}"
       ]
     }
   ],

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -5,7 +5,7 @@
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
     "binary_bucket_path": "1.11.5/2018-12-06/bin/linux/amd64",
-    "docker_version": "18",
+    "docker_version": "17.06",
     "creator": "{{env `USER`}}",
     "instance_type": "m4.large",
     "source_ami_id": "",

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -51,7 +51,7 @@ sudo systemctl enable iptables-restore
 
 sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 sudo amazon-linux-extras enable docker
-sudo yum install -y docker-17.06*
+sudo yum install -y docker-${DOCKER_VERSION}*
 sudo usermod -aG docker $USER
 
 sudo mkdir -p /etc/docker
@@ -88,7 +88,6 @@ sudo sha512sum -c cni-amd64-${CNI_VERSION}.tgz.sha512
 sudo tar -xvf cni-amd64-${CNI_VERSION}.tgz -C /opt/cni/bin
 rm cni-amd64-${CNI_VERSION}.tgz cni-amd64-${CNI_VERSION}.tgz.sha512
 
-CNI_PLUGIN_VERSION=${CNI_PLUGIN_VERSION:-"v0.7.1"}
 wget https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-amd64-${CNI_PLUGIN_VERSION}.tgz
 wget https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-amd64-${CNI_PLUGIN_VERSION}.tgz.sha512
 sudo sha512sum -c cni-plugins-amd64-${CNI_PLUGIN_VERSION}.tgz.sha512

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -81,7 +81,6 @@ sudo mkdir -p /var/lib/kubernetes
 sudo mkdir -p /var/lib/kubelet
 sudo mkdir -p /opt/cni/bin
 
-CNI_VERSION=${CNI_VERSION:-"v0.6.0"}
 wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-amd64-${CNI_VERSION}.tgz
 wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-amd64-${CNI_VERSION}.tgz.sha512
 sudo sha512sum -c cni-amd64-${CNI_VERSION}.tgz.sha512


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/79
https://github.com/awslabs/amazon-eks-ami/pull/133

*Description of changes:*
Made it possilbe to set the docker and CNI version in the packer file.

Docker version fixed to 17.06 and CNI_PLUGIN_VERSION  upgraded to v0.7.4. I can downgrade that if it is too big of a change!

@micahhausler I think this is really useful. We have upgraded to 18.6 and have had good results. Having the docker version out of the packer spec makes it easy for other people to do it as well. If these other changes to be made then I can do it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
