### PR TITLE
fix(install-worker): add s3 domains for isolated regions

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -151,6 +151,10 @@ echo "Downloading binaries from: s3://$BINARY_BUCKET_NAME"
 S3_DOMAIN="amazonaws.com"
 if [ "$BINARY_BUCKET_REGION" = "cn-north-1" ] || [ "$BINARY_BUCKET_REGION" = "cn-northwest-1" ]; then
     S3_DOMAIN="amazonaws.com.cn"
+elif [ "$BINARY_BUCKET_REGION" = "us-iso-east-1" ]; then
+    S3_DOMAIN="c2s.ic.gov"
+elif [ "$BINARY_BUCKET_REGION" = "us-isob-east-1" ]; then
+    S3_DOMAIN="sc2s.sgov.gov"
 fi
 S3_URL_BASE="https://$BINARY_BUCKET_NAME.s3.$BINARY_BUCKET_REGION.$S3_DOMAIN/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
 S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds support for binary buckets in isolated regions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
