### PR TITLE
changed kube-proxy log rotation from create to copytruncate

### DIFF
--- a/files/logrotate-kube-proxy
+++ b/files/logrotate-kube-proxy
@@ -1,4 +1,5 @@
 /var/log/kube-proxy.log {
+    copytruncate
     missingok
     rotate 5
     daily


### PR DESCRIPTION
*Issue #, if available:*
I am observing kube-proxy fails to write log to /var/log/kube-proxy.log after the file was rotated. I am seeing this behavior when using the latest EKS-Optimized AMI 
- v1.11 ami-0c5b63ec54dd3fc38
- v1.10 ami-0de0b13514617a168

I understand that in the near future kube-proxy logs will be send to stdout/stderr #156 since docker log rotation is enabled. Meanwhile, this change will help troubleshoot issue with kube-proxy

*Description of changes:*
Change the default create to copytruncate for kube-proxy log rotation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
