### PR TITLE
2704 added in option for temporary security group source cidr

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -94,12 +94,12 @@
     },
     {
       "type": "file",
-      "source": "./files/",
+      "source": "{{template_dir}}/files/",
       "destination": "/tmp/worker/"
     },
     {
       "type": "shell",
-      "script": "install-worker.sh",
+      "script": "{{template_dir}}/install-worker.sh",
       "environment_vars": [
         "KUBERNETES_VERSION={{user `kubernetes_version`}}",
         "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -20,7 +20,9 @@
     "cni_version": "",
     "cni_plugin_version": "",
     "kubernetes_build_date": "",
-    "kubernetes_version": ""
+    "kubernetes_version": "",
+    "subnet_id": "",
+    "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image (k8s: {{ user `binary_bucket_path`}}, docker:{{ user `docker_version`}})"
   },
 
   "builders": [
@@ -36,7 +38,7 @@
           "state": "available",
           "virtualization-type": "hvm"
         },
-        "owners": [ "{{user `source_ami_owners`}}" ],
+        "owners": ["{{user `source_ami_owners`}}"],
         "most_recent": true
       },
       "instance_type": "{{user `instance_type`}}",
@@ -61,7 +63,7 @@
       "encrypt_boot": "{{user `encrypted`}}",
       "kms_key_id": "{{user `kms_key_id`}}",
       "run_tags": {
-          "creator": "{{user `creator`}}"
+        "creator": "{{user `creator`}}"
       },
       "tags": {
           "created": "{{timestamp}}",
@@ -73,7 +75,9 @@
       },
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image (k8s: {{ user `kubernetes_version`}}, docker:{{ user `docker_version`}})",
-      "temporary_security_group_source_cidr": "{{user `temporary_security_group_source_cidr`}}"
+      "temporary_security_group_source_cidr": "{{user `temporary_security_group_source_cidr`}}",
+      "ami_description": "{{user `ami_description`}}",
+      "subnet_id": "{{ user `subnet_id` }}"
     }
   ],
 

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -80,7 +80,6 @@
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image (k8s: {{ user `kubernetes_version`}}, docker:{{ user `docker_version`}})",
       "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidrs`}}",
-      "ami_description": "{{user `ami_description`}}",
       "subnet_id": "{{ user `subnet_id` }}",
       "ssh_interface": "{{ user `ssh_interface` }}",
       "associate_public_ip_address": "{{user `associate_public_ip_address`}}"

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -7,10 +7,12 @@
     "source_ami_owners": "137112412989",
     "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
     "encrypted": "false",
+    "ssh_username": "ec2-user",
     "aws_access_key_id": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_access_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
-    "temporary_security_group_source_cidr": "",
+    "temporary_security_group_source_cidrs": "",
+    "ssh_interface": "",
     "arch": "",
     "instance_type": "",
     "binary_bucket_name": "",
@@ -22,6 +24,7 @@
     "kubernetes_build_date": "",
     "kubernetes_version": "",
     "subnet_id": "",
+    "associate_public_ip_address": "true",
     "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image (k8s: {{ user `binary_bucket_path`}}, docker:{{ user `docker_version`}})"
   },
 
@@ -66,18 +69,22 @@
         "creator": "{{user `creator`}}"
       },
       "tags": {
-          "created": "{{timestamp}}",
-          "docker_version": "{{ user `docker_version`}}",
-          "source_ami_id": "{{ user `source_ami_id`}}",
-          "kubernetes": "{{ user `kubernetes_version`}}/{{ user `kubernetes_build_date` }}/bin/linux/{{ user `arch` }}",
-          "cni_version": "{{ user `cni_version`}}",
-          "cni_plugin_version": "{{ user `cni_plugin_version`}}"
+        "Name": "{{ user `ami_name`}}",
+        "created": "{{timestamp}}",
+        "docker_version": "{{ user `docker_version`}}",
+        "source_ami_id": "{{ user `source_ami_id`}}",
+        "kubernetes": "{{ user `kubernetes_version`}}/{{ user `kubernetes_build_date` }}/bin/linux/{{ user `arch` }}",
+        "cni_version": "{{ user `cni_version`}}",
+        "cni_plugin_version": "{{ user `cni_plugin_version`}}"
       },
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image (k8s: {{ user `kubernetes_version`}}, docker:{{ user `docker_version`}})",
-      "temporary_security_group_source_cidr": "{{user `temporary_security_group_source_cidr`}}",
+      "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidrs`}}",
       "ami_description": "{{user `ami_description`}}",
-      "subnet_id": "{{ user `subnet_id` }}"
+      "subnet_id": "{{ user `subnet_id` }}",
+      "ssh_interface": "{{ user `ssh_interface` }}",
+      "associate_public_ip_address": "{{user `associate_public_ip_address`}}"
+
     }
   ],
 
@@ -97,7 +104,6 @@
       "environment_vars": [
         "KUBERNETES_VERSION={{user `kubernetes_version`}}",
         "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",
-        "KUBERNETES_VERSION={{user `kubernetes_version`}}",
         "KUBERNETES_BUILD_DATE={{user `kubernetes_build_date`}}",
         "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}",
         "DOCKER_VERSION={{user `docker_version`}}",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -10,7 +10,7 @@
     "aws_access_key_id": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_access_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
-
+    "temporary_security_group_source_cidr": "",
     "arch": "",
     "instance_type": "",
     "binary_bucket_name": "",
@@ -72,7 +72,8 @@
           "cni_plugin_version": "{{ user `cni_plugin_version`}}"
       },
       "ami_name": "{{user `ami_name`}}",
-      "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image (k8s: {{ user `kubernetes_version`}}, docker:{{ user `docker_version`}})"
+      "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image (k8s: {{ user `kubernetes_version`}}, docker:{{ user `docker_version`}})",
+      "temporary_security_group_source_cidr": "{{user `temporary_security_group_source_cidr`}}"
     }
   ],
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/252

*Description of changes:*
Added the following configurable variables:
* ssh_username
* temporary_security_group_source_cidrs
* ssh_interface
* subnet_id
* associate_public_ip_address
* ami_description

This is also meant to fix the issue of allowing EKS AMI's to be built into an account without a default vpc + restricted ssh access with private ip + initiate outbound internet connection by explicitly setting `"associate_public_ip_address": "true"`.

> Note: I am currently referencing this module as a .gitsubmodule with path "vendor/amazon-eks-ami" in my project. Variables are externally declared in a separate folder, and amis are built using `packer build --var-file=<external-file> vendor/amazon-eks-ami` command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
