### PR TITLE
Fix: CIDR meta-data call resulting in false ten range

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -111,7 +111,7 @@ kubectl config \
 
 ### kubelet.service configuration
 
-MAC=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1)
+MAC=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1 | sed 's/\/$//')
 CIDRS=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks)
 TEN_RANGE=$(echo $CIDRS | grep -c '^10\..*' || true )
 DNS_CLUSTER_IP=10.100.0.10


### PR DESCRIPTION
Fix mac address is returned with trailing slash which breaks CIDR call resulting in false ten range

*Issue #, if available:*

*Description of changes:*

Remove trailing slash from MAC meta-data call, which fixes the CIDR blocks call, which allows the `TEN_RANGE` variable to correctly report whether it's a `10.100.0.10` DNS cluster IP.

Example:

```
root@ubuntu:/# curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1
00:14:22:01:23:45/
root@ubuntu:/# curl -v http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks
*   Trying 169.254.169.254...
* Connected to 169.254.169.254 (169.254.169.254) port 80 (#0)
> GET /latest/meta-data/network/interfaces/macs/00:14:22:01:23:45//vpc-ipv4-cidr-blocks HTTP/1.1
> Host: 169.254.169.254
> User-Agent: curl/7.47.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Location: /latest/meta-data/network/interfaces/macs/00:14:22:01:23:45/vpc-ipv4-cidr-blocks
< Date: Thu, 07 Mar 2019 10:21:32 GMT
< Content-Length: 0
<
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.