### PR TITLE
Use the binaries included in the latest release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,16 +39,16 @@ k8s: validate
 
 .PHONY: 1.11
 1.11:
-	$(MAKE) k8s kubernetes_version=1.11.10 kubernetes_build_date=2019-08-14
+	$(MAKE) k8s kubernetes_version=1.11.10 kubernetes_build_date=2019-09-27
 
 .PHONY: 1.12
 1.12:
-	$(MAKE) k8s kubernetes_version=1.12.10 kubernetes_build_date=2019-08-14
+	$(MAKE) k8s kubernetes_version=1.12.10 kubernetes_build_date=2019-12-13
 
 .PHONY: 1.13
 1.13:
-	$(MAKE) k8s kubernetes_version=1.13.8 kubernetes_build_date=2019-08-14
+	$(MAKE) k8s kubernetes_version=1.13.12 kubernetes_build_date=2019-12-13
 
 .PHONY: 1.14
 1.14:
-	$(MAKE) k8s kubernetes_version=1.14.6 kubernetes_build_date=2019-08-22
+	$(MAKE) k8s kubernetes_version=1.14.8 kubernetes_build_date=2019-12-13


### PR DESCRIPTION
*Issue #, if available: https://github.com/awslabs/amazon-eks-ami/issues/406*

*Description of changes:*
Updated kubernetes version and build_date to match https://github.com/awslabs/amazon-eks-ami/releases/tag/v20191213

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
