### PR TITLE
Fix bug causing bootstrap.sh to fail for certain instance types

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -121,7 +121,7 @@ INSTANCE_TYPE=$(curl -s http://169.254.169.254/latest/meta-data/instance-type)
 if [[ "$USE_MAX_PODS" = "true" ]]; then
     MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
     set +o pipefail
-    MAX_PODS=$(grep $INSTANCE_TYPE $MAX_PODS_FILE | awk '{print $2}')
+    MAX_PODS=$(grep ^$INSTANCE_TYPE $MAX_PODS_FILE | awk '{print $2}')
     set -o pipefail
     if [[ -n "$MAX_PODS" ]]; then
         echo "$(jq .maxPods=$MAX_PODS $KUBELET_CONFIG)" > $KUBELET_CONFIG


### PR DESCRIPTION
*Description of changes:*

Ran into this today with an i3.16xlarge instance. The bootstrap script tries to `grep` for the first line containing "i3.16xlarge" and pass that to `awk`, but the first line containing "i3.16xlarge" is a comment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
