### PR TITLE
Removed invalid target 1.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.11 1.12 1.13 1.14
+all: 1.12 1.13 1.14
 
 .PHONY: validate
 validate:


### PR DESCRIPTION


*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/420

*Description of changes:*
Currently, AWS EKS is no longer support Kubernetes 1.11. So the dummy target 1.11 must be removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
