### PR TITLE
Add a docker daemon restart after custom daemon.json

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -203,6 +203,7 @@ fi
 # Replace with custom docker config contents.
 if [[ -n "$DOCKER_CONFIG_JSON" ]]; then
     echo "$DOCKER_CONFIG_JSON" > /etc/docker/daemon.json
+    systemctl restart docker
 fi
 
 if [[ "$ENABLE_DOCKER_BRIDGE" = "true" ]]; then


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I have added a docker daemon restart after overwriting the daemon.json. Without this the custom daemon.json file is present but it never gets picked up. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
