### PR TITLE
Use '/home/ec2-user' instead of '/tmp' to work around 'noexec'.

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -94,12 +94,13 @@
   "provisioners": [
     {
       "type": "shell",
-      "inline": ["mkdir -p /tmp/worker/"]
+      "inline": ["mkdir -p /home/ec2-user/worker/"],
+      "remote_folder": "/home/ec2-user"
     },
     {
       "type": "file",
       "source": "{{template_dir}}/files/",
-      "destination": "/tmp/worker/"
+      "destination": "/home/ec2-user/worker/"
     },
     {
       "type": "shell",
@@ -115,7 +116,8 @@
         "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
         "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}"
-      ]
+      ],
+      "remote_folder": "/home/ec2-user"
     }
   ],
   "post-processors": [

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o errexit
 IFS=$'\n\t'
 
-TEMPLATE_DIR=${TEMPLATE_DIR:-/tmp/worker}
+TEMPLATE_DIR=${TEMPLATE_DIR:-/home/ec2-user/worker}
 
 ################################################################################
 ### Validate Required Arguments ################################################
@@ -229,7 +229,7 @@ BUILD_KERNEL="$(uname -r)"
 ARCH="$(uname -m)"
 EOF
 sudo mv /tmp/release /etc/eks/release
-sudo chown root:root /etc/eks/*
+sudo chown root:root /etc/eks/{bootstrap.sh,eni-max-pods.txt,release}
 
 ################################################################################
 ### Cleanup ####################################################################


### PR DESCRIPTION
If an AMI other than `amzn2-ami-minimal-hvm-*` is used as the base image (such as a [CIS-hardened image](https://www.cisecurity.org/cis-hardened-images/)), `/tmp` may be mounted with `noexec`. This prevents the build script from running. Using something like `/opt` is also problematic since `ec2-user` may not have the required permissions. To work around this, I propose we use `/home/ec2-user` to store the scripts. I am also taking on the opportunity to fix another potential issue with permissions and globbing which may happen when using said images. 