### PR TITLE
files/kubelet: specify "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"

### DIFF
--- a/files/kubelet-config-with-secret-polling.json
+++ b/files/kubelet-config-with-secret-polling.json
@@ -31,5 +31,5 @@
   "serializeImagePulls": false,
   "serverTLSBootstrap": true,
   "configMapAndSecretChangeDetectionStrategy": "Cache",
-  "tlsCipherSuites": ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
+  "tlsCipherSuites": ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"]
 }


### PR DESCRIPTION
~~ref. https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf~~

Edit: Changing to `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`, root cause is still pending for investigation.