### PR TITLE
Made docker install optional

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -58,21 +58,25 @@ sudo systemctl enable iptables-restore
 ################################################################################
 
 sudo yum install -y yum-utils device-mapper-persistent-data lvm2
-sudo amazon-linux-extras enable docker
-DOCKER_VERSION=${DOCKER_VERSION:-"18.06"}
-sudo yum install -y docker-${DOCKER_VERSION}*
-sudo usermod -aG docker $USER
 
-# Remove all options from sysconfig docker.
-sudo sed -i '/OPTIONS/d' /etc/sysconfig/docker
+INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
+if [[ "$INSTALL_DOCKER" == "true" ]]; then
+    sudo amazon-linux-extras enable docker
+    DOCKER_VERSION=${DOCKER_VERSION:-"18.06"}
+    sudo yum install -y docker-${DOCKER_VERSION}*
+    sudo usermod -aG docker $USER
 
-sudo mkdir -p /etc/docker
-sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
-sudo chown root:root /etc/docker/daemon.json
+    # Remove all options from sysconfig docker.
+    sudo sed -i '/OPTIONS/d' /etc/sysconfig/docker
 
-# Enable docker daemon to start on boot.
-sudo systemctl daemon-reload
-sudo systemctl enable docker
+    sudo mkdir -p /etc/docker
+    sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
+    sudo chown root:root /etc/docker/daemon.json
+
+    # Enable docker daemon to start on boot.
+    sudo systemctl daemon-reload
+    sudo systemctl enable docker
+fi
 
 ################################################################################
 ### Logrotate ##################################################################


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Make docker install optional. Docker is still required, but if you are installing docker in a separate script or using an alternate runtime, this allows you to disable docker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
