### PR TITLE
add support for c5d.12x/c5d.24x/c5d.metal

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -111,7 +111,10 @@ Parameters:
       - c5d.2xlarge
       - c5d.4xlarge
       - c5d.9xlarge
+      - c5d.12xlarge
       - c5d.18xlarge
+      - c5d.24xlarge
+      - c5d.metal
       - c5n.large
       - c5n.xlarge
       - c5n.2xlarge

--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -42,7 +42,10 @@ c5d.xlarge 58
 c5d.2xlarge 58
 c5d.4xlarge 234
 c5d.9xlarge 234
+c5d.12xlarge 234
 c5d.18xlarge 737
+c5d.24xlarge 737
+c5d.metal 737
 c5n.large 29
 c5n.xlarge 58
 c5n.2xlarge 58


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for new c5d instance types 
https://aws.amazon.com/blogs/aws/now-available-new-c5d-instance-sizes-and-bare-metal-instances/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
