### PR TITLE
Add inf1 instance family in EKS AMI packer configuration

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -159,6 +159,10 @@ Parameters:
       - i3en.6xlarge
       - i3en.12xlarge
       - i3en.24xlarge
+      - inf1.xlarge
+      - inf1.2xlarge
+      - inf1.6xlarge
+      - inf1.24xlarge
       - m1.small
       - m1.medium
       - m1.large

--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -97,6 +97,10 @@ i3en.3xlarge 58
 i3en.6xlarge 234
 i3en.12xlarge 234
 i3en.24xlarge 737
+inf1.xlarge 38
+inf1.2xlarge 38
+inf1.6xlarge 234
+inf1.24xlarge 437
 m1.small 8
 m1.medium 12
 m1.large 29


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change is to add inf1 instance family in EKS AMI packer configuration

**Note 1:** Calculation process for max pods in ./files/eni-max-pods.txt

of ENI * (# of IPv4 per ENI - 1)  + 2

From https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html,  we have
Instance Type | Maximum Network Interfaces(ENI) | Private IPv4 Addresses per Interface(# of IPv4 per ENI) | IPv6 Addresses per Interface
-- | -- | -- | --
inf1.xlarge | 4 | 10 | 10
inf1.2xlarge | 4 | 10 | 10
inf1.6xlarge | 8 | 30 | 30
inf1.24xlarge | 15 | 30 | 30

calculated via [ENI * (# of IPv4 per ENI - 1) + 2](https://github.com/regulusv/amazon-eks-ami/blob/41c699059d9e1e6101d491c69657c160fd968191/files/eni-max-pods.txt#L5) :
inf1.xlarge : 4 * (10-1) + 2 = 38
inf1.2xlarge : 4 * (10-1) + 2 = 38 
inf1.6xlarge: 8 * (30-1) + 2 = 234
inf1.24xlarge: 15 * (30-1) + 2 = 437

**Note 2 :** These instances requires AWS CNI v 1.6.0, if your version is v1.5.7, please update.
Refer: https://docs.aws.amazon.com/eks/latest/userguide/cni-upgrades.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

