### PR TITLE
Implement ipvs

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -29,8 +29,9 @@
     "ssh_username": "ec2-user",
     "temporary_security_group_source_cidrs": "",
     "associate_public_ip_address": "",
-    "subnet_id": ""
+    "subnet_id": "",
 
+    "netfilter_module": "iptables"
   },
 
   "builders": [
@@ -114,7 +115,8 @@
         "CNI_PLUGIN_VERSION={{user `cni_plugin_version`}}",
         "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
         "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
-        "AWS_SESSION_TOKEN={{user `aws_session_token`}}"
+        "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
+        "NETFILTER_MODULE={{user `netfilter_module`}}"
       ]
     }
   ],

--- a/install-worker.sh
+++ b/install-worker.sh
@@ -102,6 +102,21 @@ sudo systemctl daemon-reload
 sudo systemctl enable iptables-restore
 
 ################################################################################
+### IPVS #######################################################################
+################################################################################
+
+# Check if IPVS should be enabled
+if [[ "$NETFILTER_MODULE" == "ipvs" ]]; then
+  sudo yum install ipvsadm -y
+  sudo modprobe ip_vs
+  sudo modprobe ip_vs_rr
+  sudo modprobe ip_vs_wrr
+  sudo modprobe ip_vs_sh
+  sudo modprobe nf_conntrack_ipv4
+  echo "IPVS modules have been enabled"
+fi
+
+################################################################################
 ### Docker #####################################################################
 ################################################################################
 

--- a/log-collector-script/eks-log-collector.sh
+++ b/log-collector-script/eks-log-collector.sh
@@ -236,6 +236,7 @@ collect() {
   get_mounts_info
   get_selinux_info
   get_iptables_info
+  get_ipvs_info
   get_pkglist
   get_system_services
   get_docker_info
@@ -300,6 +301,14 @@ get_iptables_info() {
   iptables --wait 1 --numeric --verbose --list --table nat > "${COLLECT_DIR}"/networking/iptables-nat.txt
   iptables --wait 1 --numeric --verbose --list > "${COLLECT_DIR}"/networking/iptables.txt
   iptables-save > "${COLLECT_DIR}"/networking/iptables-save.txt
+
+  ok
+}
+
+get_ipvs_info() {
+  try "collect ipvs information"
+
+  ipvsadm -l -n > "${COLLECT_DIR}"/networking/ipvs_rules.txt
 
   ok
 }


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/containers-roadmap/issues/142

*Description of changes:*

IPVS is a relatively common feature request for EKS users. Their primary use case is generally to gain access to more advanced load balancing algorithms (like least-connections) than what is provided by IPTables, and for the performance benefit when running large numbers of Services and Pods (IPVS is better at handling large numbers of rule-lookups than IPTables).

We can see this item is on the GitHub Containers Roadmap with 30 thumbsups, but it hasn't yet been implemented: https://github.com/aws/containers-roadmap/issues/142

Currently we don't provide IPVS as an option in the EKS AMIs since upstream Kubernetes has not set this as the default (yet). However, Kubernetes has flagged IPVS has "generally available" as of 1.11, hence users are interested in testing it out.

There are some issues with IPVS which are being ironed out which explains why it hasn't yet become the default for upstream Kubernetes. However, since we have interest from users already, I think it's worthwhile to provide this as an option for users to at least test out for themselves. We can emphasize that the feature is "beta", but still make it easy enough for eager users to begin testing in anticipation for it becoming a future Kubernetes default.

This also benefits upstream Kubernetes since EKS users can funnel their feedback upstream if they encounter any issues with IPVS during testing.

I'm opening a Pull Request which implements this feature with the following implementation:

- Define an Environment Variable in the eks-worker-al2.json file where users can define the "netfilter_module". The options are "iptables" (which I've set as the default), and "ipvs".
- Modify install-worker.sh to install the ipvsadm package and relevant kernel modules only when the netfilter_module env var is set to "ipvs".
- We do not remove the IPTables setup section of install-worker.sh because IPTables is still necessary for the AWS CNI to function. The AWS CNI uses IPTables for creating an SNAT rule for Pod traffic leaving the VPC. Therefore, IPTables needs to be setup to ensure Pods can connect to endpoints outside the VPC.
- Modify the EKS Logs Collector script to gather IPVS rules by default. This is inside a "try" block, so even if IPVS isn't installed because the user selected IPTables, it won't affect the script. Additionally, I have not added the `ipvsadm` command to the REQUIRED_UTILS section, since we don't need to fail when this command isn't installed.

Testing:

- I've tested the default IPTables setup by just running `make` in the repo without selecting IPVS. I've launched a Node Group from the resulting AMI and confirmed that k8s Services are operating normally using IPTables, and `ipvsadm` is not installed, as expected. So the existing functionality is still working as expected.

- Then I've modified the netfilter_module env var to "ipvs" and run `make` again. I've modified the kube-proxy-config ConfigMap to switch the "mode" from "iptables" to "ipvs". I've launched a new Node Group from the resulting AMIs, and cordoned all existing Nodes to force my Pods to schedule to the new Node. After creating a Deployment and exposing it as a ClusterIP Service, running `ipvsadm -l -n` on the Node confirmed the expected rules were created successfully. Connecting to the Service endpoint worked correctly. I've recreated the above test with a NodePort Service successfully as well. Connecting from the Pod to the internet also works correctly, indicating the SNAT rules created by the CNI for traffic leaving the VPC is still working as expected.

- Running the new logs collector script correctly bundles the IPVS rules into the networking/ipvs_rules.txt file.

If you have any questions about the above, please let me know.

###

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
