### PR TITLE
Revert "Removing dependency on Authenticator binary (#440)"

### DIFF
--- a/files/kubelet-kubeconfig
+++ b/files/kubelet-kubeconfig
@@ -16,14 +16,10 @@ users:
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
-      command: aws
-      env:
-        - name: AWS_STS_REGIONAL_ENDPOINTS
-          value: regional
+      command: /usr/bin/aws-iam-authenticator
       args:
-        - eks
+        - "token"
+        - "-i"
+        - "CLUSTER_NAME"
         - --region
         - "AWS_REGION"
-        - get-token
-        - --cluster-name
-        - "CLUSTER_NAME"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -167,6 +167,7 @@ S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin
 
 BINARIES=(
     kubelet
+    aws-iam-authenticator
 )
 for binary in ${BINARIES[*]} ; do
     if [[ ! -z "$AWS_ACCESS_KEY_ID" ]]; then


### PR DESCRIPTION
This reverts commit 4e0e9164885e07851ed4a737461349ae6012765e.

*Description of changes:*
EksCtl currently doesn't support AMIs without this binary. Will bring this change back in, once EksCtl has this support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
