### PR TITLE
add ability to specify aws_region & binary_bucket_region & source_ami…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,21 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := ami_name binary_bucket_name kubernetes_version kubernetes_build_date docker_version cni_version cni_plugin_version source_ami_id arch instance_type
-AWS_DEFAULT_REGION ?= us-west-2
+PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date docker_version cni_version cni_plugin_version source_ami_id source_ami_owners arch instance_type
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})
 
+aws_region ?= $(AWS_DEFAULT_REGION)
+binary_bucket_region ?= $(AWS_DEFAULT_REGION)
 ami_name ?= amazon-eks-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 arch ?= x86_64
 ifeq ($(arch), arm64)
 instance_type ?= a1.large
 else
 instance_type ?= m4.large
+endif
+
+ifeq ($(aws_region), cn-northwest-1)
+source_ami_owners ?= 141808717104
 endif
 
 T_RED := \e[0;31m


### PR DESCRIPTION
add ability to specify below variables from Makefile and provides sensible defaults.
* aws_region
* binary_bucket_region
* source_ami_owners 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
