### PR TITLE
Updating Docker version

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -14,7 +14,7 @@
     "binary_bucket_region": "us-west-2",
     "kubernetes_version": null,
     "kubernetes_build_date": null,
-    "docker_version": "18.06",
+    "docker_version": "18.09.9ce-2.amzn2",
     "cni_version": "v0.6.0",
     "cni_plugin_version": "v0.7.5",
 


### PR DESCRIPTION
### **Overview**
Updating the Docker version on worker nodes to 18.09.9ce-2.amzn2

### **Testing**
I built a worker node AMI in my dev account using Docker version 18.09.9ce-2.amzn2. After creating an instance with the AMI and SSH'ing into it, here are the versions used for docker, containerd, and runc.
```
$ docker --version 
Docker version 18.09.9-ce, build 039a7df
$ containerd --version
containerd github.com/containerd/containerd 1.2.6 894b81a4b802e4eb2a91d1ce216b8817763c29fb
$ runc --version
runc version 1.0.0-rc6+dev
commit: 2b18fe1d885ee5083ef9f0838fee39b62d653e30
spec: 1.0.1-dev
```