### PR TITLE
Increase fs.inotify.max_user_instances to 8192 from the default of 128

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -264,6 +264,7 @@ EOF
 ################################################################################
 
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
+echo fs.inotify.max_user_instances=8192 | sudo tee -a /etc/sysctl.conf
 echo vm.max_map_count=524288 | sudo tee -a /etc/sysctl.conf
 
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We have customers running out of watchers. Increase this limit to complement the earlier increase in fs.inotify.max_user_watches limit.

*Testing:*
Built new AMIs with this change and then ran the following command in an instance launched with a newly built AMI:
```
$ sysctl fs.inotify
fs.inotify.max_queued_events = 16384
fs.inotify.max_user_instances = 8192
fs.inotify.max_user_watches = 524288
```

Also ran the same commands inside a container:
```
$ sudo docker run -it --rm ubuntu bash -c "sysctl fs.inotify"
fs.inotify.max_queued_events = 16384
fs.inotify.max_user_instances = 8192
fs.inotify.max_user_watches = 524288
$ sudo docker run -it --rm ubuntu bash -c "cat /proc/sys/fs/inotify/max_user_instances"
8192
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
