### PR TITLE
Fixed retrieval of eth0 MAC address during bootstrap.sh

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -134,8 +134,9 @@ kubectl config \
 
 ### kubelet.service configuration
 
-MAC=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1 | sed 's/\/$//')
-TEN_RANGE=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks | grep -c '^10\..*' || true )
+MAC=$(cat /sys/class/net/eth0/address)
+CIDRS=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks)
+TEN_RANGE=$(echo $CIDRS | tr ' ' '\n' | grep -c '^10\..*' || true )
 DNS_CLUSTER_IP=10.100.0.10
 if [[ "$TEN_RANGE" != "0" ]] ; then
     DNS_CLUSTER_IP=172.20.0.10;


### PR DESCRIPTION
*Description of changes:*

* Replaced call to metadata service with cat of
`/sys/class/net/eth0/address`, since the data is available on-instance
* Restored separate setting of `CIDRS` and `TEN_RANGE` variables for easier
debugging
* Use `tr` to translate any spaces to new lines in `CIDRS` variable

*Issue #, if available:*

https://github.com/awslabs/amazon-eks-ami/issues/222

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
