### PR TITLE
Add PublicIpAddress parameter

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -8,6 +8,14 @@ Parameters:
     Description: The EC2 Key Pair to allow SSH access to the instances
     Type: AWS::EC2::KeyPair::KeyName
 
+  PublicIpAddress:
+    Description: Requests a public IP address from Amazon's public IP address pool.
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    Type: String
+
   NodeImageId:
     Description: AMI id for the node instances.
     Type: AWS::EC2::Image::Id
@@ -164,6 +172,7 @@ Metadata:
           - NodeInstanceType
           - NodeImageId
           - NodeVolumeSize
+          - PublicIpAddress
           - KeyName
           - BootstrapArguments
       - Label:
@@ -296,7 +305,7 @@ Resources:
   NodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: true
+      AssociatePublicIpAddress: !Ref PublicIpAddress
       IamInstanceProfile: !Ref NodeInstanceProfile
       ImageId: !Ref NodeImageId
       InstanceType: !Ref NodeInstanceType


### PR DESCRIPTION
*Description of changes:*

I added the public IP address as a parameter, but keep `true` as default.

I think that some times the nodes will never be EIP associated with it and in most cases, prefer to use Load Balancer to publish the k8s service.

