### PR TITLE
Set kubeReserved and evictionHard in the kubelet-config

### DIFF
--- a/files/kubelet-config.json
+++ b/files/kubelet-config.json
@@ -28,16 +28,6 @@
   "featureGates": {
     "RotateKubeletServerCertificate": true
   },
-  "evictionHard": {
-    "memory.available": "100Mi",
-    "nodefs.available": "10%",
-    "nodefs.inodesFree": "5%"
-  },
-  "kubeReserved": {
-    "cpu": "60m",
-    "ephemeral-storage": "1Gi",
-    "memory": "0.24Gi"
-  },
   "serializeImagePulls": false,
   "serverTLSBootstrap": true
 }


### PR DESCRIPTION
### **Overview:**
This change to bootstrap.sh sets kubeReserved and evictionHard in /etc/kubernetes/kubelet/kubelet-config.json for worker nodes. The values used for kubeReserved are dynamically calculated based on the available CPU and memory of the instance. The amount of CPU and memory allocated for a given EC2 instance is calculated using this formula from GKE, https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#node_allocatable. Note that the values used for evictionHard are hard-coded. 

Here is a related issue: Kube/System Reserved resources should be enabled by default (https://github.com/awslabs/amazon-eks-ami/issues/318)

### **Testing:**
We are testing to see if the memory reserved for the kubelet in kubeReserved is enforced on the worker node. Specifically, we are trying to observe if pods that are requesting a large percentage of available CPU and memory resources on a worker node are continuously evicted and replaced with new pods before they can use memory resources reserved for the kubelet when kubeReserved is set. In the case that kubeReserved is not set, these pods which are causing memory starvation of the kubelet, should continue to run without being recycled. We expect this to cause the worker node to transition a not ready status.

**Procedure:**
1. Launch a cluster with one worker node with instance type t3.medium (2 vCPU, 4 GiB)
2. Create a deployment with the given specification and scale the number of pods to equal the number of gibibytes available to the instance. In this case, scale the deployment to four replicas. 
	$ kubectl create -f mem-deployment.yaml # mem-deployment.yaml is from [mem-deployment.txt](https://github.com/awslabs/amazon-eks-ami/files/3796273/mem-deployment.txt)
	$ kubectl scale deployment cpu-deployment --replicas=4
3. Wait five minutes and then view the cluster events. Check to see if any of the pods were evicted. Since kubeReserved is not set on the worker node, the pods shouldn’t be getting evicted. We expect the worker node to become become unresponsive and enter status “Not Ready.”
	$ kubectl get events --sort-by=.metadata.creationTimestamp
	$ kubectl get nodes # check to see if the node has status “Not Ready”
4. Clean up the deployment.
	$ kubectl delete deployment mem-deployment
5. Now, we want to compare this behavior against having kubeReserved set on your worker node. SSH into your worker node and replace /etc/eks/bootstrap.sh with the version from this PR, which calculates and sets kubeReserved and evictionHard in /etc/kubernetes/kubelet/kubelet-config.json.
6. Rerun the bootstrap.sh script and restart kubelet by running, $ systemctl restart kubectl. See the instructions below for more details about how to rerun bootstrap.sh. 
7. Now repeat steps 2-4. When viewing cluster events, check to see if any of the pods were evicted and if any new pods were created. Since kubeReserved is now set, we expect the pods to be recycling since they’re trying to use memory set aside to keep the kubelet healthy. 
8. Repeat steps 1-7 with other worker node instance types.

Instructions for how to rerun bootstrap.sh on a worker node and restart the kubelet:
1. Modify /etc/eks/bootstrap.sh to be the version included in this PR. You need to run $ sudo vi /etc/eks/bootstrap.sh to modify the file.
2. On the worker node, run: $ curl http://169.254.169.254/latest/user-data
3. Copy and paste variables for B64_CLUSTER_CA, APISERVER_ENDPOINT
4. Run: $ sudo /etc/eks/bootstrap.sh ClusterName  --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $APISERVER_ENDPOINT
5. Run $ cat /etc/kubernetes/kubelet/kubelet-config.json to confirm that kubeReserved has been set 
6. To restart kubelet to use the modified kubelet-config.json run $ sudo systemctl restart kubelet

### **Results Using a t3.medium Worker Node (2 vCPU, 4 GiB):**

**When kubeReserved and evictionHard are not set in the kubelet-config:**
```
$ kubectl get pods
NAME                              READY   STATUS    RESTARTS   AGE
mem-deployment-5d85bd8c74-fw65j   1/1     Running   0          2m44s
mem-deployment-5d85bd8c74-mgdz5   1/1     Running   0          2m44s
mem-deployment-5d85bd8c74-pgnx5   1/1     Running   0          2m44s
mem-deployment-5d85bd8c74-rlr6c   1/1     Running   0          2m57s
```
```
$ kubectl get nodes
NAME                                            STATUS     ROLES    AGE    VERSION
ip-192-168-180-252.us-west-2.compute.internal   NotReady   <none>   104m   v1.13.11-eks-5876d6
```
Note that not setting kubeReserved causes the worker node to become unavailable. The four pods continue to run and starve the kubelet of resources.

**When kubeReserved and evictionHard are set in the kubelet-config:**

Values for evictionHard and kubeReserved in /etc/kubernetes/kubelet/kubelet-config.json:
```
  "evictionHard": {
    "memory.available": "100Mi",
    "nodefs.available": "10%",
    "nodefs.inodesFree": "5%"
  },
  "kubeReserved": {
    "cpu": "70m",
    "ephemeral-storage": "1Gi",
    "memory": "768Mi"
  }
```
```
$ kubectl get pods
NAME                              READY   STATUS      RESTARTS   AGE
mem-deployment-5d85bd8c74-4q94g   0/1     Evicted     0          54s
mem-deployment-5d85bd8c74-4ts4s   0/1     Pending     0          48s
mem-deployment-5d85bd8c74-6hv7n   1/1     Running     2          89s
mem-deployment-5d85bd8c74-6njp4   0/1     Evicted     0          51s
mem-deployment-5d85bd8c74-7fspp   0/1     Evicted     0          52s
mem-deployment-5d85bd8c74-7qjdl   0/1     Evicted     0          89s
mem-deployment-5d85bd8c74-87kt8   0/1     Evicted     0          53s
mem-deployment-5d85bd8c74-959mc   0/1     OOMKilled   2          98s
mem-deployment-5d85bd8c74-b4rvq   0/1     Evicted     0          49s
mem-deployment-5d85bd8c74-gbfhr   1/1     Running     2          89s
mem-deployment-5d85bd8c74-gzdqt   0/1     Evicted     0          52s
mem-deployment-5d85bd8c74-pbnz4   0/1     Evicted     0          49s
mem-deployment-5d85bd8c74-rqhx4   0/1     Evicted     0          53s
mem-deployment-5d85bd8c74-rs59v   0/1     Evicted     0          49s
mem-deployment-5d85bd8c74-slqts   0/1     Evicted     0          54s
mem-deployment-5d85bd8c74-srdnl   0/1     Evicted     0          51s
mem-deployment-5d85bd8c74-sxkxs   0/1     Evicted     0          54s
mem-deployment-5d85bd8c74-v9px4   0/1     Evicted     0          54s
mem-deployment-5d85bd8c74-x55fb   0/1     Evicted     0          52s
mem-deployment-5d85bd8c74-x8lr4   0/1     Evicted     0          54s
mem-deployment-5d85bd8c74-z79hr   0/1     Evicted     0          50s
```
```
$ kubectl get nodes
NAME                                            STATUS   ROLES    AGE    VERSION
ip-192-168-180-252.us-west-2.compute.internal   Ready    <none>   119m   v1.13.11-eks-5876d6
```
Note that the worker node and the kubelet stays responsive when kubeReserved and evictionHard are set. The pods are evicted and replaced with new pods instead of being allowed to continue running.

### **Conclusion**
Setting kubeReserved and evictionHard by default is necessary because a majority of customers would prefer to have their worker nodes stay alive and responsive over having their pods persist on the node, while potentially using CPU and memory resources that are needed by the kubelet. 
