### PR TITLE
update docker version to 18.06

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -5,7 +5,7 @@
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
     "binary_bucket_path": "1.11.5/2018-12-06/bin/linux/amd64",
-    "docker_version": "17.06",
+    "docker_version": "18.06",
     "creator": "{{env `USER`}}",
     "instance_type": "m4.large",
     "source_ami_id": "",

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -59,7 +59,7 @@ sudo systemctl enable iptables-restore
 
 sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 sudo amazon-linux-extras enable docker
-DOCKER_VERSION=${DOCKER_VERSION:-"17.06"}
+DOCKER_VERSION=${DOCKER_VERSION:-"18.06"}
 sudo yum install -y docker-${DOCKER_VERSION}*
 sudo usermod -aG docker $USER
 


### PR DESCRIPTION
*Issue #, if available:*
Updating the docker version installed by default to 18.06
https://alas.aws.amazon.com/ALAS-2019-1156.html

*Description of changes:*
Updated the default docker version to fix https://alas.aws.amazon.com/ALAS-2019-1156.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
