### PR TITLE
Fix useradd to run with privileges

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -110,7 +110,7 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
 if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo amazon-linux-extras enable docker
-    sudo groupadd -fog 1950 docker && useradd --gid 1950 docker
+    sudo groupadd -fog 1950 docker && sudo useradd --gid 1950 docker
     sudo yum install -y docker-${DOCKER_VERSION}*
     sudo usermod -aG docker $USER
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Missing `sudo` before `useradd` results in an error that `useradd is not found`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
