### PR TITLE
Update eni-max-pods.txt

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -150,8 +150,8 @@ t3.micro 4
 t3.small 8
 t3.medium 17
 t3.large 35
-t3.xlarge 44
-t3.2xlarge 44
+t3.xlarge 58
+t3.2xlarge 58
 x1.16xlarge 234
 x1.32xlarge 234
 x1e.xlarge 29


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
if I understood correctly the calc for max pods, the t3.xlarge and t3.2xlarge should have 58 available pods.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
