### PR TITLE
updating logrotateConf ownership to root

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -136,6 +136,7 @@ fi
 sudo mv $TEMPLATE_DIR/logrotate-kube-proxy /etc/logrotate.d/kube-proxy
 sudo mv $TEMPLATE_DIR/logrotate.conf /etc/logrotate.conf
 sudo chown root:root /etc/logrotate.d/kube-proxy
+sudo chown root:root /etc/logrotate.conf
 sudo mkdir -p /var/log/journal
 
 ################################################################################


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In one of the [recent commit](https://github.com/awslabs/amazon-eks-ami/commit/707fc575a64df66b449a43a1e09cc618d6221370), default path of logrotate.conf was changed to /etc/logrotate.conf. However, the ownership of this file is still `ec2-user` which is getting updated to `root` user in this commit

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
