### PR TITLE
Adding new directory and file for 1.14 and above by removing --allow-privileged=true flag

### DIFF
--- a/files/1.14/kubelet.service
+++ b/files/1.14/kubelet.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Kubernetes Kubelet
+Documentation=https://github.com/kubernetes/kubernetes
+After=docker.service
+Requires=docker.service
+
+[Service]
+ExecStartPre=/sbin/iptables -P FORWARD ACCEPT
+ExecStart=/usr/bin/kubelet --cloud-provider aws \
+    --config /etc/kubernetes/kubelet/kubelet-config.json \
+    --kubeconfig /var/lib/kubelet/kubeconfig \
+    --container-runtime docker \
+    --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
+
+Restart=on-failure
+RestartForceExitStatus=SIGPIPE
+RestartSec=5
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -194,7 +194,11 @@ sudo mkdir -p /etc/kubernetes/kubelet
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 sudo mv $TEMPLATE_DIR/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
 sudo chown root:root /var/lib/kubelet/kubeconfig
-sudo mv $TEMPLATE_DIR/kubelet.service /etc/systemd/system/kubelet.service
+if [ "$KUBERNETES_MINOR_VERSION" = "1.14" ]; then
+    sudo mv $TEMPLATE_DIR/1.14/kubelet.service /etc/systemd/system/kubelet.service
+else
+    sudo mv $TEMPLATE_DIR/kubelet.service /etc/systemd/system/kubelet.service
+fi
 sudo chown root:root /etc/systemd/system/kubelet.service
 sudo mv $TEMPLATE_DIR/$KUBELET_CONFIG /etc/kubernetes/kubelet/kubelet-config.json
 sudo chown root:root /etc/kubernetes/kubelet/kubelet-config.json


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
I am making this change for removing the deprecated flag : --allow-privileged=true from kubelet service configuration.

I am adding a new directory of 1.14 which can be later moved back to the same file onec we are out from 1.13.

Going forward we can use this file for kubelet service config.    

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
