### PR TITLE
Update systemd to always restart kubelet to support dynamic kubelet configuration

### DIFF
--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
 Restart=on-failure
-RestartForceExitStatus=SIGPIPE SIGKILL
+RestartForceExitStatus=0 SIGPIPE SIGKILL
 RestartSec=5
 KillMode=process
 

--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -12,8 +12,7 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --container-runtime docker \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
-Restart=on-failure
-RestartForceExitStatus=0 SIGPIPE SIGKILL
+Restart=always
 RestartSec=5
 KillMode=process
 


### PR DESCRIPTION
*Description of changes:*
We were trying to enable [dynamic kubelet configuration](https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/) on our cluster but the new nodes failed to become ready because `systemd` didn't restart `kubelet.service` after it cleanly terminated to reload the new configuration.

`kubelet` reloads dynamic configuration by exiting the process with code 0 and assume that a babysitter process will restart the service. We should configure `systemd` to restart `kubelet` on exit code 0 as well (or use `Restart=always`).

See:
- https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/#understanding-how-the-kubelet-checkpoints-config
- https://github.com/kubernetes/kubernetes/blob/4c00c3c459261e8ff3381c1070ddf798f0131956/pkg/kubelet/kubeletconfig/configsync.go#L191-L207

*Workaround*
Since we are already using a userdata script to add `--dynamic-config-dir` as an extra argument, we add the below script to append the exit code to `kubelet.service` configuration.
```bash
cat << EOF > /etc/systemd/system/kubelet.service.d/90-restart-on-exit-code-0.conf
[Service]
RestartForceExitStatus=0
EOF
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
