### PR TITLE
Fix Makefile indentation for 1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.15 1.16 1.17 1.18
+all: 1.15 1.16 1.17 1.18 1.19
 
 .PHONY: validate
 validate:

--- a/Makefile
+++ b/Makefile
@@ -60,5 +60,5 @@ k8s: validate
 	$(MAKE) k8s kubernetes_version=1.18.9 kubernetes_build_date=2020-11-02 pull_cni_from_github=true
 
 .PHONY: 1.19
-	1.19:
-	    $(MAKE) k8s kubernetes_version=1.19.6 kubernetes_build_date=2021-01-05 pull_cni_from_github=true
+1.19:
+	$(MAKE) k8s kubernetes_version=1.19.6 kubernetes_build_date=2021-01-05 pull_cni_from_github=true


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/awslabs/amazon-eks-ami/issues/615

*Description of changes:*

Fix Makefile tab indentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
