### PR TITLE
Allow (optional) smaller EBS root volumes with container optimized AMI

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -33,6 +33,14 @@
         {
           "device_name": "/dev/xvda",
           "volume_type": "gp2",
+          "volume_size": 4,
+          "delete_on_termination": true
+        }
+      ],
+      "ami_block_device_mappings": [
+        {
+          "device_name": "/dev/xvda",
+          "volume_type": "gp2",
           "volume_size": 20,
           "delete_on_termination": true
         }


### PR DESCRIPTION
This PR addresses #162 

*Description of changes:*
It is possible to maintain the 20GB *default* root volume size for the AMI while still allowing instances to be launched with a smaller root volume size as long as **the snapshot** associated with the AMI is smaller. The size of the snapshot is determined by the size of the block device on the instance used to build the AMI.

The current [Packer configuration](https://github.com/awslabs/amazon-eks-ami/blob/master/eks-worker-al2.json) uses the `launch_block_device_mappings` property to set the volume size to 20GB and in doing so forces the snapshot to be 20GB as well.

This PR reduces the volume size specified under [launch_block_device_mappings](https://www.packer.io/docs/builders/amazon-ebs.html#launch_block_device_mappings) to 4GB **and** adds the [ami_block_device_mappings](https://www.packer.io/docs/builders/amazon-ebs.html#ami_block_device_mappings) property with a volume size of 20GB. 

This gives us the best of both worlds. The **default is still 20GB** but the AMI user can override BlockDeviceMappings to resize the volume as low as 4GB or as high as EBS supports.

The Amazon Linux 2 minimal AMI has a snapshot size of 2GB. After the EKS AMI is built disk usage is about 1.5GB, so 4GB seems like a reasonable *minimum* value to me as it provides room for additional base packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
