### PR TITLE
refactors to packer variable usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,12 @@
-DOCKER_VERSION ?= 18.06
-KUBERNETES_BUILD_DATE ?= 2019-03-27
-CNI_VERSION ?= v0.6.0
-CNI_PLUGIN_VERSION ?= v0.7.5
-ARCH ?= x86_64
-BINARY_BUCKET_NAME ?= amazon-eks
-SOURCE_AMI_OWNERS ?= 137112412989
-
 PACKER_BINARY ?= packer
-AWS_BINARY ?= aws
+PACKER_VARIABLES := binary_bucket_name kubernetes_version kubernetes_build_date docker_version cni_version cni_plugin_version source_ami_id arch instance_type
 
-ifeq ($(ARCH), arm64)
-INSTANCE_TYPE ?= a1.large
+arch ?= x86_64
+ifeq ($(arch), arm64)
+instance_type ?= a1.large
 else
-INSTANCE_TYPE ?= m4.large
+instance_type ?= m4.large
 endif
-
-DATE ?= $(shell date +%Y-%m-%d)
 
 AWS_DEFAULT_REGION ?= us-west-2
 
@@ -25,51 +16,29 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.10 1.11 1.12
+all: 1.10 1.11 1.12 1.13
 
 .PHONY: validate
 validate:
-	$(PACKER_BINARY) validate \
-		-var instance_type=$(INSTANCE_TYPE) \
-		eks-worker-al2.json
+	$(PACKER_BINARY) validate $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)=$($(packerVar)),)) eks-worker-al2.json
 
 .PHONY: k8s
 k8s: validate
-	@echo "$(T_GREEN)Building AMI for version $(T_YELLOW)$(VERSION)$(T_GREEN) on $(T_YELLOW)$(ARCH)$(T_RESET)"
-	$(eval SOURCE_AMI_ID := $(shell $(AWS_BINARY) ec2 describe-images \
-		--output text \
-		--filters \
-			Name=owner-id,Values=$(SOURCE_AMI_OWNERS) \
-			Name=virtualization-type,Values=hvm \
-			Name=root-device-type,Values=ebs \
-			Name=name,Values=amzn2-ami-minimal-hvm-* \
-			Name=architecture,Values=$(ARCH) \
-			Name=state,Values=available \
-		--query 'max_by(Images[], &CreationDate).ImageId'))
-	@if [ -z "$(SOURCE_AMI_ID)" ]; then\
-		echo "$(T_RED)Failed to find candidate AMI!$(T_RESET)"; \
-		exit 1; \
-	fi
-	$(PACKER_BINARY) build \
-		-var instance_type=$(INSTANCE_TYPE) \
-		-var kubernetes_version=$(VERSION) \
-		-var kubernetes_build_date=$(KUBERNETES_BUILD_DATE) \
-		-var source_ami_id=$(SOURCE_AMI_ID) \
-		-var arch=$(ARCH) \
-		-var binary_bucket_name=$(BINARY_BUCKET_NAME) \
-		-var cni_version=$(CNI_VERSION) \
-		-var cni_plugin_version=$(CNI_PLUGIN_VERSION) \
-		-var docker_version=$(DOCKER_VERSION) \
-		eks-worker-al2.json
+	@echo "$(T_GREEN)Building AMI for version $(T_YELLOW)$(kubernetes_version)$(T_GREEN) on $(T_YELLOW)$(arch)$(T_RESET)"
+	$(PACKER_BINARY) build $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)=$($(packerVar)),)) eks-worker-al2.json
 
 .PHONY: 1.10
-1.10: validate
-	$(MAKE) VERSION=1.10.13 k8s
+1.10:
+	$(MAKE) k8s kubernetes_version=1.10.13 kubernetes_build_date=2019-03-27
 
 .PHONY: 1.11
-1.11: validate
-	$(MAKE) VERSION=1.11.9 k8s
+1.11:
+	$(MAKE) k8s kubernetes_version=1.11.9 kubernetes_build_date=2019-03-27
 
 .PHONY: 1.12
-1.12: validate
-	$(MAKE) VERSION=1.12.7 k8s
+1.12:
+	$(MAKE) k8s kubernetes_version=1.12.7 kubernetes_build_date=2019-03-27
+
+.PHONY: 1.13
+1.13:
+	$(MAKE) k8s kubernetes_version=1.13.7 kubernetes_build_date=2019-06-11

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -1,26 +1,28 @@
 {
   "variables": {
     "aws_region": "us-west-2",
-    "ami_name": "amazon-eks-node-{{timestamp}}",
-    "binary_bucket_region": "us-west-2",
+    "ami_name": "amazon-eks-node-{{user `kubernetes_version`}}-v{{isotime `20060102`}}",
     "creator": "{{env `USER`}}",
-    "source_ami_owners": "137112412989",
-    "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
     "encrypted": "false",
+    "kms_key_id": "",
+    
     "aws_access_key_id": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_access_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
 
-    "arch": "",
-    "instance_type": "",
-    "binary_bucket_name": "",
-    "docker_version": "",
+    "binary_bucket_name": "amazon-eks",
+    "binary_bucket_region": "us-west-2",
+    "kubernetes_version": null,
+    "kubernetes_build_date": null,
+    "docker_version": "18.06",
+    "cni_version": "v0.6.0",
+    "cni_plugin_version": "v0.7.5",
+
     "source_ami_id": "",
-    "kms_key_id": "",
-    "cni_version": "",
-    "cni_plugin_version": "",
-    "kubernetes_build_date": "",
-    "kubernetes_version": ""
+    "source_ami_owners": "137112412989",
+    "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
+    "arch": null,
+    "instance_type": null
   },
 
   "builders": [


### PR DESCRIPTION
Changes done:
1. Use packer to automatically generate AMIName like "amazon-eks-node-1.13.7-v20190611"
2. Remove the dependency of aws-cli (use packer to filter source AMIs if source amiID is undefined)
3. Refactor makeFile to rely on default variables defined in packer as much as possible.  Also, make k8s version & date explicit in each AMI release variant.
4. Re-order packer variables to group them by their purpose.

BTW, 
only important packer variables are exposed to makeFile(PACKER_VARIABLES), and it can be extended if there is valid use cases