### PR TITLE
Add 1.14 to the EKS Makefile and update older versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.10 1.11 1.12 1.13
+all: 1.11 1.12 1.13 1.14
 
 .PHONY: validate
 validate:
@@ -30,18 +30,20 @@ k8s: validate
 	@echo "$(T_GREEN)Building AMI for version $(T_YELLOW)$(kubernetes_version)$(T_GREEN) on $(T_YELLOW)$(arch)$(T_RESET)"
 	$(PACKER_BINARY) build $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)=$($(packerVar)),)) eks-worker-al2.json
 
-.PHONY: 1.10
-1.10:
-	$(MAKE) k8s kubernetes_version=1.10.13 kubernetes_build_date=2019-03-27
+# Build dates and versions taken from https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 
 .PHONY: 1.11
 1.11:
-	$(MAKE) k8s kubernetes_version=1.11.9 kubernetes_build_date=2019-03-27
+	$(MAKE) k8s kubernetes_version=1.11.10 kubernetes_build_date=2019-08-14
 
 .PHONY: 1.12
 1.12:
-	$(MAKE) k8s kubernetes_version=1.12.7 kubernetes_build_date=2019-03-27
+	$(MAKE) k8s kubernetes_version=1.12.10 kubernetes_build_date=2019-08-14
 
 .PHONY: 1.13
 1.13:
-	$(MAKE) k8s kubernetes_version=1.13.7 kubernetes_build_date=2019-06-11
+	$(MAKE) k8s kubernetes_version=1.13.8 kubernetes_build_date=2019-08-14
+
+.PHONY: 1.14
+1.14:
+	$(MAKE) k8s kubernetes_version=1.14.6 kubernetes_build_date=2019-08-22


### PR DESCRIPTION
*Issue #333* 

*Description of changes:*

Add 1.14 to the list of Makefile targets.

Remove 1.10 as it's no longer a supported version

Update versions and build dates for older EKS versions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
