### PR TITLE
Set hairpin mode to "hairpin-veth"

### DIFF
--- a/files/kubelet-config.json
+++ b/files/kubelet-config.json
@@ -22,6 +22,7 @@
     }
   },
   "clusterDomain": "cluster.local",
+  "hairpinMode": "hairpin-veth",
   "cgroupDriver": "cgroupfs",
   "featureGates": {
     "RotateKubeletServerCertificate": true


### PR DESCRIPTION
*Issue #, if available:*
closes https://github.com/awslabs/amazon-eks-ami/issues/147

*Description of changes:*
Configure hairpinMode to hairpin-veth as kubenet is not enabled

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
