### PR TITLE
Add a new manifest containing the AMI name

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -162,6 +162,11 @@
       "type": "manifest",
       "output": "manifest.json",
       "strip_path": true
+    },
+    {
+      "type": "manifest",
+      "output": "{{user `ami_name`}}-manifest.json",
+      "strip_path": true
     }
   ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This commit adds a new manifest which contains AMI name in the manifest filename so that parallel builds can be triggered. Even though the new manifest is now generated along with the current one for backwards compatibility, eventually the old manifest (manifest.json) will be deprecated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
