### PR TITLE
Reducing memory allocated in kubeReserved

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -147,40 +147,21 @@ get_resource_to_reserve_in_range() {
   echo $resources_to_reserve
 }
 
-# Calculates the amount of memory to reserve for the kubelet in mebibytes from the total memory available on the instance.
-# From the total memory capacity of this worker node, we calculate the memory resources to reserve
-# by reserving a percentage of the memory in each range up to the total memory available on the instance.
-# We are using these memory ranges from GKE (https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#node_allocatable):
-# 255 Mi of memory for machines with less than 1024Mi of memory
-# 25% of the first 4096Mi of memory
-# 20% of the next 4096Mi of memory (up to 8192Mi)
-# 10% of the next 8192Mi of memory (up to 16384Mi)
-# 6% of the next 114688Mi of memory (up to 131072Mi)
-# 2% of any memory above 131072Mi
+# Calculates the amount of memory to reserve for kubeReserved in mebibytes. KubeReserved is a function of pod
+# density so we are calculating the amount of memory to reserve for Kubernetes systems daemons by
+# considering the maximum number of pods this instance type supports.
 # Args:
-#   $1 total available memory on the machine in Mi
+#   $1 the instance type of the worker node
 # Return:
 #   memory to reserve in Mi for the kubelet
 get_memory_mebibytes_to_reserve() {
-  local total_memory_on_instance=$1
-  local memory_ranges=(0 4096 8192 16384 131072 $total_memory_on_instance)
-  local memory_percentage_reserved_for_ranges=(2500 2000 1000 600 200)
-  if (( $total_memory_on_instance <= 1024 )); then
-    memory_to_reserve="255"
-  else
-    memory_to_reserve="0"
-    for i in ${!memory_percentage_reserved_for_ranges[@]}; do
-      local start_range=${memory_ranges[$i]}
-      local end_range=${memory_ranges[(($i+1))]}
-      local percentage_to_reserve_for_range=${memory_percentage_reserved_for_ranges[$i]}
-      memory_to_reserve=$(($memory_to_reserve + \
-          $(get_resource_to_reserve_in_range $total_memory_on_instance $start_range $end_range $percentage_to_reserve_for_range)))
-    done
-  fi
+  local instance_type=$1
+  max_num_pods=$(cat /etc/eks/eni-max-pods.txt | grep $instance_type | awk '{print $2;}')
+  memory_to_reserve=$((11 * $max_num_pods + 255))
   echo $memory_to_reserve
 }
 
-# Calculates the amount of CPU to reserve for the kubelet in millicores from the total number of vCPUs available on the instance.
+# Calculates the amount of CPU to reserve for kubeReserved in millicores from the total number of vCPUs available on the instance.
 # From the total core capacity of this worker node, we calculate the CPU resources to reserve by reserving a percentage
 # of the available cores in each range up to the total number of cores available on the instance.
 # We are using these CPU ranges from GKE (https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#node_allocatable):
@@ -188,12 +169,10 @@ get_memory_mebibytes_to_reserve() {
 # 1% of the next core (up to 2 cores)
 # 0.5% of the next 2 cores (up to 4 cores)
 # 0.25% of any cores above 4 cores
-# Args:
-#   $1 total number of millicores on the instance (number of vCPUs * 1000)
 # Return:
 #   CPU resources to reserve in millicores (m)
 get_cpu_millicores_to_reserve() {
-  local total_cpu_on_instance=$1
+  local total_cpu_on_instance=$(($(nproc) * 1000))
   local cpu_ranges=(0 1000 2000 4000 $total_cpu_on_instance)
   local cpu_percentage_reserved_for_ranges=(600 100 50 25)
   cpu_to_reserve="0"
@@ -289,24 +268,21 @@ fi
 KUBELET_CONFIG=/etc/kubernetes/kubelet/kubelet-config.json
 echo "$(jq ".clusterDNS=[\"$DNS_CLUSTER_IP\"]" $KUBELET_CONFIG)" > $KUBELET_CONFIG
 
+INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+INSTANCE_TYPE=$(curl -s http://169.254.169.254/latest/meta-data/instance-type)
+
 # Sets kubeReserved and evictionHard in /etc/kubernetes/kubelet/kubelet-config.json for worker nodes. The following two function
-# calls calculate the CPU and memory resources to reserve for the kubelet based on instance type of the worker node.
+# calls calculate the CPU and memory resources to reserve for kubeReserved based on the instance type of the worker node.
 # Note that allocatable memory and CPU resources on worker nodes is calculated by the Kubernetes scheduler
 # with this formula when scheduling pods: Allocatable = Capacity - Reserved - Eviction Threshold.
 
-# gets the memory and CPU capacity of the worker node
-MEMORY_MI=$(free -m | grep Mem | awk '{print $2}')
-CPU_MILLICORES=$(($(nproc) * 1000))
 # calculates the amount of each resource to reserve
-mebibytes_to_reserve=$(get_memory_mebibytes_to_reserve $MEMORY_MI)
-cpu_millicores_to_reserve=$(get_cpu_millicores_to_reserve $CPU_MILLICORES)
+mebibytes_to_reserve=$(get_memory_mebibytes_to_reserve $INSTANCE_TYPE)
+cpu_millicores_to_reserve=$(get_cpu_millicores_to_reserve)
 # writes kubeReserved and evictionHard to the kubelet-config using the amount of CPU and memory to be reserved
 echo "$(jq '. += {"evictionHard": {"memory.available": "100Mi", "nodefs.available": "10%", "nodefs.inodesFree": "5%"}}' $KUBELET_CONFIG)" > $KUBELET_CONFIG
 echo "$(jq --arg mebibytes_to_reserve "${mebibytes_to_reserve}Mi" --arg cpu_millicores_to_reserve "${cpu_millicores_to_reserve}m" \
     '. += {kubeReserved: {"cpu": $cpu_millicores_to_reserve, "ephemeral-storage": "1Gi", "memory": $mebibytes_to_reserve}}' $KUBELET_CONFIG)" > $KUBELET_CONFIG
-
-INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
-INSTANCE_TYPE=$(curl -s http://169.254.169.254/latest/meta-data/instance-type)
 
 if [[ "$USE_MAX_PODS" = "true" ]]; then
     MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
@@ -348,3 +324,4 @@ fi
 systemctl daemon-reload
 systemctl enable kubelet
 systemctl start kubelet
+


### PR DESCRIPTION
### Overview: 

Related issue: https://github.com/awslabs/amazon-eks-ami/issues/387

This PR reduces the memory dynamically allocated in kubeReserved. The purpose of kubeReserved is to reserve resources for Kubernetes system daemons that aren’t run as pods, including the kubelet and container runtime. If resources are not reserved, the allocatable resources on worker nodes will include the resources required by these processes, resulting in pods and system daemons competing for the same resources. Note that the resources required by Kubernetes system daemons is a function of pod density on worker nodes. We will continue using our current formula for reserving CPU resources. 

For more information about kube-reserved see: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/

### Testing:

**Setup:** 
These tests were run against a 1.14 EKS cluster with three worker nodes of the given instance type. We used ami-05d586e6f773f6abf for the worker node AMI which doesn’t set kubeReserved. Since kubeReserved is a function of pod density, we ran the kubelet_perf e2e test (https://github.com/kubernetes/kubernetes/blob/master/test/e2e/node/kubelet_perf.go) with the maximum number of pods we support per worker node. By default, this upstream test is run with 100 pods per worker node. Our worker nodes support more or less than 100 pods depending on the maximum number of network interfaces and the number of IP addresses per network interface supported by that instance type.

To calculate the number of pods that can run on a given worker node instance type:
MaximumNetworkInterfaces * (IPPerNetworkInterface - 1) + 2

Note that we add two for the aws-node and kube-proxy pods running on all worker nodes.

For more information about IP addresses per network interface per instance type see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html and https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt

While running the kubelet_perf e2e test, we also ran chaoskube to ensure a constant pod churn while the test was executing (https://github.com/linki/chaoskube). We configured chaoskube to kill a random pod every two seconds in the namespace where the kubelet_perf replica set was running. 

**Data:**
To calculate the Kubernetes system daemon memory usage, we added together the RSS memory usage by the kubelet and container runtime.

Kubernetes system daemon example memory usages on different instance types:

t3.small (2 vCPU, 2 GiB, 11 pods): 150.27 Mi, 176.62 Mi, 156.34 Mi
t3.medium (2 vCPU, 4 GiB, 17 pods): 203.09 Mi, 218.98 Mi, 214.50 Mi
t3.large (2 vCPU, 8 GiB, 35 pods): 247.61 Mi, 226.05 Mi, 221.93 Mi
t3.xlarge (4 vCPU, 16 GiB, 58 pods): 297.76 Mi, 332.58 Mi, 305.94 Mi
t3.2xlarge (8 vCPU, 32 GiB, 58 pods): 299.23 Mi, 298.33 Mi, 318.36 Mi
m5.4xlarge (16 vCPU, 64 GiB, 234 pods): 931.70 Mi, 934.83 Mi, 949.34 Mi
m4.10xlarge (40 vCPU, 160 GiB, 234 pods): 1057.43 Mi, 1057.81 Mi , 1058.28 Mi
m5.12xlarge (48 vCPU, 192 GiB, 234 pods): 1103.84 Mi, 1098.63 Mi, 1100.50 Mi
r4.8xlarge (32 vCPU, 244 GiB, 234 pods): 1004.25 Mi, 1007.63 Mi, 1028.63 Mi
m5.24xlarge (96 vCPU, 384 GiB, 737 pods): 3837.95 Mi, 3821.56 Mi, 3833.79 Mi

Note that memory usage by Kubernetes system daemons is a function of running pods, not the available memory. For example, all instances which support 234 pods used approximately 1000 Mi for Kubernetes system daemons each, even though the available memory greatly varies between these instance types. 

If we plot this data using the number of pods as the x-axis and the Kubernetes system daemon memory usage in MiB as the y-axis:

![Screen Shot 2020-02-18 at 1 35 32 PM](https://user-images.githubusercontent.com/55205932/74780025-9abc0d00-5253-11ea-96a7-ca5fe02b8749.png)

We can see pod number and memory usage has a linear relationship. While slightly over-estimating the memory usage for safety, we can see this relationship can be modeled by:
MemoryToReserve = 6 * NumPods + 255

Example KubeReserved Memory Reservations:

t3.small (2 vCPU, 2 GiB, 11 pods): 321 Mi
t3.medium (2 vCPU, 4 GiB, 17 pods): 357 Mi
t3.large (2 vCPU, 8 GiB, 35 pods): 465 Mi
t3.xlarge (4 vCPU, 16 GiB, 58 pods): 603 Mi
t3.2xlarge (8 vCPU, 32 GiB, 58 pods): 603 Mi
m5.4xlarge (16 vCPU, 64 GiB, 234 pods): 1659 Mi
m4.10xlarge (40 vCPU, 160 GiB, 234 pods): 1659 Mi
m5.12xlarge (48 vCPU, 192 GiB, 234 pods): 1659 Mi
r4.8xlarge (32 vCPU, 244 GiB, 234 pods): 1659 Mi
m5.24xlarge (96 vCPU, 384 GiB, 737 pods): 4677 Mi