### PR TITLE
AMI release to get Cluster DNS IP from SCIDR for Self Managed Nodegroups

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -100,6 +100,7 @@ set -u
 USE_MAX_PODS="${USE_MAX_PODS:-true}"
 B64_CLUSTER_CA="${B64_CLUSTER_CA:-}"
 APISERVER_ENDPOINT="${APISERVER_ENDPOINT:-}"
+DNS_CLUSTER_IP="${DNS_CLUSTER_IP:-}"
 KUBELET_EXTRA_ARGS="${KUBELET_EXTRA_ARGS:-}"
 ENABLE_DOCKER_BRIDGE="${ENABLE_DOCKER_BRIDGE:-false}"
 API_RETRY_ATTEMPTS="${API_RETRY_ATTEMPTS:-3}"
@@ -218,7 +219,7 @@ PAUSE_CONTAINER="$PAUSE_CONTAINER_IMAGE:$PAUSE_CONTAINER_VERSION"
 CA_CERTIFICATE_DIRECTORY=/etc/kubernetes/pki
 CA_CERTIFICATE_FILE_PATH=$CA_CERTIFICATE_DIRECTORY/ca.crt
 mkdir -p $CA_CERTIFICATE_DIRECTORY
-if [[ -z "${B64_CLUSTER_CA}" ]] && [[ -z "${APISERVER_ENDPOINT}" ]]; then
+if [[ -z "${DNS_CLUSTER_IP}" ]] || [[ -z "${B64_CLUSTER_CA}" ]] || [[ -z "${APISERVER_ENDPOINT}" ]]; then
     DESCRIBE_CLUSTER_RESULT="/tmp/describe_cluster_result.txt"
 
     # Retry the DescribeCluster API for API_RETRY_ATTEMPTS
@@ -236,7 +237,7 @@ if [[ -z "${B64_CLUSTER_CA}" ]] && [[ -z "${APISERVER_ENDPOINT}" ]]; then
             --region=${AWS_DEFAULT_REGION} \
             --name=${CLUSTER_NAME} \
             --output=text \
-            --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint}' > $DESCRIBE_CLUSTER_RESULT || rc=$?
+            --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint, kubernetesNetworkConfig: kubernetesNetworkConfig.serviceIpv4Cidr}' > $DESCRIBE_CLUSTER_RESULT || rc=$?
         if [[ $rc -eq 0 ]]; then
             break
         fi
@@ -249,6 +250,7 @@ if [[ -z "${B64_CLUSTER_CA}" ]] && [[ -z "${APISERVER_ENDPOINT}" ]]; then
     done
     B64_CLUSTER_CA=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $1}')
     APISERVER_ENDPOINT=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $2}')
+    SERVICE_IPV4_CIDR=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $3}')
 fi
 
 echo $B64_CLUSTER_CA | base64 -d > $CA_CERTIFICATE_FILE_PATH
@@ -258,15 +260,20 @@ sed -i s,MASTER_ENDPOINT,$APISERVER_ENDPOINT,g /var/lib/kubelet/kubeconfig
 sed -i s,AWS_REGION,$AWS_DEFAULT_REGION,g /var/lib/kubelet/kubeconfig
 ### kubelet.service configuration
 
-if [ -z ${DNS_CLUSTER_IP+x} ]; then
+if [[ -z "${DNS_CLUSTER_IP}" ]]; then
+  if [[ ! -z "${SERVICE_IPV4_CIDR}" ]] && [[ "${SERVICE_IPV4_CIDR}" != "None" ]] ; then
+    #Sets the DNS Cluster IP address that would be chosen from the serviceIpv4Cidr. (x.y.z.10)
+    DNS_CLUSTER_IP=${SERVICE_IPV4_CIDR%.*}.10
+  else
     MAC=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1 | sed 's/\/$//')
     TEN_RANGE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks | grep -c '^10\..*' || true )
     DNS_CLUSTER_IP=10.100.0.10
     if [[ "$TEN_RANGE" != "0" ]]; then
-        DNS_CLUSTER_IP=172.20.0.10
+      DNS_CLUSTER_IP=172.20.0.10
     fi
+  fi
 else
-    DNS_CLUSTER_IP="${DNS_CLUSTER_IP}"
+  DNS_CLUSTER_IP="${DNS_CLUSTER_IP}"
 fi
 
 KUBELET_CONFIG=/etc/kubernetes/kubelet/kubelet-config.json


### PR DESCRIPTION
Issue:
Getting Cluster DNS IP from SCIDR for Self Managed Nodegroups, when DNS IP is not provided by user. This is being done as a part of SCIDR Feature Launch

Description of changes:
Added a code to find SCIDR from Describe Cluster and assign DNS IP using that. This is done as a part of new SCIDR feature, where we allow user to give SCIDR value as well. For Mnaged Nodegroups this is handles in ISO. For unmanaged nodegroups we are handling it by creating a new AMI version. If the SCIDR is given then the Cluster DNS IP is set using that. To make it backward compatible, if SCIDR is null DNS IP will be set 10... or 172... depending on the vpc-ipv4-cidr-blocks as it was happening earlier.

Testing:
Since the feature is not launched yet. I added the service model in the nodegroup created during testing by : aws configure add-model
Created a file in the nodegroup that holds the value of SCIDR fetched from Describe Cluster API and DNS Cluster IP.
Created a cluster with SCIDR, then created a Self managed nodegroup with new Service Model loaded in it and one with current API.
Created a cluster and Self managed nodegroup in external-client-account as well to test backward compatibility

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.