### PR TITLE
add SIGKILL to RestartForceExitStatus

### DIFF
--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
 Restart=on-failure
-RestartForceExitStatus=SIGPIPE
+RestartForceExitStatus=SIGPIPE SIGKILL
 RestartSec=5
 KillMode=process
 


### PR DESCRIPTION
*Issue #, if available:*
#553  kubelet.service can't restart if I use Kill -9
*Description of changes:*
update files/kubelet.service,  add SIGKILL to RestartForceExitStatus

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
