### PR TITLE
Output the autoscaling group name

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -516,3 +516,6 @@ Outputs:
     Description: The security group for the node group
     Value: !Ref NodeSecurityGroup
 
+  NodeAutoScalingGroup:
+    Description: The autoscaling group
+    Value: !Ref NodeGroup


### PR DESCRIPTION

*Issue #, if available:*
None that I'm aware of.

*Description of changes:*
This name of the AutoScaling Group is useful for things like the Cluster Autoscaler so that it can manage automatic cluster scaling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
