### PR TITLE
Fix t3a.small limit

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -184,7 +184,7 @@ t3.xlarge 58
 t3.2xlarge 58
 t3a.nano 4
 t3a.micro 4
-t3a.small 11
+t3a.small 8
 t3a.medium 17
 t3a.large 35
 t3a.xlarge 58


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-eks-ami/issues/262#issuecomment-514730428

*Description of changes:*
t3a.small only have 2 ENIs with 4 IPs each, so 2 * 3 + 2 = 8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
