### PR TITLE
Downgrades containerd to containerd-1.3.2-1.amzn2 to fix issue #563

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -121,6 +121,12 @@ if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
     sudo chown root:root /etc/docker/daemon.json
 
+    # https://github.com/awslabs/amazon-eks-ami/issues/563
+    # Due to an issue with the latest containerd, customers are seeing
+    # pods getting stuck in terminating, so we need to downgrade containerd
+    # until the issue is fixed upstream or we have another workaround.
+    sudo yum downgrade -y containerd-1.3.2-1.amzn2
+
     # Enable docker daemon to start on boot.
     sudo systemctl daemon-reload
     sudo systemctl enable docker


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-eks-ami/issues/563

*Description of changes:*

As described in [this issue](https://github.com/awslabs/amazon-eks-ami/issues/563), customers are experiencing issues where pods are getting stuck in `Terminating` when they have readiness/liveness probes. This seems to be related to `containerd` version `1.4.0`. Upgrading and downgrading containerd fixes the issue in our repro, but we're downgrading because the newer version is not available in AL2 repos yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
