### PR TITLE
Missing sha256 check sum for 'else' path

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -192,12 +192,12 @@ else
         echo "AWS cli present - using it to copy binaries from s3."
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz .
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz.sha256 .
-        sudo sha256sum -c "${CNI_PLUGIN_FILENAME}.tgz.sha256"
     else
         echo "AWS cli missing - using wget to fetch cni binaries from s3. Note: This won't work for private bucket."
         sudo wget "$S3_URL_BASE/${CNI_PLUGIN_FILENAME}.tgz"
         sudo wget "$S3_URL_BASE/${CNI_PLUGIN_FILENAME}.tgz.sha256"
     fi
+    sudo sha256sum -c "${CNI_PLUGIN_FILENAME}.tgz.sha256"
 fi
 sudo tar -xvf "${CNI_PLUGIN_FILENAME}.tgz" -C /opt/cni/bin
 rm "${CNI_PLUGIN_FILENAME}.tgz"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When using 'wget' to fetch cni binaries from s3, checksum file is downloaded but not used

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.