### PR TITLE
ensure kubelet.service.d directory exists

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -306,6 +306,8 @@ if [[ "$USE_MAX_PODS" = "true" ]]; then
     fi
 fi
 
+mkdir -p /etc/systemd/system/kubelet.service.d
+
 cat <<EOF > /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf
 [Service]
 Environment='KUBELET_ARGS=--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I used this Packer config as the base for a EKS node based on Ubuntu 20.04 LTS with `files/bootstrap.sh` used exactly as-is. During cloud-init, I saw the following error:

```
/etc/eks/bootstrap.sh: line 309: /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf: No such file or directory
```

Straight-forward fix is to `mkdir -p` the directory in question.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
