### PR TITLE
Fixed regex to match 10.x in all cases

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -113,7 +113,7 @@ kubectl config \
 
 MAC=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1 | sed 's/\/$//')
 CIDRS=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks)
-TEN_RANGE=$(echo $CIDRS | grep -c '^10\..*' || true )
+TEN_RANGE=$(echo $CIDRS | grep -cE '[^\d]?10\.[\.\d\/]*' || true )
 DNS_CLUSTER_IP=10.100.0.10
 if [[ "$TEN_RANGE" != "0" ]] ; then
     DNS_CLUSTER_IP=172.20.0.10;


### PR DESCRIPTION
*Description of changes:*

* Replaced ^ anchor
* regex needs to match irrespective of the position in the string

Related to, but not necessarily a solution for https://github.com/awslabs/amazon-eks-ami/issues/222

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
