### PR TITLE
Add AMI `v20190211` for k8s 1.11 and 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ versions by running `aws s3 ls s3://amazon-eks/cloudformation/`.
 
 | CloudFormation Version | EKS AMI versions                      | [amazon-vpc-cni-k8s](https://github.com/aws/amazon-vpc-cni-k8s/releases) |
 | ---------------------- | ------------------------------------- | -------------------- |
+| 2018-12-10             | amazon-eks-node-(1.11,1.10)-v20190211 | v1.2.1 |
 | 2018-12-10             | amazon-eks-node-(1.11,1.10)-v20181210 | v1.2.1 |
 | 2018-11-07             | amazon-eks-node-v25+                  | v1.2.1 (for t3 and r5 instances) |
 | 2018-08-30             | amazon-eks-node-v23+                  | v1.1.0 |


### PR DESCRIPTION
Relates to https://github.com/awslabs/amazon-eks-ami/commit/6b959bfc065de241f3657eca589f36c1edb517ae

Post: https://aws.amazon.com/security/security-bulletins/AWS-2019-002/