### PR TITLE
Clean resolv.conf before snapshotting

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -175,17 +175,22 @@ sudo rm -rf \
 
 # Clean up files to reduce confusion during debug
 sudo rm -rf \
+    /etc/hostname \
     /etc/machine-id \
+    /etc/resolv.conf \
     /etc/ssh/ssh_host* \
-    /root/.ssh/authorized_keys \
     /home/ec2-user/.ssh/authorized_keys \
-    /var/log/secure \
-    /var/log/wtmp \
-    /var/lib/cloud/sem \
+    /root/.ssh/authorized_keys \
     /var/lib/cloud/data \
     /var/lib/cloud/instance \
     /var/lib/cloud/instances \
+    /var/lib/cloud/sem \
+    /var/lib/dhclient/* \
+    /var/lib/dhcp/dhclient.* \
+    /var/lib/yum/history \
+    /var/log/cloud-init-output.log \
     /var/log/cloud-init.log \
-    /var/log/cloud-init-output.log
+    /var/log/secure \
+    /var/log/wtmp
 
 sudo touch /etc/machine-id


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

`/etc/resolv.conf` was getting the search domain appended with the region the AMI was built in. In the EKS case, this resulted in the following contents for an instance in us-east-2:

```
$ cat /etc/resolv.conf 
; generated by /usr/sbin/dhclient-script
search us-east-2.compute.internal us-west-2.compute.internal
options timeout:2 attempts:5
nameserver 192.168.0.2
```

New instances will now just get the search domain for the region they are launched in:

```
$ cat /etc/resolv.conf 
; generated by /usr/sbin/dhclient-script
search us-east-2.compute.internal 
options timeout:2 attempts:5
nameserver 192.168.0.2
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
