### PR TITLE
Add missing instance types

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -173,6 +173,16 @@ Parameters:
       - d2.4xlarge
       - d2.8xlarge
       - d2.xlarge
+      - d3.2xlarge
+      - d3.4xlarge
+      - d3.8xlarge
+      - d3.xlarge
+      - d3en.12xlarge
+      - d3en.2xlarge
+      - d3en.4xlarge
+      - d3en.6xlarge
+      - d3en.8xlarge
+      - d3en.xlarge
       - f1.16xlarge
       - f1.2xlarge
       - f1.4xlarge
@@ -182,6 +192,9 @@ Parameters:
       - g3.4xlarge
       - g3.8xlarge
       - g3s.xlarge
+      - g4ad.16xlarge
+      - g4ad.4xlarge
+      - g4ad.8xlarge
       - g4dn.12xlarge
       - g4dn.16xlarge
       - g4dn.2xlarge
@@ -284,6 +297,13 @@ Parameters:
       - m5n.8xlarge
       - m5n.large
       - m5n.xlarge
+      - m5zn.12xlarge
+      - m5zn.2xlarge
+      - m5zn.3xlarge
+      - m5zn.6xlarge
+      - m5zn.large
+      - m5zn.metal
+      - m5zn.xlarge
       - m6g.12xlarge
       - m6g.16xlarge
       - m6g.2xlarge
@@ -302,6 +322,7 @@ Parameters:
       - m6gd.medium
       - m6gd.metal
       - m6gd.xlarge
+      - mac1.metal
       - p2.16xlarge
       - p2.8xlarge
       - p2.xlarge
@@ -346,6 +367,15 @@ Parameters:
       - r5ad.8xlarge
       - r5ad.large
       - r5ad.xlarge
+      - r5b.12xlarge
+      - r5b.16xlarge
+      - r5b.24xlarge
+      - r5b.2xlarge
+      - r5b.4xlarge
+      - r5b.8xlarge
+      - r5b.large
+      - r5b.metal
+      - r5b.xlarge
       - r5d.12xlarge
       - r5d.16xlarge
       - r5d.24xlarge

--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-# This file was generated at 2020-09-30T15:27:32-07:00
+# This file was generated at 2020-12-12T18:33:04-03:00
 #
 # Mapping is calculated from AWS EC2 API using the following formula:
 # * First IP on each ENI is not used for pods
@@ -106,6 +106,16 @@ d2.2xlarge 58
 d2.4xlarge 234
 d2.8xlarge 234
 d2.xlarge 58
+d3.2xlarge 18
+d3.4xlarge 38
+d3.8xlarge 59
+d3.xlarge 10
+d3en.12xlarge 89
+d3en.2xlarge 18
+d3en.4xlarge 38
+d3en.6xlarge 58
+d3en.8xlarge 78
+d3en.xlarge 10
 f1.16xlarge 394
 f1.2xlarge 58
 f1.4xlarge 234
@@ -115,6 +125,9 @@ g3.16xlarge 737
 g3.4xlarge 234
 g3.8xlarge 234
 g3s.xlarge 58
+g4ad.16xlarge 234
+g4ad.4xlarge 29
+g4ad.8xlarge 58
 g4dn.12xlarge 234
 g4dn.16xlarge 58
 g4dn.2xlarge 29
@@ -217,6 +230,13 @@ m5n.4xlarge 234
 m5n.8xlarge 234
 m5n.large 29
 m5n.xlarge 58
+m5zn.12xlarge 737
+m5zn.2xlarge 58
+m5zn.3xlarge 234
+m5zn.6xlarge 234
+m5zn.large 29
+m5zn.metal 737
+m5zn.xlarge 58
 m6g.12xlarge 234
 m6g.16xlarge 737
 m6g.2xlarge 58
@@ -235,6 +255,7 @@ m6gd.large 29
 m6gd.medium 8
 m6gd.metal 737
 m6gd.xlarge 58
+mac1.metal 234
 p2.16xlarge 234
 p2.8xlarge 234
 p2.xlarge 58
@@ -279,6 +300,15 @@ r5ad.4xlarge 234
 r5ad.8xlarge 234
 r5ad.large 29
 r5ad.xlarge 58
+r5b.12xlarge 234
+r5b.16xlarge 737
+r5b.24xlarge 737
+r5b.2xlarge 58
+r5b.4xlarge 234
+r5b.8xlarge 234
+r5b.large 29
+r5b.metal 737
+r5b.xlarge 58
 r5d.12xlarge 234
 r5d.16xlarge 737
 r5d.24xlarge 737


### PR DESCRIPTION
*Issue #, if available:* #579 

*Description of changes:*

Adds missing instances that were released recently.

- I re-generated the `eni-max-pods.txt` file using `https://github.com/aws/amazon-vpc-cni-k8s`'s script.
- Update `amazon-eks-nodegroup.yaml`, copying the new instances so that they appear in the same order as in `eni-max-pods.txt`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
