### PR TITLE
Revert "Bump CNI plugin version to 0.8.6"

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -16,7 +16,7 @@
     "kubernetes_build_date": null,
     "docker_version": "19.03.6ce-4.amzn2",
     "cni_version": "v0.6.0",
-    "cni_plugin_version": "v0.8.6",
+    "cni_plugin_version": "v0.7.5",
     "pull_cni_from_github": "true",
 
     "source_ami_id": "",


### PR DESCRIPTION
This reverts commit 822aa4ab3894706f2b309b88df0d8c886a6e782d.

*Issue #, if available:*

*Description of changes:*
Reverting the CNI plugin version update due to build problems

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
