### PR TITLE
Consistent Docker GID version in Image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 manifest.json
 *.swp
+.idea

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -110,6 +110,7 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
 if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo amazon-linux-extras enable docker
+    sudo useradd --gid 1950 docker
     sudo yum install -y docker-${DOCKER_VERSION}*
     sudo usermod -aG docker $USER
 


### PR DESCRIPTION
Docker install across versions change GID for docker, this causes problems for consistency. This commit solves it by adding same GID docker group


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
