### PR TITLE
Adding containerd_version as a packer variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date docker_version cni_plugin_version source_ami_id source_ami_owners arch instance_type security_group_id additional_yum_repos pull_cni_from_github
+PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date docker_version containerd_verion cni_plugin_version source_ami_id source_ami_owners arch instance_type security_group_id additional_yum_repos pull_cni_from_github
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})
@@ -29,7 +29,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.15 1.16 1.17
+all: 1.15 1.16 1.17 1.18
 
 .PHONY: validate
 validate:

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -13,7 +13,7 @@
     "kubernetes_version": null,
     "kubernetes_build_date": null,
     "docker_version": "19.03.6ce-4.amzn2",
-    "containerd_version": "1.4.1-1.amzn2",
+    "containerd_version": "1.4.1-2.amzn2",
     "cni_plugin_version": "v0.8.6",
     "pull_cni_from_github": "true",
     "source_ami_id": "",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -5,26 +5,23 @@
     "creator": "{{env `USER`}}",
     "encrypted": "false",
     "kms_key_id": "",
-
     "aws_access_key_id": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_access_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
-
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
     "kubernetes_version": null,
     "kubernetes_build_date": null,
     "docker_version": "19.03.6ce-4.amzn2",
+    "containerd_version": "1.3.2-1.amzn2",
     "cni_plugin_version": "v0.8.6",
     "pull_cni_from_github": "true",
-
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
     "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
     "arch": null,
     "instance_type": null,
     "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image",
-
     "ssh_interface": "",
     "ssh_username": "ec2-user",
     "temporary_security_group_source_cidrs": "",
@@ -36,7 +33,6 @@
     "ami_users": "",
     "additional_yum_repos": ""
   },
-
   "builders": [
     {
       "type": "amazon-ebs",
@@ -52,7 +48,9 @@
           "state": "available",
           "virtualization-type": "hvm"
         },
-        "owners": [ "{{user `source_ami_owners`}}" ],
+        "owners": [
+          "{{user `source_ami_owners`}}"
+        ],
         "most_recent": true
       },
       "instance_type": "{{user `instance_type`}}",
@@ -81,30 +79,30 @@
       "encrypt_boot": "{{user `encrypted`}}",
       "kms_key_id": "{{user `kms_key_id`}}",
       "run_tags": {
-          "creator": "{{user `creator`}}"
+        "creator": "{{user `creator`}}"
       },
       "subnet_id": "{{user `subnet_id`}}",
       "tags": {
-          "Name": "{{user `ami_name`}}",
-          "created": "{{timestamp}}",
-          "docker_version": "{{ user `docker_version`}}",
-          "source_ami_id": "{{ user `source_ami_id`}}",
-          "kubernetes": "{{ user `kubernetes_version`}}/{{ user `kubernetes_build_date` }}/bin/linux/{{ user `arch` }}",
-          "cni_plugin_version": "{{ user `cni_plugin_version`}}"
+        "Name": "{{user `ami_name`}}",
+        "created": "{{timestamp}}",
+        "docker_version": "{{ user `docker_version`}}",
+        "containerd_version": "{{ user `containerd_version`}}",
+        "source_ami_id": "{{ user `source_ami_id`}}",
+        "kubernetes": "{{ user `kubernetes_version`}}/{{ user `kubernetes_build_date` }}/bin/linux/{{ user `arch` }}",
+        "cni_plugin_version": "{{ user `cni_plugin_version`}}"
       },
       "ami_name": "{{user `ami_name`}}",
-      "ami_description": "{{ user `ami_description` }}, (k8s: {{ user `kubernetes_version`}}, docker:{{ user `docker_version`}})"
+      "ami_description": "{{ user `ami_description` }}, (k8s: {{ user `kubernetes_version` }}, docker: {{ user `docker_version` }}, containerd: {{ user `containerd_version` }})"
     }
   ],
-
   "provisioners": [
     {
-        "type": "shell",
-        "remote_folder": "{{ user `remote_folder`}}",
-        "script": "{{template_dir}}/scripts/install_additional_repos.sh",
-        "environment_vars": [
-          "ADDITIONAL_YUM_REPOS={{user `additional_yum_repos`}}"
-        ]
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "script": "{{template_dir}}/scripts/install_additional_repos.sh",
+      "environment_vars": [
+        "ADDITIONAL_YUM_REPOS={{user `additional_yum_repos`}}"
+      ]
     },
     {
       "type": "shell",
@@ -116,7 +114,9 @@
       "type": "shell",
       "pause_before": "90s",
       "remote_folder": "{{ user `remote_folder`}}",
-      "inline": ["mkdir -p /tmp/worker/"]
+      "inline": [
+        "mkdir -p /tmp/worker/"
+      ]
     },
     {
       "type": "file",
@@ -133,6 +133,7 @@
         "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",
         "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}",
         "DOCKER_VERSION={{user `docker_version`}}",
+        "CONTAINERD_VERSION={{user `containerd_version`}}",
         "CNI_PLUGIN_VERSION={{user `cni_plugin_version`}}",
         "PULL_CNI_FROM_GITHUB={{user `pull_cni_from_github`}}",
         "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -13,7 +13,7 @@
     "kubernetes_version": null,
     "kubernetes_build_date": null,
     "docker_version": "19.03.6ce-4.amzn2",
-    "containerd_version": "1.3.2-1.amzn2",
+    "containerd_version": "1.4.1-1.amzn2",
     "cni_plugin_version": "v0.8.6",
     "pull_cni_from_github": "true",
     "source_ami_id": "",

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -24,6 +24,7 @@ validate_env_set() {
 validate_env_set BINARY_BUCKET_NAME
 validate_env_set BINARY_BUCKET_REGION
 validate_env_set DOCKER_VERSION
+validate_env_set CONTAINERD_VERSION
 validate_env_set CNI_PLUGIN_VERSION
 validate_env_set KUBERNETES_VERSION
 validate_env_set KUBERNETES_BUILD_DATE
@@ -125,7 +126,7 @@ if [[ "$INSTALL_DOCKER" == "true" ]]; then
     # Due to an issue with the latest containerd, customers are seeing
     # pods getting stuck in terminating, so we need to downgrade containerd
     # until the issue is fixed upstream or we have another workaround.
-    sudo yum downgrade -y containerd-1.3.2-1.amzn2
+    sudo yum downgrade -y containerd-${CONTAINERD_VERSION}
 
     # Enable docker daemon to start on boot.
     sudo systemctl daemon-reload

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -122,10 +122,6 @@ if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
     sudo chown root:root /etc/docker/daemon.json
 
-    # https://github.com/awslabs/amazon-eks-ami/issues/563
-    # Due to an issue with the latest containerd, customers are seeing
-    # pods getting stuck in terminating, so we need to downgrade containerd
-    # until the issue is fixed upstream or we have another workaround.
     sudo yum downgrade -y containerd-${CONTAINERD_VERSION}
 
     # Enable docker daemon to start on boot.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds containerd version to the AMI description.
- Adds containerd version as a packer variable. 
- Fixes Makefile to point to correct targets.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Validation Done:
- Created an AMI successfully via `make 1.15`
- Validated that the correct containerd version was installed:
```
[ec2-user@ip-192-168-34-16 ~]$ rpm -q containerd
containerd-1.4.1-2.amzn2.x86_64
```
- Created a customAMI Managed Nodegroup with this AMI. Validated that the AMI joined the cluster and that I was able to run containers on the AMI.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
