### PR TITLE
update binaries to use latest ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,18 +37,14 @@ k8s: validate
 
 # Build dates and versions taken from https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 
-.PHONY: 1.11
-1.11:
-	$(MAKE) k8s kubernetes_version=1.11.10 kubernetes_build_date=2019-08-14
-
 .PHONY: 1.12
 1.12:
-	$(MAKE) k8s kubernetes_version=1.12.10 kubernetes_build_date=2019-08-14
+	$(MAKE) k8s kubernetes_version=1.12.10 kubernetes_build_date=2020-01-22
 
 .PHONY: 1.13
 1.13:
-	$(MAKE) k8s kubernetes_version=1.13.8 kubernetes_build_date=2019-08-14
+	$(MAKE) k8s kubernetes_version=1.13.12 kubernetes_build_date=2020-01-22
 
 .PHONY: 1.14
 1.14:
-	$(MAKE) k8s kubernetes_version=1.14.6 kubernetes_build_date=2019-08-22
+	$(MAKE) k8s kubernetes_version=1.14.9 kubernetes_build_date=2020-01-22


### PR DESCRIPTION
Update binaries to use latest ones

## Kubernetes versions
* 1.14.9
* 1.13.12
* 1.12.10

## Authenticator version
v0.5.0

NOTE: we haven't released new AMIs using these binaries yet, it's already staged in our pipeline and will be released soon


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
