### PR TITLE
Add a flag that allows CNI packages to be pulled from S3 instead of Github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date docker_version cni_version cni_plugin_version source_ami_id source_ami_owners arch instance_type security_group_id additional_yum_repos
+PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date docker_version cni_version cni_plugin_version source_ami_id source_ami_owners arch instance_type security_group_id additional_yum_repos pull_cni_from_github
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})
@@ -39,16 +39,16 @@ k8s: validate
 
 .PHONY: 1.12
 1.12:
-	$(MAKE) k8s kubernetes_version=1.12.10 kubernetes_build_date=2020-01-22
+	$(MAKE) k8s kubernetes_version=1.12.10 kubernetes_build_date=2020-04-17 pull_cni_from_github=true
 
 .PHONY: 1.13
 1.13:
-	$(MAKE) k8s kubernetes_version=1.13.12 kubernetes_build_date=2020-01-22
+	$(MAKE) k8s kubernetes_version=1.13.12 kubernetes_build_date=2020-04-16 pull_cni_from_github=true
 
 .PHONY: 1.14
 1.14:
-	$(MAKE) k8s kubernetes_version=1.14.9 kubernetes_build_date=2020-01-22
+	$(MAKE) k8s kubernetes_version=1.14.9 kubernetes_build_date=2020-04-16 pull_cni_from_github=true
  
 .PHONY: 1.15
 1.15:
-	$(MAKE) k8s kubernetes_version=1.15.10 kubernetes_build_date=2020-02-22
+	$(MAKE) k8s kubernetes_version=1.15.11 kubernetes_build_date=2020-04-16 pull_cni_from_github=true

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -17,6 +17,7 @@
     "docker_version": "18.09.9ce-2.amzn2",
     "cni_version": "v0.6.0",
     "cni_plugin_version": "v0.7.5",
+    "pull_cni_from_github": "true",
 
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
@@ -136,6 +137,7 @@
         "DOCKER_VERSION={{user `docker_version`}}",
         "CNI_VERSION={{user `cni_version`}}",
         "CNI_PLUGIN_VERSION={{user `cni_plugin_version`}}",
+        "PULL_CNI_FROM_GITHUB={{user `pull_cni_from_github`}}",
         "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
         "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -28,6 +28,7 @@ validate_env_set CNI_VERSION
 validate_env_set CNI_PLUGIN_VERSION
 validate_env_set KUBERNETES_VERSION
 validate_env_set KUBERNETES_BUILD_DATE
+validate_env_set PULL_CNI_FROM_GITHUB
 
 ################################################################################
 ### Machine Architecture #######################################################
@@ -145,18 +146,6 @@ sudo mkdir -p /var/lib/kubernetes
 sudo mkdir -p /var/lib/kubelet
 sudo mkdir -p /opt/cni/bin
 
-wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-${ARCH}-${CNI_VERSION}.tgz
-wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-${ARCH}-${CNI_VERSION}.tgz.sha512
-sudo sha512sum -c cni-${ARCH}-${CNI_VERSION}.tgz.sha512
-sudo tar -xvf cni-${ARCH}-${CNI_VERSION}.tgz -C /opt/cni/bin
-rm cni-${ARCH}-${CNI_VERSION}.tgz cni-${ARCH}-${CNI_VERSION}.tgz.sha512
-
-wget https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz
-wget https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz.sha512
-sudo sha512sum -c cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz.sha512
-sudo tar -xvf cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz -C /opt/cni/bin
-rm cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz.sha512
-
 echo "Downloading binaries from: s3://$BINARY_BUCKET_NAME"
 S3_DOMAIN="amazonaws.com"
 if [ "$BINARY_BUCKET_REGION" = "cn-north-1" ] || [ "$BINARY_BUCKET_REGION" = "cn-northwest-1" ]; then
@@ -183,6 +172,41 @@ for binary in ${BINARIES[*]} ; do
     sudo chmod +x $binary
     sudo mv $binary /usr/bin/
 done
+
+if [ "$PULL_CNI_FROM_GITHUB" = "true" ]; then
+    echo "Downloading CNI assets from Github"
+    wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-${ARCH}-${CNI_VERSION}.tgz
+    wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-${ARCH}-${CNI_VERSION}.tgz.sha512
+
+    wget https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz
+    wget https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz.sha512
+    sudo sha512sum -c cni-${ARCH}-${CNI_VERSION}.tgz.sha512
+    sudo sha512sum -c cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz.sha512
+    rm cni-${ARCH}-${CNI_VERSION}.tgz.sha512
+    rm cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz.sha512
+else
+    CNI_BINARIES=(
+            cni-${ARCH}-${CNI_VERSION}.tgz
+            cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz
+    )
+    for binary in ${CNI_BINARIES[*]} ; do
+        if [[ ! -z "$AWS_ACCESS_KEY_ID" ]]; then
+            echo "AWS cli present - using it to copy binaries from s3."
+            aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
+            aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
+            sudo sha256sum -c $binary.sha256
+        else
+            echo "AWS cli missing - using wget to fetch cni binaries from s3. Note: This won't work for private bucket."
+            sudo wget $S3_URL_BASE/$binary
+            sudo wget $S3_URL_BASE/$binary.sha256
+        fi
+    done
+fi
+sudo tar -xvf cni-${ARCH}-${CNI_VERSION}.tgz -C /opt/cni/bin
+sudo tar -xvf cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz -C /opt/cni/bin
+rm cni-${ARCH}-${CNI_VERSION}.tgz
+rm cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz
+
 sudo rm *.sha256
 
 KUBERNETES_MINOR_VERSION=${KUBERNETES_VERSION%.*}


### PR DESCRIPTION
Adding a way that the CNI assets be pulled from S3 is desired by setting a config value in the Makefile.

The default behavior is unchanged and will still pull assets from
Github.

Testing

Tested by building AMIs locally with these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
