### PR TITLE
Set a minimum evictionHard and kubeReserved

### DIFF
--- a/files/kubelet-config.json
+++ b/files/kubelet-config.json
@@ -28,6 +28,16 @@
   "featureGates": {
     "RotateKubeletServerCertificate": true
   },
+  "evictionHard": {
+    "memory.available": "100Mi",
+    "nodefs.available": "10%",
+    "nodefs.inodesFree": "5%"
+  },
+  "kubeReserved": {
+    "cpu": "60m",
+    "ephemeral-storage": "1Gi",
+    "memory": "0.24Gi"
+  },
   "serializeImagePulls": false,
   "serverTLSBootstrap": true
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-eks-ami/issues/318 (partial fix)

*Description of changes:* Add a minimal eviction-hard and kube-reserved configuration to help prevent kubelets becoming unresponsive.

These numbers are hardcoded and do *not* take into account instance type. EKS needs to support instance types down to t2.nano. In the near future, we'll want to determine optimal numbers per instance type and set these numbers according to that, as described in #318.

Also, note I've omitted system-reserved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
