### PR TITLE
add support for sonobuoy e2e registry overrides

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -32,7 +32,8 @@
     "remote_folder": "",
     "launch_block_device_mappings_volume_size": "4",
     "ami_users": "",
-    "additional_yum_repos": ""
+    "additional_yum_repos": "",
+    "sonobuoy_e2e_registry": ""
   },
   "builders": [
     {
@@ -140,7 +141,8 @@
         "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
         "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
-        "CLEANUP_IMAGE={{user `cleanup_image`}}"
+        "CLEANUP_IMAGE={{user `cleanup_image`}}",
+        "SONOBUOY_E2E_REGISTRY={{user `sonobuoy_e2e_registry`}}"
       ]
     },
     {

--- a/files/sonobuoy-e2e-registry-config
+++ b/files/sonobuoy-e2e-registry-config
@@ -1,0 +1,5 @@
+dockerLibraryRegistry: SONOBUOY_E2E_REGISTRY/library
+e2eRegistry: SONOBUOY_E2E_REGISTRY/kubernetes-e2e-test-images
+gcRegistry: SONOBUOY_E2E_REGISTRY
+googleContainerRegistry: SONOBUOY_E2E_REGISTRY/google-containers
+sampleRegistry: SONOBUOY_E2E_REGISTRY/google-samples

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -129,6 +129,11 @@ if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo systemctl enable docker
 fi
 
+if [[ -n "$SONOBUOY_E2E_REGISTRY" ]]; then
+    sudo mv $TEMPLATE_DIR/sonobuoy-e2e-registry-config /etc/eks/sonobuoy-e2e-registry-config
+    sed -i s,SONOBUOY_E2E_REGISTRY,$SONOBUOY_E2E_REGISTRY,g /etc/eks/sonobuoy-e2e-registry-config
+fi
+
 ################################################################################
 ### Logrotate ##################################################################
 ################################################################################


### PR DESCRIPTION
*Issue #, if available:*
na

*Description of changes:*
Adds support to override the sonobuoy e2e test registry for conformance testing in airgapped regions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
