### PR TITLE
Updated changedlog with correct s3 bucket name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@
 * amazon-eks-node-1.15-v20201117
 
 Binaries used to build these AMIs are published :
-* s3://amazon-eks/1.18.9/2020-11-07/
-* s3://amazon-eks/1.17.12/2020-11-07/
-* s3://amazon-eks/1.16.15/2020-11-07/
-* s3://amazon-eks/1.15.12/2020-11-07/
+* s3://amazon-eks/1.18.9/2020-11-02/
+* s3://amazon-eks/1.17.12/2020-11-02/
+* s3://amazon-eks/1.16.15/2020-11-02/
+* s3://amazon-eks/1.15.12/2020-11-02/
 
 Notable changes :
 * Bug fix [#526](https://github.com/awslabs/amazon-eks-ami/pull/526)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/567
*Description of changes:*
For v20201117 AMI release, update s3 binary bucket name from 11-07 to 11-02

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
