### PR TITLE
Use kubernetes minor version to choose kubelet config

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -91,9 +91,8 @@
       "script": "install-worker.sh",
       "environment_vars": [
         "KUBERNETES_VERSION={{user `kubernetes_version`}}",
-        "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",
-        "KUBERNETES_VERSION={{user `kubernetes_version`}}",
         "KUBERNETES_BUILD_DATE={{user `kubernetes_build_date`}}",
+        "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",
         "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}",
         "DOCKER_VERSION={{user `docker_version`}}",
         "CNI_VERSION={{user `cni_version`}}",

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -170,7 +170,8 @@ done
 sudo rm *.sha256
 
 KUBELET_CONFIG=""
-if [ "$KUBERNETES_VERSION" = "1.10" ] || [ "$KUBERNETES_VERSION" = "1.11" ]; then
+KUBERNETES_MINOR_VERSION=${KUBERNETES_VERSION%.*}
+if [ "$KUBERNETES_MINOR_VERSION" = "1.10" ] || [ "$KUBERNETES_MINOR_VERSION" = "1.11" ]; then
     KUBELET_CONFIG=kubelet-config.json
 else
     # For newer versions use this config to fix https://github.com/kubernetes/kubernetes/issues/74412.


### PR DESCRIPTION
*Issue #, if available:*
#268 (Thanks @apr-1985)

*Description of changes:*
`KUBERNETES_VERSION ` expects a revision version number but this is used to compare with minor version and get right kubelet config files. It will always use `kubelet-config-with-secret-polling.json` for 1.10 and 1.11. 

Get minor version var from original version helps in this case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->