### PR TITLE
Provide region during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
+AWS_REGION ?= us-west-2
+
 # Defaults to Amazon Linux 2 LTS AMI
 # * use the us-west-2 minimal hvm image
 # https://aws.amazon.com/amazon-linux-2/release-notes/
-SOURCE_AMI_ID ?= $(shell aws ec2 describe-images \
+SOURCE_AMI_ID ?= $(shell aws \
+	--region $(AWS_REGION) \
+	ec2 describe-images \
 	--output text \
 	--filters \
 		Name=owner-id,Values=137112412989 \
@@ -12,8 +16,6 @@ SOURCE_AMI_ID ?= $(shell aws ec2 describe-images \
 		Name=state,Values=available \
 	--query 'max_by(Images[], &CreationDate).ImageId')
 
-AWS_DEFAULT_REGION = us-west-2
-
 .PHONY: all validate ami 1.11 1.10
 
 all: 1.11
@@ -23,6 +25,7 @@ validate:
 
 1.10: validate
 	packer build \
+		-var aws_region=$(AWS_REGION) \
 		-var kubernetes_version=1.10 \
 		-var binary_bucket_path=1.10.13/2019-03-13/bin/linux/amd64 \
 		-var source_ami_id=$(SOURCE_AMI_ID) \
@@ -30,6 +33,7 @@ validate:
 
 1.11: validate
 	packer build \
+		-var aws_region=$(AWS_REGION) \
 		-var kubernetes_version=1.11 \
 		-var binary_bucket_path=1.11.8/2019-03-13/bin/linux/amd64 \
 		-var source_ami_id=$(SOURCE_AMI_ID) \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the Makefile we have `AWS_DEFAULT_REGION` parameter but it's been never used. This pull request will allow us to provide build region and source_ami_id lookup in provided region. Without this such error was produced: `Error querying AMI: InvalidAMIID.NotFound`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
