### PR TITLE
added t3a instance types to eni-max-pod list

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -157,6 +157,13 @@ t3.medium 17
 t3.large 35
 t3.xlarge 58
 t3.2xlarge 58
+t3a.nano 4
+t3a.micro 4
+t3a.small 11
+t3a.medium 17
+t3a.large 35
+t3a.xlarge 58
+t3a.2xlarge 58
 x1.16xlarge 234
 x1.32xlarge 234
 x1e.xlarge 29


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds t3a instance types to the eni-max-pods. Without this, the cni plugin will not allocate the ip addresses properly for each pod.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
