### PR TITLE
Moved the file copy after the execution of upgrade_kernel.sh

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -5,7 +5,7 @@
     "creator": "{{env `USER`}}",
     "encrypted": "false",
     "kms_key_id": "",
-    
+
     "aws_access_key_id": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_access_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
@@ -65,7 +65,7 @@
           "delete_on_termination": true
         }
       ],
-      "ami_block_device_mappings": [    
+      "ami_block_device_mappings": [
         {
           "device_name": "/dev/xvda",
           "volume_type": "gp2",
@@ -101,16 +101,6 @@
 
   "provisioners": [
     {
-      "type": "shell",
-      "remote_folder": "{{ user `remote_folder`}}",
-      "inline": ["mkdir -p /tmp/worker/"]
-    },
-    {
-      "type": "file",
-      "source": "{{template_dir}}/files/",
-      "destination": "/tmp/worker/"
-    },
-    {
         "type": "shell",
         "remote_folder": "{{ user `remote_folder`}}",
         "script": "{{template_dir}}/scripts/install_additional_repos.sh",
@@ -123,6 +113,16 @@
       "remote_folder": "{{ user `remote_folder`}}",
       "expect_disconnect": true,
       "script": "{{template_dir}}/scripts/upgrade_kernel.sh"
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "inline": ["mkdir -p /tmp/worker/"]
+    },
+    {
+      "type": "file",
+      "source": "{{template_dir}}/files/",
+      "destination": "/tmp/worker/"
     },
     {
       "type": "shell",


### PR DESCRIPTION
Upon running a recent packer build on AL2 today, it failed with the following error while executing the install-worker.sh script:
```
19-May-2020 14:52:03 | amazon-ebs: mv: cannot stat ‘/tmp/worker/iptables-restore.service’: No such file or directory
```

*Description of changes:*
Moved the file copy after the execution of upgrade_kernel.sh. upgrade_kernel.sh performs a system reboot which will remove the contents of /tmp.

I was able to successfully build a new AMI on an x86_64 arch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
