### PR TITLE
Updated bug-report.md + question.md instructions to reference existing release info locations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -21,7 +21,7 @@ about: Report a bug encountered using the EKS AMI
 - Kubernetes version (use `aws eks describe-cluster --name <name> --query cluster.version`):
 - AMI Version:
 - Kernel (e.g. `uname -a`):
-- Release information (run `cat /tmp/release` on a node):
+- Release information (run `cat /etc/eks/release` on a node):
 <!-- Put release info in the triple backticks below-->
 ```
 ```

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -13,7 +13,7 @@ about: Any question relating to the EKS AMI
 - Kubernetes version (use `aws eks describe-cluster --name <name> --query cluster.version`):
 - AMI Version:
 - Kernel (e.g. `uname -a`):
-- Release information (run `cat /tmp/release` on a node):
+- Release information (run `cat /etc/eks/release` on a node):
 <!-- Put release info in the triple backticks below-->
 ```
 ```


### PR DESCRIPTION
*Description of changes:*

Open issues / questions consistently show something like the following because the issue templates ask to `cat` a non-existent file

> Release information (run cat /tmp/release on a node):
> `[ec2-user@ip-10-XX-XX-XX ~]# cat /tmp/release`
> cat: /tmp/release: No such file or directory
> `[ec2-user@ip-10-XX-XX-XX ~]`# 

Assumed intended file - `cat /etc/eks/release` based on this change to `./install-worker.sh`
```68e7a62a (Micah Hausler    2018-11-13 10:58:12 -0800 180) sudo mv /tmp/release /etc/eks/release```

Now:

```
[ec2-user@ip-10-XX-XX-XX ~]$ cat /etc/eks/release
 BASE_AMI_ID="ami-027c5e2ccf2970def"
 BUILD_TIME="Fri Mar 29 19:36:34 UTC 2019"
 BUILD_KERNEL="4.14.104-95.84.amzn2.x86_64"
 ARCH="x86_64"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
