### PR TITLE
Property --cgroup-root was not specified

### DIFF
--- a/files/kubelet-config.json
+++ b/files/kubelet-config.json
@@ -23,6 +23,7 @@
   },
   "clusterDomain": "cluster.local",
   "cgroupDriver": "cgroupfs",
+  "cgroupRoot": "/",
   "featureGates": {
     "RotateKubeletServerCertificate": true
   },


### PR DESCRIPTION
*Issue #, if available:*
closes https://github.com/awslabs/amazon-eks-ami/issues/146

*Description of changes:*
Configure `--cgroup-root=/` and remove noise in the kubelet log

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
