### PR TITLE
Add enable-docker-bridge bootstrap argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,4 +100,4 @@ Note: CNI >= 1.2.1 is required for t3 and r5 instance support.
 
 * EKS Launch AMI
 
-<!-- git log --pretty=format:"* %h %s" -->
+<!-- git log --pretty=format:"* %h %s" $(git describe --abbrev=0 --tags)..HEAD -->


### PR DESCRIPTION
*Issue #, if available:*

Fixes #183

*Description of changes:*

* Updated changelog git command
* Added enable-docker-bridge bootstrap argument

The default will be to leave the bridge network disabled, but users can now add `--enable-docker-bridge true` as a bootstrap argument in order to preserve the old behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
