### PR TITLE
Fix issue with 1.10 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ k8s: validate
 
 .PHONY: 1.10
 1.10: validate
-	$(MAKE) VERSION=1.10.13-01-eks k8s
+	$(MAKE) VERSION=1.10.13 k8s
 
 .PHONY: 1.11
 1.11: validate


### PR DESCRIPTION
*Issue #, if available:*

No issue filed, but can create if wanted. Is very minor fix.

*Description of changes:*

Drop a bit of the KUBERNETES_VERSION string in the 1.10 target. As you can see listing the S3 bucket this is incorrect:

```
roberts-MacBook-Pro-3:amazon-eks-ami robertottaway$ aws s3 ls s3://amazon-eks/ --region us-west-2
                           PRE 1.10.11/
                           PRE 1.10.13/
                           PRE 1.10.3/
                           PRE 1.11.5/
                           PRE 1.11.8/
                           PRE 1.11.9/
                           PRE 1.12.7/
                           PRE cloudformation/
```

Before fix:

```
    amazon-ebs: fatal error: An error occurred (404) when calling the HeadObject operation: Key "1.10.13-01-eks/2019-03-27/bin/linux/amd64/kubelet" does not exist
```

After fix build works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.