### PR TITLE
Revert "Change cgroup driver to systemd (#521)"

### DIFF
--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -1,8 +1,5 @@
 {
   "bridge": "none",
-  "exec-opts": [
-    "native.cgroupdriver=systemd"
-  ],
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "10m",

--- a/files/kubelet-config.json
+++ b/files/kubelet-config.json
@@ -24,7 +24,7 @@
   "clusterDomain": "cluster.local",
   "hairpinMode": "hairpin-veth",
   "readOnlyPort": 0,
-  "cgroupDriver": "systemd",
+  "cgroupDriver": "cgroupfs",
   "cgroupRoot": "/",
   "featureGates": {
     "RotateKubeletServerCertificate": true


### PR DESCRIPTION
This reverts commit f9d2c39535a8b53a951c1a896590aef5254dc896.


*Description of changes:*

EksCtl uses a nodebootsrap process where it configures the kubelet config, but not the docker config

Before we revert this commit, we need to finalize on how we can safely update eksctl to also set these values.

https://github.com/weaveworks/eksctl/blob/1555c35b1b315ff31c062a789c5f756a6122d057/docs/current-001-node_bootstrap.md 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
