### PR TITLE
Fix formula comment

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -11,11 +11,11 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-# This file was generated at 2020-07-27T21:19:16-07:00
+# This file was generated at 2020-09-03T14:12:27-07:00
 #
 # Mapping is calculated from AWS EC2 API using the following formula:
 # * First IP on each ENI is not used for pods
-# * 2 additional host-networking pods (AWS ENI and kube-proxy) are accounted for
+# * +2 for for the pods that use host-networking (AWS CNI and kube-proxy)
 #
 #   # of ENI * (# of IPv4 per ENI - 1) + 2
 #

--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-# This file was generated at 2020-09-03T14:12:27-07:00
+# This file was generated at 2020-09-15T18:15:46-07:00
 #
 # Mapping is calculated from AWS EC2 API using the following formula:
 # * First IP on each ENI is not used for pods
@@ -146,7 +146,7 @@ i3en.6xlarge 234
 i3en.large 29
 i3en.metal 737
 i3en.xlarge 58
-inf1.24xlarge 437
+inf1.24xlarge 321
 inf1.2xlarge 38
 inf1.6xlarge 234
 inf1.xlarge 38
@@ -343,6 +343,13 @@ t3a.micro 4
 t3a.nano 4
 t3a.small 8
 t3a.xlarge 58
+t4g.2xlarge 58
+t4g.large 35
+t4g.medium 17
+t4g.micro 4
+t4g.nano 4
+t4g.small 11
+t4g.xlarge 58
 u-12tb1.metal 147
 u-18tb1.metal 737
 u-24tb1.metal 737


### PR DESCRIPTION
*Description of changes:*
Our documentation is currently wrong, saying "ENI" instead of "CNI". 

Old comment:
```
# * 2 additional host-networking pods (AWS ENI and kube-proxy) are accounted for
```
New comment
```
# * +2 for for the pods that use host-networking (AWS CNI and kube-proxy)
```

Follow up to https://github.com/aws/amazon-vpc-cni-k8s/pull/1191

Also added support for the [newly released `t4g`](https://aws.amazon.com/blogs/aws/new-t4g-instances-burstable-performance-powered-by-aws-graviton2/) instance type.

Follow up to https://github.com/aws/amazon-vpc-cni-k8s/pull/1219

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
