### PR TITLE
Sets the 5.4 linux kernel as default for kubernetes version 1.19 and …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date docker_version containerd_version cni_plugin_version source_ami_id source_ami_owners arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry
+PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version cni_plugin_version source_ami_id source_ami_owners arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -12,6 +12,7 @@
     "binary_bucket_region": "us-west-2",
     "kubernetes_version": null,
     "kubernetes_build_date": null,
+    "kernel_version": "",
     "docker_version": "19.03.6ce-4.amzn2",
     "containerd_version": "1.4.1-2.amzn2",
     "cni_plugin_version": "v0.8.6",
@@ -110,7 +111,11 @@
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
       "expect_disconnect": true,
-      "script": "{{template_dir}}/scripts/upgrade_kernel.sh"
+      "script": "{{template_dir}}/scripts/upgrade_kernel.sh",
+      "environment_vars": [
+        "KUBERNETES_VERSION={{user `kubernetes_version`}}",
+        "KERNEL_VERSION={{user `kernel_version`}}"
+      ]
     },
     {
       "type": "shell",

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -4,5 +4,32 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
-sudo yum update -y kernel
+if [[ -z "$KERNEL_VERSION" ]]; then
+    # Save for resetting
+    OLDIFS=$IFS
+    # Makes 5.4 kernel the default on 1.19 and higher
+    IFS='.'
+    # Convert kubernetes version in an array to compare versions
+    read -ra ADDR <<< "$KUBERNETES_VERSION"
+    # Reset
+    IFS=$OLDIFS
+
+    if (( ADDR[0] == 1 && ADDR[1] < 19 )); then
+        KERNEL_VERSION=4.14
+    else
+        KERNEL_VERSION=5.4
+    fi
+
+    echo "kernel_version is unset. Setting to $KERNEL_VERSION based on kubernetes_version $KUBERNETES_VERSION"
+fi
+
+if [[ $KERNEL_VERSION == "4.14" ]]; then
+    sudo yum update -y kernel
+elif [[ $KERNEL_VERSION == "5.4" ]]; then
+    sudo amazon-linux-extras install -y kernel-5.4
+else
+    echo "$KERNEL_VERSION is not a valid kernel version"
+    exit 1
+fi
+
 sudo reboot


### PR DESCRIPTION
…higher

Sets the 5.4 linux kernel as default for kubernetes version 1.19 and higher

*Issue #, if available:*

*Description of changes:*
As of Kubernetes version 1.19, the amazon-eks-ami should default to the 5.4 linux kernel using the AL extras repository. Versions prior to 1.19 will remain on the 4.14 kernel to keep the experience consistent for customers. However, customers can build custom AMIs and set the `kernel_version` argument to `5.4` in order to using the 5.4 kernel.

I tested this with the following:

1. Built a 1.18 AMI and confirmed that it was still using the 4.14 kernel
2. Built a 1.19 AMI and confirmed that it was using the 5.4 kernel
3. Built a 1.18 AMI with `kernel_version` set to 5.4 and verified it upgraded the kernel
4. Built a 1.19 AMI with `kernel_version` set to 4.14 and verified that it only installed latest patches
4. Manually tested output in `scripts/upgrade_kernel.sh` with different k8s versions, including 2.x k8s versions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
