### PR TITLE
Fix retries in bootstrap.sh

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -237,9 +237,10 @@ CA_CERTIFICATE_FILE_PATH=$CA_CERTIFICATE_DIRECTORY/ca.crt
 mkdir -p $CA_CERTIFICATE_DIRECTORY
 if [[ -z "${B64_CLUSTER_CA}" ]] && [[ -z "${APISERVER_ENDPOINT}" ]]; then
     DESCRIBE_CLUSTER_RESULT="/tmp/describe_cluster_result.txt"
-    rc=0
-    # Retry the DescribleCluster API for API_RETRY_ATTEMPTS
+
+    # Retry the DescribeCluster API for API_RETRY_ATTEMPTS
     for attempt in `seq 0 $API_RETRY_ATTEMPTS`; do
+        rc=0
         if [[ $attempt -gt 0 ]]; then
             echo "Attempt $attempt of $API_RETRY_ATTEMPTS"
         fi


### PR DESCRIPTION
*Description of changes:*

If `aws eks describe-cluster` fails the first time, the retries never work because the `rc` value is never able to be set back to zero it will stay as the value of the original error exit code. Also `DescribleCluster` was changed to `DescribeCluster`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
