### PR TITLE
Add support for g4 instance family

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -64,6 +64,13 @@ g3s.xlarge 58
 g3.4xlarge 234
 g3.8xlarge 234
 g3.16xlarge 452
+g4dn.xlarge 29
+g4dn.2xlarge 29
+g4dn.4xlarge 29
+g4dn.8xlarge 58
+g4dn.16xlarge 58
+g4dn.12xlarge 234
+g4dn.metal 737
 h1.2xlarge 58
 h1.4xlarge 234
 h1.8xlarge 234


### PR DESCRIPTION
*Description of changes:*

Added the `g4dn` family.

Relies on https://github.com/aws/amazon-vpc-cni-k8s/pull/621 to be merged and released first.

https://aws.amazon.com/about-aws/whats-new/2019/09/introducing-amazon-ec2-g4-instances-the-most-cost-effective-gpu-platform/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
