### PR TITLE
Updating limits for memlock ulimit

### DIFF
--- a/files/docker-daemon.json
+++ b/files/docker-daemon.json
@@ -6,5 +6,12 @@
     "max-file": "10"
   },
   "live-restore": true,
-  "max-concurrent-downloads": 10
+  "max-concurrent-downloads": 10,
+  "default-ulimits": {
+    "memlock": {
+      "Hard": -1,
+      "Name": "memlock",
+      "Soft": -1
+    }
+  }
 }


### PR DESCRIPTION
*Description of changes:*

Updating the ulimit for memlock.

This should be backward compatible and only affects those customers that use memlock. 

More about K8s memory management - https://github.com/kubernetes/kubernetes/issues/53533#issuecomment-427233471

Tested by building a nodegroup with this AMI and confirming that it joins with the cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
