### PR TITLE
Update bootstrap.sh to get the correct $max_num_pods for instance types f1.16xlarge, g3.16xlarge, h1.16xlarge, i3.16xlarge, and r4.16xlarge

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -159,8 +159,7 @@ get_resource_to_reserve_in_range() {
 # Return:
 #   memory to reserve in Mi for the kubelet
 get_memory_mebibytes_to_reserve() {
-  local instance_type=$1
-  max_num_pods=$(cat /etc/eks/eni-max-pods.txt | grep -v "^#" | grep $instance_type | awk '{print $2;}')
+  local max_num_pods=$1
   memory_to_reserve=$((11 * $max_num_pods + 255))
   echo $memory_to_reserve
 }
@@ -280,8 +279,16 @@ INSTANCE_TYPE=$(curl -s http://169.254.169.254/latest/meta-data/instance-type)
 # Note that allocatable memory and CPU resources on worker nodes is calculated by the Kubernetes scheduler
 # with this formula when scheduling pods: Allocatable = Capacity - Reserved - Eviction Threshold.
 
+#calculate the max number of pods per instance type
+MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
+MAX_PODS=$(cat $MAX_PODS_FILE | awk "/^$INSTANCE_TYPE/"' { print $2 }')
+if [ -z "$MAX_PODS" ]; then
+    echo 'No entry for $INSTANCE_TYPE in $MAX_PODS_FILE'
+    exit 1
+fi
+
 # calculates the amount of each resource to reserve
-mebibytes_to_reserve=$(get_memory_mebibytes_to_reserve $INSTANCE_TYPE)
+mebibytes_to_reserve=$(get_memory_mebibytes_to_reserve $MAX_PODS)
 cpu_millicores_to_reserve=$(get_cpu_millicores_to_reserve)
 # writes kubeReserved and evictionHard to the kubelet-config using the amount of CPU and memory to be reserved
 echo "$(jq '. += {"evictionHard": {"memory.available": "100Mi", "nodefs.available": "10%", "nodefs.inodesFree": "5%"}}' $KUBELET_CONFIG)" > $KUBELET_CONFIG
@@ -289,9 +296,7 @@ echo "$(jq --arg mebibytes_to_reserve "${mebibytes_to_reserve}Mi" --arg cpu_mill
     '. += {kubeReserved: {"cpu": $cpu_millicores_to_reserve, "ephemeral-storage": "1Gi", "memory": $mebibytes_to_reserve}}' $KUBELET_CONFIG)" > $KUBELET_CONFIG
 
 if [[ "$USE_MAX_PODS" = "true" ]]; then
-    MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
     set +o pipefail
-    MAX_PODS=$(grep ^$INSTANCE_TYPE $MAX_PODS_FILE | awk '{print $2}')
     set -o pipefail
     if [[ -n "$MAX_PODS" ]]; then
         echo "$(jq ".maxPods=$MAX_PODS" $KUBELET_CONFIG)" > $KUBELET_CONFIG

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -281,7 +281,9 @@ INSTANCE_TYPE=$(curl -s http://169.254.169.254/latest/meta-data/instance-type)
 
 #calculate the max number of pods per instance type
 MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
+set +o pipefail
 MAX_PODS=$(cat $MAX_PODS_FILE | awk "/^$INSTANCE_TYPE/"' { print $2 }')
+set -o pipefail
 if [ -z "$MAX_PODS" ]; then
     echo 'No entry for $INSTANCE_TYPE in $MAX_PODS_FILE'
     exit 1
@@ -296,8 +298,6 @@ echo "$(jq --arg mebibytes_to_reserve "${mebibytes_to_reserve}Mi" --arg cpu_mill
     '. += {kubeReserved: {"cpu": $cpu_millicores_to_reserve, "ephemeral-storage": "1Gi", "memory": $mebibytes_to_reserve}}' $KUBELET_CONFIG)" > $KUBELET_CONFIG
 
 if [[ "$USE_MAX_PODS" = "true" ]]; then
-    set +o pipefail
-    set -o pipefail
     if [[ -n "$MAX_PODS" ]]; then
         echo "$(jq ".maxPods=$MAX_PODS" $KUBELET_CONFIG)" > $KUBELET_CONFIG
     else

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -160,7 +160,7 @@ get_resource_to_reserve_in_range() {
 #   memory to reserve in Mi for the kubelet
 get_memory_mebibytes_to_reserve() {
   local instance_type=$1
-  max_num_pods=$(cat /etc/eks/eni-max-pods.txt | grep $instance_type | awk '{print $2;}')
+  max_num_pods=$(cat /etc/eks/eni-max-pods.txt | grep -v "^#" | grep $instance_type | awk '{print $2;}')
   memory_to_reserve=$((11 * $max_num_pods + 255))
   echo $memory_to_reserve
 }


### PR DESCRIPTION
*Issue #, if available:*

When running the the bootstrap.sh script with the instances f1.16xlarge, g3.16xlarge, h1.16xlarge, i3.16xlarge, and r4.16xlarge it would fail with the error:

line XXX: If: unbound variable

The error is happening because apart from the list of instances and the max number of pods the eni-max-pods.txt is also listing this instances at the beginning of the file in this note:

    # If f1.16xlarge, g3.16xlarge, h1.16xlarge, i3.16xlarge, and r4.16xlarge
    # instances use more than 31 IPv4 or IPv6 addresses per interface

Therefore the following lines of code fail 

    max_num_pods=$(cat /etc/eks/eni-max-pods.txt | grep $instance_type | awk '{print $2;}')
    memory_to_reserve=$((11 * $max_num_pods + 255))

For example $instance_type  is replaced with  f1.16xlarge and we run the following commands the value for max_num_pods will be:

    $ max_num_pods=$(cat /etc/eks/eni-max-pods.txt | grep r4.16xlarge | awk '{print $2;}')
    $ echo $max_num_pods
    If 452

instead of just 452

*Description of changes:*

I modified the function get_memory_mebibytes_to_reserve()

### new one

    get_memory_mebibytes_to_reserve() {
        local max_num_pods=$1
        memory_to_reserve=$((11 * $max_num_pods + 255))
        echo $memory_to_reserve
    }

### existent one

    get_memory_mebibytes_to_reserve() {
        local instance_type=$1
        max_num_pods=$(cat /etc/eks/eni-max-pods.txt | grep $instance_type | awk '{print $2;}')
        memory_to_reserve=$((11 * $max_num_pods + 255))
        echo $memory_to_reserve
    }

With this modification it will receive the max_num_pods value and in this way it will not need to calculate the max number of pods twice.

This lines will calculate the max number of pods, it checks that it starts with the instance type so it will no take the ocurrence in comments:

    MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
    set +o pipefail
    MAX_PODS=$(cat $MAX_PODS_FILE | awk "/^$INSTANCE_TYPE/"' { print $2 }')
    set -o pipefail
    if [ -z "$MAX_PODS" ]; then
        echo 'No entry for $INSTANCE_TYPE in $MAX_PODS_FILE'
        exit 1
    fi

I added to exit with an error if it does not find the instance type in the file, because if this is not included it will fail with with unbound error in the function get_memory_mebibytes_to_reserve(),
However, checked that according with this code that the idea is to continue setting the variables even if the instance type is not provided. My question in this point is which should be the best "default "value for mebibytes_to_reserve when the instance type is not in the list, as it is expected to be calculated base on the pod density on the nodes [1], and given that the instance features is very different from one type of instance to other. Do you think assume the bigger number of pods could be an option?

    if [[ -n "$MAX_PODS" ]]; then
        echo "$(jq ".maxPods=$MAX_PODS" $KUBELET_CONFIG)" > $KUBELET_CONFIG
    else
        echo "No entry for $INSTANCE_TYPE in $MAX_PODS_FILE. Not setting max pods for kubelet"
    fi


Continue with the description of the changes I modified this line to pass $MAX_PODS instead of
### new one

    mebibytes_to_reserve=$(get_memory_mebibytes_to_reserve $MAX_PODS)

### existent one

    mebibytes_to_reserve=$(get_memory_mebibytes_to_reserve $INSTANCE_TYPE) 

Finally, I remove the calculation of the pods in this section because it was calculated in the previous lines

### new one

    if [[ "$USE_MAX_PODS" = "true" ]]; then
        if [[ -n "$MAX_PODS" ]]; then
            echo "$(jq ".maxPods=$MAX_PODS" $KUBELET_CONFIG)" > $KUBELET_CONFIG
        else
            echo "No entry for $INSTANCE_TYPE in $MAX_PODS_FILE. Not setting max pods for kubelet"
        fi
    fi

### existent one
    
    if [[ "$USE_MAX_PODS" = "true" ]]; then
        MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
        set +o pipefail
        MAX_PODS=$(grep ^$INSTANCE_TYPE $MAX_PODS_FILE | awk '{print $2}')
        set -o pipefail
        if [[ -n "$MAX_PODS" ]]; then
            echo "$(jq ".maxPods=$MAX_PODS" $KUBELET_CONFIG)" > $KUBELET_CONFIG
        else
            echo "No entry for $INSTANCE_TYPE in $MAX_PODS_FILE. Not setting max pods for kubelet"
        fi
    fi

References:

[1] https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->