### PR TITLE
Fixed amazon-eks-nodegroup.yaml lint issues

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -401,7 +401,6 @@ Resources:
 
   NodeSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
-    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow node to communicate with each other
       FromPort: 0
@@ -412,7 +411,6 @@ Resources:
 
   ClusterControlPlaneSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
-    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow pods to communicate with the cluster API Server
       FromPort: 443
@@ -423,7 +421,6 @@ Resources:
 
   ControlPlaneEgressToNodeSecurityGroup:
     Type: "AWS::EC2::SecurityGroupEgress"
-    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow the cluster control plane to communicate with worker Kubelet and pods
       DestinationSecurityGroupId: !Ref NodeSecurityGroup
@@ -434,7 +431,6 @@ Resources:
 
   ControlPlaneEgressToNodeSecurityGroupOn443:
     Type: "AWS::EC2::SecurityGroupEgress"
-    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow the cluster control plane to communicate with pods running extension API servers on port 443
       DestinationSecurityGroupId: !Ref NodeSecurityGroup
@@ -445,7 +441,6 @@ Resources:
 
   NodeSecurityGroupFromControlPlaneIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
-    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
       FromPort: 1025
@@ -456,7 +451,6 @@ Resources:
 
   NodeSecurityGroupFromControlPlaneOn443Ingress:
     Type: "AWS::EC2::SecurityGroupIngress"
-    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow pods running extension API servers on port 443 to receive communication from cluster control plane
       FromPort: 443
@@ -468,7 +462,7 @@ Resources:
   NodeLaunchConfig:
     Type: "AWS::AutoScaling::LaunchConfiguration"
     Properties:
-      AssociatePublicIpAddress: "true"
+      AssociatePublicIpAddress: true
       BlockDeviceMappings:
         - DeviceName: /dev/xvda
           Ebs:
@@ -503,15 +497,15 @@ Resources:
       MinSize: !Ref NodeAutoScalingGroupMinSize
       Tags:
         - Key: Name
-          PropagateAtLaunch: "true"
+          PropagateAtLaunch: true
           Value: !Sub ${ClusterName}-${NodeGroupName}-Node
         - Key: !Sub kubernetes.io/cluster/${ClusterName}
-          PropagateAtLaunch: "true"
+          PropagateAtLaunch: true
           Value: owned
       VPCZoneIdentifier: !Ref Subnets
     UpdatePolicy:
       AutoScalingRollingUpdate:
-        MaxBatchSize: "1"
+        MaxBatchSize: 1
         MinInstancesInService: !Ref NodeAutoScalingGroupDesiredCapacity
         PauseTime: PT5M
 


### PR DESCRIPTION
*Description of changes:*

These validations come from `cfn-lint`, the template was updated to be in compliance

```
W3005 Obsolete DependsOn on resource (NodeSecurityGroup), dependency already enforced by a "Ref" at Resources/NodeSecurityGroupIngress/Properties/SourceSecurityGroupId/Ref
amazon-eks-nodegroup.yaml:404:5

W3005 Obsolete DependsOn on resource (NodeSecurityGroup), dependency already enforced by a "Ref" at Resources/NodeSecurityGroupIngress/Properties/GroupId/Ref
amazon-eks-nodegroup.yaml:404:5

W3005 Obsolete DependsOn on resource (NodeSecurityGroup), dependency already enforced by a "Ref" at Resources/ClusterControlPlaneSecurityGroupIngress/Properties/SourceSecurityGroupId/Ref
amazon-eks-nodegroup.yaml:415:5

W3005 Obsolete DependsOn on resource (NodeSecurityGroup), dependency already enforced by a "Ref" at Resources/ControlPlaneEgressToNodeSecurityGroup/Properties/DestinationSecurityGroupId/Ref
amazon-eks-nodegroup.yaml:426:5

W3005 Obsolete DependsOn on resource (NodeSecurityGroup), dependency already enforced by a "Ref" at Resources/ControlPlaneEgressToNodeSecurityGroupOn443/Properties/DestinationSecurityGroupId/Ref
amazon-eks-nodegroup.yaml:437:5

W3005 Obsolete DependsOn on resource (NodeSecurityGroup), dependency already enforced by a "Ref" at Resources/NodeSecurityGroupFromControlPlaneIngress/Properties/GroupId/Ref
amazon-eks-nodegroup.yaml:448:5

W3005 Obsolete DependsOn on resource (NodeSecurityGroup), dependency already enforced by a "Ref" at Resources/NodeSecurityGroupFromControlPlaneOn443Ingress/Properties/GroupId/Ref
amazon-eks-nodegroup.yaml:459:5

E3012 Property Resources/NodeLaunchConfig/Properties/AssociatePublicIpAddress should be of type Boolean
amazon-eks-nodegroup.yaml:471:7

E3012 Property Resources/NodeGroup/Properties/Tags/0/PropagateAtLaunch should be of type Boolean
amazon-eks-nodegroup.yaml:506:11

E3012 Property Resources/NodeGroup/Properties/Tags/1/PropagateAtLaunch should be of type Boolean
amazon-eks-nodegroup.yaml:509:11

E3016 Value for MaxBatchSize must be of type Integer
amazon-eks-nodegroup.yaml:514:9
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
