### PR TITLE
Change cgroup driver to systemd

### DIFF
--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -1,5 +1,8 @@
 {
   "bridge": "none",
+  "exec-opts": [
+    "native.cgroupdriver=systemd"
+  ],
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "10m",

--- a/files/kubelet-config.json
+++ b/files/kubelet-config.json
@@ -24,7 +24,7 @@
   "clusterDomain": "cluster.local",
   "hairpinMode": "hairpin-veth",
   "readOnlyPort": 0,
-  "cgroupDriver": "cgroupfs",
+  "cgroupDriver": "systemd",
   "cgroupRoot": "/",
   "featureGates": {
     "RotateKubeletServerCertificate": true


### PR DESCRIPTION


Fixes #490

*Issue #, if available:*
#490

*Description of changes:*

Kubernetes documentation indicates that for stability reasons
one should run kubernetes with the systemd cgroup driver if the
init system itself is systemd.

https://kubernetes.io/docs/setup/production-environment/container-runtimes/#cgroup-drivers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
