### PR TITLE
update gpu clocks on gpu instance types only

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -417,25 +417,30 @@ systemctl start kubelet
 if  command -v nvidia-smi &>/dev/null ; then
    echo "nvidia-smi found"
 
-   sudo nvidia-smi -pm 1 # set persistence mode
-   sudo nvidia-smi --auto-boost-default=0
+   nvidia-smi -q > /tmp/nvidia-smi-check
+   if [[ "$?" == "0" ]]; then
+      sudo nvidia-smi -pm 1 # set persistence mode
+      sudo nvidia-smi --auto-boost-default=0
 
-   GPUNAME=$(nvidia-smi -L | head -n1)
-   echo $GPUNAME
+      GPUNAME=$(nvidia-smi -L | head -n1)
+      echo $GPUNAME
 
-   # set application clock to maximum
-   if [[ $GPUNAME == *"A100"* ]]; then
-      nvidia-smi -ac 1215,1410
-   elif [[ $GPUNAME == *"V100"* ]]; then
-      nvidia-smi -ac 877,1530
-   elif [[ $GPUNAME == *"K80"* ]]; then
-      nvidia-smi -ac 2505,875
-   elif [[ $GPUNAME == *"T4"* ]]; then
-      nvidia-smi -ac 5001,1590
-   elif [[ $GPUNAME == *"M60"* ]]; then
-      nvidia-smi -ac 2505,1177
+      # set application clock to maximum
+      if [[ $GPUNAME == *"A100"* ]]; then
+         nvidia-smi -ac 1215,1410
+      elif [[ $GPUNAME == *"V100"* ]]; then
+         nvidia-smi -ac 877,1530
+      elif [[ $GPUNAME == *"K80"* ]]; then
+         nvidia-smi -ac 2505,875
+      elif [[ $GPUNAME == *"T4"* ]]; then
+         nvidia-smi -ac 5001,1590
+      elif [[ $GPUNAME == *"M60"* ]]; then
+         nvidia-smi -ac 2505,1177
+      else
+         echo "unsupported gpu"
+      fi
    else
-      echo "unsupported gpu"
+      cat /tmp/nvidia-smi-check
    fi
 else
     echo "nvidia-smi not found"


### PR DESCRIPTION
*Fixes issue* https://github.com/awslabs/amazon-eks-ami/issues/606
*Description of changes:*
- Updated GPU boost clock logic to check that `nvidia-smi -q` returns a valid response (confirming that nvidia drivers are correctly configured on the AMI/instance type) before attempting to change clock speeds.

*Tests*
Created a GPU AMI that included these changes. Created the nodegroups via customAMI managed nodes with the following instance types:
- non-GPU instance type
- GPU instance type

Confirmed that non-GPU instance type nodes ran successfully. Confirmed that the GPU instance type had the correct GPU clock configuration by running `nvidia-smi -q -d CLOCK` and comparing to the values we set in the script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
