### PR TITLE
change the amiName pattern to use minor version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := binary_bucket_name kubernetes_version kubernetes_build_date docker_version cni_version cni_plugin_version source_ami_id arch instance_type
+PACKER_VARIABLES := ami_name binary_bucket_name kubernetes_version kubernetes_build_date docker_version cni_version cni_plugin_version source_ami_id arch instance_type
+AWS_DEFAULT_REGION ?= us-west-2
 
+K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
+K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})
+
+ami_name ?= amazon-eks-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 arch ?= x86_64
 ifeq ($(arch), arm64)
 instance_type ?= a1.large
 else
 instance_type ?= m4.large
 endif
-
-AWS_DEFAULT_REGION ?= us-west-2
 
 T_RED := \e[0;31m
 T_GREEN := \e[0;32m

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "aws_region": "us-west-2",
-    "ami_name": "amazon-eks-node-{{user `kubernetes_version`}}-v{{isotime `20060102`}}",
+    "ami_name": null,
     "creator": "{{env `USER`}}",
     "encrypted": "false",
     "kms_key_id": "",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The default amiName pattern was changed from `amazon-eks-node-{{timestamp}}` to `amazon-eks-node-1.13.7-v20190730` in https://github.com/awslabs/amazon-eks-ami/commit/1f83c10d772487427428932271a06f8b29977618.
This PR change it to use minor version instead to align with EKS's current amiName: `amazon-eks-node-1.13-v20190730`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
