### PR TITLE
Switched to RPM install for AWS CLI

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -17,6 +17,7 @@ sudo yum update -y
 # Install necessary packages
 sudo yum install -y \
     aws-cfn-bootstrap \
+    awscli \
     chrony \
     conntrack \
     curl \
@@ -35,11 +36,6 @@ cat <<EOF | sudo tee -a /etc/chrony.conf
 # real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
 rtcsync
 EOF
-
-curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
-sudo python get-pip.py
-rm get-pip.py
-sudo pip install --upgrade awscli
 
 ################################################################################
 ### iptables ###################################################################


### PR DESCRIPTION
*Issue #, if available:*

Fixes #194

*Description of changes:*

Performing a `yum upgrade` after installing pip and the AWS CLI from python.org causes python packaging to break. This is resolved by using the AL packaged RPM for the AWS CLI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
