### PR TITLE
Fix `--enable-docker-bridge` 

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -208,7 +208,7 @@ fi
 if [[ "$ENABLE_DOCKER_BRIDGE" = "true" ]]; then
     # Enabling the docker bridge network. We have to disable live-restore as it
     # prevents docker from recreating the default bridge network on restart
-    echo "$(jq '.bridge="docker0" | ."live-restore"=false' /etc/docker/daemon.json)" > /etc/docker/daemon.json
+    echo "$(jq 'del(.bridge) | ."live-restore"=false | ."bip"="203.0.113.1/24"' /etc/docker/daemon.json)" > /etc/docker/daemon.json
     systemctl restart docker
 fi
 


### PR DESCRIPTION
*Issue #, if available:*
No Issue # created

*Description of changes:*
* Add a .editorconfig file
* Fix `--enable-docker-bridge` -- without this change DNS does not seem to work with the bridge when building a docker container from within a docker container without specifying `--network host`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
