### PR TITLE
Increase ulimit for number of open files (nofile) limit.

### DIFF
--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -10,8 +10,8 @@
   "default-ulimits": {
     "nofile": {
       "Name": "nofile",
-      "Soft": 2048,
-      "Hard": 8192
+      "Soft": 65536,
+      "Hard": 65536
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:* #193 

*Description of changes:*

This change retains the explicit limits for maximum number of open files for containers via docker daemon config file, but increases them to 65536.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
