### PR TITLE
Fix regression introduced for images built in us-east-1

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -157,11 +157,17 @@ sudo tar -xvf cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz -C /opt/cni/bin
 rm cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz.sha512
 
 echo "Downloading binaries from: s3://$BINARY_BUCKET_NAME"
-S3_DOMAIN="amazonaws.com"
-if [ "$BINARY_BUCKET_REGION" = "cn-north-1" ] || [ "$BINARY_BUCKET_REGION" = "cn-northwest-1" ]; then
-    S3_DOMAIN="amazonaws.com.cn"
+
+S3_DOMAIN="s3.$BINARY_BUCKET_REGION"
+if [ "$BINARY_BUCKET_REGION" = "us-east-1"]; then
+    S3_DOMAIN="s3"
 fi
-S3_URL_BASE="https://$BINARY_BUCKET_NAME.s3.$BINARY_BUCKET_REGION.$S3_DOMAIN/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
+
+AMZ_DOMAIN="amazonaws.com"
+if [ "$BINARY_BUCKET_REGION" = "cn-north-1" ] || [ "$BINARY_BUCKET_REGION" = "cn-northwest-1" ]; then
+    AMZ_DOMAIN="amazonaws.com.cn"
+fi
+S3_URL_BASE="https://$BINARY_BUCKET_NAME.$S3_DOMAIN.$AMZ_DOMAIN/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
 S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
 
 BINARIES=(


### PR DESCRIPTION
When https://github.com/awslabs/amazon-eks-ami/commit/7695621fce7e2400eec946bafb3fca7ce521f4fd#diff-4de22a3515c1c580a6b6a45c86b7289c was added, us-east-1 no longer was being stripped from the S3_BASE_URL variable. Specifying the region on us-east-1 will result in an invalid url. In this pr I want to add the logic back in. 