### PR TITLE
2107 allow private ssh when building

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -23,7 +23,7 @@
     "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
     "arch": null,
     "instance_type": null,
-    "ami_description": "A Redhat RHEL 8 EKS-optimized node.",
+    "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image",
 
     "ssh_interface": "",
     "ssh_username": "ec2-user",
@@ -58,7 +58,7 @@
           "delete_on_termination": true
         }
       ],
-      "ami_block_device_mappings": [
+      "ami_block_device_mappings": [    
         {
           "device_name": "/dev/xvda",
           "volume_type": "gp2",
@@ -78,6 +78,7 @@
       },
       "subnet_id": "{{user `subnet_id`}}",
       "tags": {
+          "Name": "{{user `ami_name`}}",
           "created": "{{timestamp}}",
           "docker_version": "{{ user `docker_version`}}",
           "source_ami_id": "{{ user `source_ami_id`}}",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -22,7 +22,15 @@
     "source_ami_owners": "137112412989",
     "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
     "arch": null,
-    "instance_type": null
+    "instance_type": null,
+    "ami_description": "A Redhat RHEL 8 EKS-optimized node.",
+
+    "ssh_interface": "",
+    "ssh_username": "ec2-user",
+    "temporary_security_group_source_cidrs": "",
+    "associate_public_ip_address": ""
+  
+
   },
 
   "builders": [
@@ -58,7 +66,10 @@
           "delete_on_termination": true
         }
       ],
-      "ssh_username": "ec2-user",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_interface": "{{user `ssh_interface`}}",
+      "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidrs`}}",
+      "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
       "ssh_pty": true,
       "encrypt_boot": "{{user `encrypted`}}",
       "kms_key_id": "{{user `kms_key_id`}}",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -28,8 +28,8 @@
     "ssh_interface": "",
     "ssh_username": "ec2-user",
     "temporary_security_group_source_cidrs": "",
-    "associate_public_ip_address": ""
-  
+    "associate_public_ip_address": "",
+    "subnet_id": ""
 
   },
 
@@ -76,6 +76,7 @@
       "run_tags": {
           "creator": "{{user `creator`}}"
       },
+      "subnet_id": "{{user `subnet_id`}}",
       "tags": {
           "created": "{{timestamp}}",
           "docker_version": "{{ user `docker_version`}}",
@@ -85,7 +86,7 @@
           "cni_plugin_version": "{{ user `cni_plugin_version`}}"
       },
       "ami_name": "{{user `ami_name`}}",
-      "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image (k8s: {{ user `kubernetes_version`}}, docker:{{ user `docker_version`}})"
+      "ami_description": "{{ user `ami_description` }}, (k8s: {{ user `kubernetes_version`}}, docker:{{ user `docker_version`}})"
     }
   ],
 
@@ -96,12 +97,12 @@
     },
     {
       "type": "file",
-      "source": "./files/",
+      "source": "{{template_dir}}/files/",
       "destination": "/tmp/worker/"
     },
     {
       "type": "shell",
-      "script": "install-worker.sh",
+      "script": "{{template_dir}}/install-worker.sh",
       "environment_vars": [
         "KUBERNETES_VERSION={{user `kubernetes_version`}}",
         "KUBERNETES_BUILD_DATE={{user `kubernetes_build_date`}}",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added the following configurable variables to 

**1. allow private ssh to private subnet:**
- ssh_username
- temporary_security_group_source_cidrs
- ssh_interface
- subnet_id

**2. allow assignment of public ip address when default is disabled**
- associate_public_ip_address

**3. customize ami description**
- ami_description

**Also allowed ./install-worker + ./files source paths to be relative to template dir.**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
