### PR TITLE
Regression: TLS Ciphersuite: restrict to TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256

### DIFF
--- a/files/kubelet-config.json
+++ b/files/kubelet-config.json
@@ -32,5 +32,6 @@
   "protectKernelDefaults": true,
   "readOnlyPort": 0,
   "serializeImagePulls": false,
-  "serverTLSBootstrap": true
+  "serverTLSBootstrap": true,
+  "tlsCipherSuites": ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
 }


### PR DESCRIPTION
*Description of changes:*

See section 2.1.14 of the CIS benchmark:

> [2.1.14] Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
> If using a Kubelet config file, edit the file to set TLSCipherSuites: to TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
> If using executable arguments, edit the kubelet service file /etc/systemd/system/kubelet.service on each worker node and set the below parameter.
> --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256

Note that this is a regression, this had been set previously in PR #276
but got lost in #352.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.