### PR TITLE
Address issue #138 correct max-pods for t3/t2.small instances

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -133,14 +133,14 @@ r5d.24xlarge 737
 t1.micro 4
 t2.nano 4
 t2.micro 4
-t2.small 8
+t2.small 11
 t2.medium 17
 t2.large 35
 t2.xlarge 44
 t2.2xlarge 44
 t3.nano 4
 t3.micro 4
-t3.small 8
+t3.small 11
 t3.medium 17
 t3.large 35
 t3.xlarge 44


### PR DESCRIPTION
Issue #138

Updated the t2 and t3.small instances max pods to 11 as per the updated CNI plugin version 1.3.0.
Maximum of 11 pods should be schedulable for the above mentioned instance types.
