### PR TITLE
Change clocksource only if using xen

### DIFF
--- a/install-worker.sh
+++ b/install-worker.sh
@@ -77,8 +77,9 @@ cat <<EOF | sudo tee -a /etc/chrony.conf
 rtcsync
 EOF
 
-# Make tsc the clock source
-if grep --quiet tsc /sys/devices/system/clocksource/clocksource0/available_clocksource; then
+# If current clocksource is xen, switch to tsc
+if grep --quiet xen /sys/devices/system/clocksource/clocksource0/current_clocksource &&
+  grep --quiet tsc /sys/devices/system/clocksource/clocksource0/available_clocksource; then
     echo "tsc" | sudo tee /sys/devices/system/clocksource/clocksource0/current_clocksource
 else
     echo "tsc as a clock source is not applicable, skipping."


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Per https://github.com/awslabs/amazon-eks-ami/pull/272#issuecomment-497910461, only change the clocksource to tsc if it is already set to xen. Nitro-based instances use kvm-clock as clocksource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.