### PR TITLE
files/bootstrap.sh: ensure /etc/docker exists before writing to it

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -398,11 +398,15 @@ fi
 
 # Replace with custom docker config contents.
 if [[ -n "$DOCKER_CONFIG_JSON" ]]; then
+    mkdir -p /etc/docker
+
     echo "$DOCKER_CONFIG_JSON" > /etc/docker/daemon.json
     systemctl restart docker
 fi
 
 if [[ "$ENABLE_DOCKER_BRIDGE" = "true" ]]; then
+    mkdir -p /etc/docker
+
     # Enabling the docker bridge network. We have to disable live-restore as it
     # prevents docker from recreating the default bridge network on restart
     echo "$(jq '.bridge="docker0" | ."live-restore"=false' /etc/docker/daemon.json)" > /etc/docker/daemon.json


### PR DESCRIPTION
*Description of changes:*

On distros like Flatcar Container Linux, /etc/docker may not exist, so
additional step is required apart from running /etc/eks/bootstrap.sh
script to get things running.

This will be fixed in next release of Flatcar, but I think it's still
valuable to include for possibly other distros.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
