### PR TITLE
Adding 1.16 to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,8 @@ k8s: validate
 .PHONY: 1.15
 1.15:
 	$(MAKE) k8s kubernetes_version=1.15.11 kubernetes_build_date=2020-04-16 pull_cni_from_github=true
+
+.PHONY: 1.16
+1.16:
+	$(MAKE) k8s kubernetes_version=1.16.8 kubernetes_build_date=2020-04-16 pull_cni_from_github=true
+


### PR DESCRIPTION
*Description of changes:*

Allow 1.16 version builds for EKS Optimized AMI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
