### PR TITLE
build ARM AMIs with m6g.large instance type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ aws_region ?= $(AWS_DEFAULT_REGION)
 binary_bucket_region ?= $(AWS_DEFAULT_REGION)
 arch ?= x86_64
 ifeq ($(arch), arm64)
-instance_type ?= a1.large
+instance_type ?= m6g.large
 ami_name ?= amazon-eks-arm64-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 else
 instance_type ?= m4.large


### PR DESCRIPTION
*Description of changes:*
`m6g.large` instance types are available in all AWS partitions while `a1.large` instance type is not. Use `m6g.large` instance type as the default when building ARM AMIs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
