### PR TITLE
Change to use instance-identity/document to fetch region directly

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -195,9 +195,10 @@ if [ -z "$CLUSTER_NAME" ]; then
     exit  1
 fi
 
-ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
-AWS_DEFAULT_REGION=$(echo $ZONE | awk '{print substr($0, 1, length($0)-1)}')
-AWS_SERVICES_DOMAIN=$(curl -s http://169.254.169.254/2018-09-24/meta-data/services/domain)
+
+TOKEN=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 600" "http://169.254.169.254/latest/api/token")
+AWS_DEFAULT_REGION=$(curl -s --retry 5 -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region -r)
+AWS_SERVICES_DOMAIN=$(curl -s --retry 5 -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/2018-09-24/meta-data/services/domain)
 
 MACHINE=$(uname -m)
 if [ "$MACHINE" == "x86_64" ]; then


### PR DESCRIPTION
*Issue #, if available:*
#466 

We are using ZONE to infer the REGION which is not the best way. There're edge cases like #466 describes that this method can not cover. The most elegant way is to read REGION directly from ec2 metadata service. 
https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh#L198-L199

`http://169.254.169.254/latest/dynamic/instance-identity/document` provides the information and here's an output example

```
{
  "accountId" : "xxxx",
  "architecture" : "x86_64",
  "availabilityZone" : "us-west-2d",
  "billingProducts" : null,
  "devpayProductCodes" : null,
  "marketplaceProductCodes" : null,
  "imageId" : "ami-0c13bb9cbfd007e56",
  "instanceId" : "i-040xxxxx5b",
  "instanceType" : "m5.large",
  "kernelId" : null,
  "pendingTime" : "2020-04-02T01:03:19Z",
  "privateIp" : "192.168.x.169",
  "ramdiskId" : null,
  "region" : "us-west-2",
  "version" : "2017-09-30"
}

```


*Description of changes:*
Change to use instance-identity/document to fetch region directly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
