### PR TITLE
Use local-ipv4 for determining $TEN_RANGE

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -111,9 +111,8 @@ kubectl config \
 
 ### kubelet.service configuration
 
-MAC=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1 | sed 's/\/$//')
-CIDRS=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks)
-TEN_RANGE=$(echo $CIDRS | grep -c '^10\..*' || true )
+INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+TEN_RANGE=$(echo $INTERNAL_IP | grep -c '^10\..*' || true )
 DNS_CLUSTER_IP=10.100.0.10
 if [[ "$TEN_RANGE" != "0" ]] ; then
     DNS_CLUSTER_IP=172.20.0.10;
@@ -122,7 +121,6 @@ fi
 KUBELET_CONFIG=/etc/kubernetes/kubelet/kubelet-config.json
 echo "$(jq ".clusterDNS=[\"$DNS_CLUSTER_IP\"]" $KUBELET_CONFIG)" > $KUBELET_CONFIG
 
-INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
 INSTANCE_TYPE=$(curl -s http://169.254.169.254/latest/meta-data/instance-type)
 
 if [[ "$USE_MAX_PODS" = "true" ]]; then


### PR DESCRIPTION
*Description of changes:*

* Simpler method of determining whether the instance is deployed into a
subnet with a 10. CIDR
* Eliminates redundant calls to metadata service and parsing of their
responses
* Better handles scenarios where an instance spans multiple subnets (CNI
custom networking)
* Potential fix for incorrect setting of $TEN_RANGE, which causes DNS resolution to fail for all pods on the node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
