### PR TITLE
v20190814 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # Changelog
+### AMI Release v20190814
+* amazon-eks-node-1.13-v20190814
+* amazon-eks-gpu-node-1.13-v20190814
+* amazon-eks-node-1.13-v20190814
+* amazon-eks-gpu-node-1.13-v20190814
+* amazon-eks-node-1.13-v20190814
+* amazon-eks-gpu-node-1.13-v20190814
+#### Changes
+* 0468404 change the amiName pattern to use minor version (#307)
+* 19ff806 2107 allow private ssh when building (#303)
+* 2b9b501 add support for ap-east-1 region (#305)
+* ccae017 Fix t3a.small limit
+* f409acd Add new m5 and r5 instances
+* 8bbf269 Add c5.12xlarge and c5.24xlarge instances
+* 1f83c10 refactor packer variables
+* 41f4dd9 Install ec2-instance-connect
+* a40bd46 Added CHANGELOG for v20190701
+
+
 
 ### amazon-eks-node-1.13-v20190701 | amazon-eks-node-1.12-v20190701 | amazon-eks-node-1.11-v20190701 | amazon-eks-node-1.10-v20190701 | amazon-eks-gpu-node-1.13-v20190701 | amazon-eks-gpu-node-1.12-v20190701 | amazon-eks-gpu-node-1.11-v20190701 | amazon-eks-gpu-node-1.10-v20190701
 


### PR DESCRIPTION
New Release v20190814.
The kubernetes in AMI are compiled with `1.13.8`, `1.12.10`, `1.11.10`, binaries will be released to amazon-eks bucket soon.

*  we have back ported fix for bug when using custom DHCP options with multiple domain: https://github.com/kubernetes/kubernetes/pull/79446




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
