### PR TITLE
Removed AssociatePublicIpAddress setting from NodeLaunchCongig and ad…

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -409,6 +409,7 @@ Resources:
 
   NodeSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow node to communicate with each other
       FromPort: 0
@@ -419,6 +420,7 @@ Resources:
 
   ClusterControlPlaneSecurityGroupIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow pods to communicate with the cluster API Server
       FromPort: 443
@@ -429,6 +431,7 @@ Resources:
 
   ControlPlaneEgressToNodeSecurityGroup:
     Type: "AWS::EC2::SecurityGroupEgress"
+    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow the cluster control plane to communicate with worker Kubelet and pods
       DestinationSecurityGroupId: !Ref NodeSecurityGroup
@@ -439,6 +442,7 @@ Resources:
 
   ControlPlaneEgressToNodeSecurityGroupOn443:
     Type: "AWS::EC2::SecurityGroupEgress"
+    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow the cluster control plane to communicate with pods running extension API servers on port 443
       DestinationSecurityGroupId: !Ref NodeSecurityGroup
@@ -449,6 +453,7 @@ Resources:
 
   NodeSecurityGroupFromControlPlaneIngress:
     Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
       FromPort: 1025
@@ -459,6 +464,7 @@ Resources:
 
   NodeSecurityGroupFromControlPlaneOn443Ingress:
     Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: NodeSecurityGroup
     Properties:
       Description: Allow pods running extension API servers on port 443 to receive communication from cluster control plane
       FromPort: 443
@@ -470,7 +476,6 @@ Resources:
   NodeLaunchConfig:
     Type: "AWS::AutoScaling::LaunchConfiguration"
     Properties:
-      AssociatePublicIpAddress: true
       BlockDeviceMappings:
         - DeviceName: /dev/xvda
           Ebs:


### PR DESCRIPTION
…ded NodeSecurityGroup dependency to SG Ingress/Egress

*Issue #, if available:*

*Description of changes:*
1. Added NodeSecurityGroup dependency to SG Ingress/Egress.
2. We used to enforce public ip assignment for nodes in ASG. Now we are defaulting it to subnet setting


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
