### PR TITLE
Handle a missing instance_type in bootstrap

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -291,10 +291,10 @@ INSTANCE_TYPE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169
 #calculate the max number of pods per instance type
 MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
 set +o pipefail
-MAX_PODS=$(cat $MAX_PODS_FILE | awk "/^$INSTANCE_TYPE/"' { print $2 }')
+MAX_PODS=$(cat $MAX_PODS_FILE | awk "/^${INSTANCE_TYPE:-unset}/"' { print $2 }')
 set -o pipefail
-if [ -z "$MAX_PODS" ]; then
-    echo 'No entry for $INSTANCE_TYPE in $MAX_PODS_FILE'
+if [ -z "$MAX_PODS" ] || [ -z "$INSTANCE_TYPE" ]; then
+    echo "No entry for type '$INSTANCE_TYPE' in $MAX_PODS_FILE"
     exit 1
 fi
 


### PR DESCRIPTION
We had a weird case happen where nodes weren't able to join a cluster.

After digging in logs and code, it appears that the EC2 Instance Metadata service may have been at fault.

Specifically, the log entry on failure was:
```
/etc/eks/bootstrap.sh: line 169: Copyright: unbound variable
Exited with error on line 302
Nov 05 23:08:53 cloud-init[4143]: util.py[WARNING]: Failed running /var/lib/cloud/instance/scripts/part-001 [1]
Nov 05 23:08:53 cloud-init[4143]: cc_scripts_user.py[WARNING]: Failed to run module scripts-user (scripts in /var/lib/cloud/instance/scripts)
Nov 05 23:08:53 cloud-init[4143]: util.py[WARNING]: Running module scripts-user (<module 'cloudinit.config.cc_scripts_user' from '/usr/lib/python2.7/site-packages/cloudinit/config/cc_scripts_user.pyc'>) failed
```

That's 
```
get_memory_mebibytes_to_reserve() {
  local max_num_pods=$1
  memory_to_reserve=$((11 * $max_num_pods + 255))  <==== this line!
  echo $memory_to_reserve
}
```

The only way that "Copyright" could be found there is from "eni-max-pods.txt", where it's conveniently the second word of the first line.

My speculation is that the metadata service returned an empty instance_type, and thus "$INSTANCE_TYPE" was "" in this line:
`MAX_PODS=$(cat $MAX_PODS_FILE | awk "/^$INSTANCE_TYPE/"' { print $2 }')`

That would return a *lot* of data, not just a single value, and the first thing in that data is "Copyright".

This PR adds a default string to that `awk` search, and also fixes a log output that was single-quoted and would prevent its variable expansion from happening.

This is a pretty rare case, but we managed to trip over it and I figured I'd try to help the next person a bit.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
