### PR TITLE
Fixed search for 10.x CIDR range

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -135,8 +135,7 @@ kubectl config \
 ### kubelet.service configuration
 
 MAC=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1 | sed 's/\/$//')
-CIDRS=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks)
-TEN_RANGE=$(echo $CIDRS | grep -cE '[^\d]?10\.[\.\d\/]*' || true )
+TEN_RANGE=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks | grep -c '^10\..*' || true )
 DNS_CLUSTER_IP=10.100.0.10
 if [[ "$TEN_RANGE" != "0" ]] ; then
     DNS_CLUSTER_IP=172.20.0.10;


### PR DESCRIPTION
*Issue #, if available:*

Simplified search for 10.x CIDR ranges.

*Description of changes:*

Bash replaces the newlines from the instance metadata service with a space, making the `grep` regex more complicated. By removing the intermediate CIDRS variable, we can get a newline separated string and properly grep it. The logic introduced in #221 did work, but the regex `[^\d]?` (optional non-digit) is easily confused with `^[\d]?` (optional leading digit).

```
$ curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks 
192.168.0.0/16
100.64.0.0/16
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
