### PR TITLE
Fixed an explanation for the usage of bootstrap.sh with option

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -12,7 +12,7 @@ trap 'err_report $LINENO' ERR
 IFS=$'\n\t'
 
 function print_help {
-    echo "usage: $0 [options] <cluster-name>"
+    echo "usage: $0 <cluster-name> [options]"
     echo "Bootstraps an instance into an EKS cluster"
     echo ""
     echo "-h,--help print this help"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- fix the phrase for how to use bootstrap.sh with an option 
from `"usage: $0 [options] <cluster-name>"` to `"usage: $0 <cluster-name> [options]"`.

This is because that <cluster-name> is `$1` and [options] is `$2` in the script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
