### PR TITLE
Fix downloading binaries from public s3 bucket.

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -120,7 +120,7 @@ BINARIES=(
     aws-iam-authenticator
 )
 for binary in ${BINARIES[*]} ; do
-    if which aws >/dev/null; then
+    if [[ ! -z "$AWS_ACCESS_KEY_ID" ]]; then
         echo "AWS cli present - using it to copy binaries from s3."
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .


### PR DESCRIPTION
*Issue #, if available:* #210 

*Description of changes:*

Using the existence of the `aws` CLI as the condition for downloading binaries is incorrect. For those who build the AMI from the public s3 buckets, this causes an auth error, as the AWS_ACCESS_KEY_ID et al. environment variables are blank. Instead, check if AWS_ACCESS_KEY_ID is not empty in order to use the `aws` CLI; otherwise, stick to `wget`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.