### PR TITLE
adding the additional scripts folder into internal build system

### DIFF
--- a/ArchiveBuildConfig.yaml
+++ b/ArchiveBuildConfig.yaml
@@ -8,10 +8,10 @@ dependencies:
   source:
     dirs:
       - src: files/
+      - src: scripts/
     files:
       - src: Makefile
       - src: eks-worker-al2.json
-      - src: install-worker.sh
       - src: amazon-eks-nodegroup.yaml
 archive:
   name: amazon-eks-ami.tar.gz


### PR DESCRIPTION
This PR adds the scripts folder into our internal build scripts.
That folder was added by me in https://github.com/awslabs/amazon-eks-ami/pull/411



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
