### PR TITLE
Ability to provide custom ami during build

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -9,6 +9,8 @@
     "creator": "{{env `USER`}}",
     "instance_type": "m4.large",
     "source_ami_id": "",
+    "source_ami_owners": "137112412989",
+    "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
     "encrypted": "false",
     "kms_key_id": "",
     "cni_version": "v0.6.0",
@@ -23,12 +25,12 @@
       "source_ami_filter": {
         "filters": {
           "architecture": "x86_64",
-          "name": "amzn2-ami-minimal-hvm-*",
+          "name": "{{user `source_ami_filter_name`}}",
           "root-device-type": "ebs",
           "state": "available",
           "virtualization-type": "hvm"
         },
-        "owners": [ "137112412989" ],
+        "owners": [ "{{user `source_ami_owners`}}" ],
         "most_recent": true
       },
       "instance_type": "{{user `instance_type`}}",
@@ -58,6 +60,7 @@
       "tags": {
           "created": "{{timestamp}}",
           "docker_version": "{{ user `docker_version`}}",
+          "source_ami_id": "{{ user `source_ami_id`}}",
           "kubernetes": "{{ user `binary_bucket_path`}}",
           "cni_version": "{{ user `cni_version`}}",
           "cni_plugin_version": "{{ user `cni_plugin_version`}}"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/172

*Description of changes:*
This change will allow us to provide custom ami name prefix within source_ami_filter section and different image owner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
