### PR TITLE
Increase ulimits for docker containers.

### DIFF
--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -6,5 +6,12 @@
     "max-file": "10"
   },
   "live-restore": true,
-  "max-concurrent-downloads": 10
+  "max-concurrent-downloads": 10,
+  "default-ulimits": {
+    "nofile": {
+      "Name": "nofile",
+      "Soft": 2048,
+      "Hard": 8192
+    }
+  }
 }

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -63,6 +63,9 @@ DOCKER_VERSION=${DOCKER_VERSION:-"18.06"}
 sudo yum install -y docker-${DOCKER_VERSION}*
 sudo usermod -aG docker $USER
 
+# Remove all options from sysconfig docker.
+sudo sed -i '/OPTIONS/d' /etc/sysconfig/docker
+
 sudo mkdir -p /etc/docker
 sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
 sudo chown root:root /etc/docker/daemon.json


### PR DESCRIPTION
*Issue #, if available:*

Rebase of #132 for docker 18.06. The configuration failed for docker 17.06, but works on 18.06

*Description of changes:*

Increase the default ulimits for containers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
