### PR TITLE
Handle unset AWS_ACCESS_KEY_ID

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -216,7 +216,7 @@ BINARIES=(
     aws-iam-authenticator
 )
 for binary in ${BINARIES[*]} ; do
-    if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+    if aws sts get-caller-identity > /dev/null 2>&1; then
         echo "AWS cli present - using it to copy binaries from s3."
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
@@ -240,7 +240,7 @@ if [ "$PULL_CNI_FROM_GITHUB" = "true" ]; then
     sudo sha512sum -c "${CNI_PLUGIN_FILENAME}.tgz.sha512"
     rm "${CNI_PLUGIN_FILENAME}.tgz.sha512"
 else
-    if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+    if aws sts get-caller-identity > /dev/null 2>&1; then
         echo "AWS cli present - using it to copy binaries from s3."
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz .
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz.sha256 .
@@ -309,7 +309,7 @@ fi
 ################################################################################
 if [[ $KUBERNETES_VERSION == "1.22"* ]]; then
     ECR_BINARY="ecr-credential-provider"
-    if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+    if aws sts get-caller-identity > /dev/null 2>&1; then
         echo "AWS cli present - using it to copy ecr-credential-provider binaries from s3."
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_BINARY .
     else


### PR DESCRIPTION
*Description of changes:*

Use `aws sts get-caller-identity` to check whether AWS CLI is installed, rather than the presence of an unnecessary AWS_ACCESS_KEY_ID variable (instance profiles, AWS CLI profiles, and others are reasons it's not necessary)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
