### PR TITLE
CloudFormation template to deploy CodeBuild project

### DIFF
--- a/amazon-eks-codebuild.yaml
+++ b/amazon-eks-codebuild.yaml
@@ -132,8 +132,6 @@ Resources:
         EnvironmentVariables:
           - Name: AWS_DEFAULT_REGION
             Value: "us-west-2" # amazon-eks S3 bucket is in us-west-2
-          - Name: PACKER_VERSION
-            Value: "1.7.0"
           - Name: PACKER_LOG
             Value: !If
               - IsPackerLog
@@ -159,8 +157,9 @@ Resources:
             install:
               commands:
                 - echo "Installing Packer..."
-                - curl -qL -o packer.zip https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && unzip packer.zip
-                - export PATH=${PATH}:${CODEBUILD_SRC_DIR}
+                - curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
+                - apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+                - apt-get update && apt-get install -y packer build-essential
             build:
               commands:
                 - echo "Building Packer template, eks-worker-al2.json"
@@ -172,7 +171,7 @@ Resources:
                 - |
                   if [ "${AWS_REGION}" != "us-west-2" ] ; then
                     echo "Copying AMI from us-west-2 to ${AWS_REGION}"
-                    IMAGE_ID=`cat manifest.json | jq '.builds[0].artifact_id' | cut -d ":" -f2 | tr -d '"'`
+                    IMAGE_ID=`cat manifest.json | jq '.builds[0].artifact_id' | cut -d ':' -f2 | tr -d '"'`
                     IMAGE_NAME=`aws ec2 describe-images --region us-west-2 --image-ids ${IMAGE_ID} | jq '.Images[0].Name' | tr -d '"'`
                     aws ec2 copy-image --source-region us-west-2 --source-image-id ${IMAGE_ID} --name "${IMAGE_NAME}" --region ${AWS_REGION}
                     aws ec2 deregister-image --image-id ${IMAGE_ID} --region us-west-2

--- a/amazon-eks-codebuild.yaml
+++ b/amazon-eks-codebuild.yaml
@@ -1,0 +1,189 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: CodeBuild project to build a custom Amazon EKS AMI
+
+Parameters:
+  SourceVersion:
+    Type: String
+    Description: GitHub tag/branch to build
+    Default: "v20210208"
+  KubernetesVersion:
+    Type: String
+    Description: Kubernetes Cluster Version
+    Default: "1.18"
+    AllowedValues:
+      - "1.19"
+      - "1.18"
+      - "1.17"
+      - "1.16"
+      - "1.15"
+  PackerLog:
+    Type: String
+    Description: Enable Packer debug logging
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+
+Conditions:
+  IsPackerLog: !Equals [!Ref PackerLog, "true"]
+
+Resources:
+  CodeBuildRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: "codebuild.amazonaws.com"
+            Action: "sts:AssumeRole"
+      Description: !Sub "DO NOT DELETE - Used by CodeBuild, created by ${AWS::StackName}"
+      Policies:
+        - PolicyName: CodeBuildPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: "s3:GetObject"
+                Resource: !Sub "arn:${AWS::Partition}:s3:::amazon-eks/*"
+
+  CloudWatchLogsPolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: CloudWatchLogs
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - "logs:CreateLogStream"
+              - "logs:PutLogEvents"
+            Resource: !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${Project}:*"
+      Roles:
+        - !Ref CodeBuildRole
+
+  # see https://www.packer.io/docs/builders/amazon#specifying-amazon-credentials
+  PackerPolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: PackerPolicy
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - "ec2:AttachVolume"
+              - "ec2:AuthorizeSecurityGroupIngress"
+              - "ec2:CopyImage"
+              - "ec2:CreateImage"
+              - "ec2:CreateKeypair"
+              - "ec2:CreateSecurityGroup"
+              - "ec2:CreateSnapshot"
+              - "ec2:CreateTags"
+              - "ec2:CreateVolume"
+              - "ec2:DeleteKeyPair"
+              - "ec2:DeleteSecurityGroup"
+              - "ec2:DeleteSnapshot"
+              - "ec2:DeleteVolume"
+              - "ec2:DeregisterImage"
+              - "ec2:DescribeImageAttribute"
+              - "ec2:DescribeImages"
+              - "ec2:DescribeInstances"
+              - "ec2:DescribeInstanceStatus"
+              - "ec2:DescribeRegions"
+              - "ec2:DescribeSecurityGroups"
+              - "ec2:DescribeSnapshots"
+              - "ec2:DescribeSpotPriceHistory"
+              - "ec2:DescribeSubnets"
+              - "ec2:DescribeTags"
+              - "ec2:DescribeVolumes"
+              - "ec2:DetachVolume"
+              - "ec2:GetPasswordData"
+              - "ec2:ModifyImageAttribute"
+              - "ec2:ModifyInstanceAttribute"
+              - "ec2:ModifySnapshotAttribute"
+              - "ec2:RegisterImage"
+              - "ec2:RunInstances"
+              - "ec2:StopInstances"
+              - "ec2:TerminateInstances"
+            Resource: "*"
+      Roles:
+        - !Ref CodeBuildRole
+
+  LogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: !Sub "/aws/codebuild/${Project}"
+      RetentionInDays: 3
+
+  Project:
+    Type: "AWS::CodeBuild::Project"
+    Properties:
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Cache:
+        Modes:
+          - LOCAL_SOURCE_CACHE
+          - LOCAL_CUSTOM_CACHE
+        Type: LOCAL
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        EnvironmentVariables:
+          - Name: AWS_DEFAULT_REGION
+            Value: "us-west-2" # amazon-eks S3 bucket is in us-west-2
+          - Name: PACKER_VERSION
+            Value: "1.7.0"
+          - Name: PACKER_LOG
+            Value: !If
+              - IsPackerLog
+              - "1"
+              - "0"
+          - Name: PACKER_NO_COLOR
+            Value: "1"
+          - Name: CHECKPOINT_DISABLE
+            Value: "1"
+          - Name: K8S_VERSION
+            Value: !Ref KubernetesVersion
+        Image: aws/codebuild/standard:5.0 # AmazonLinux2 isn't supported by packer
+        Type: LINUX_CONTAINER
+      LogsConfig:
+        CloudWatchLogs:
+          Status: ENABLED
+      Name: amazon-eks-ami
+      Source:
+        BuildSpec: |-
+          version: 0.2
+
+          phases:
+            install:
+              commands:
+                - echo "Installing Packer..."
+                - curl -qL -o packer.zip https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && unzip packer.zip
+                - export PATH=${PATH}:${CODEBUILD_SRC_DIR}
+            build:
+              commands:
+                - echo "Building Packer template, eks-worker-al2.json"
+                - make ${K8S_VERSION}
+            post_build:
+              commands:
+                - echo "Packer build completed on `date`"
+                - cat manifest.json
+                - |
+                  if [ "${AWS_REGION}" != "us-west-2" ] ; then
+                    echo "Copying AMI from us-west-2 to ${AWS_REGION}"
+                    IMAGE_ID=`cat manifest.json | jq '.builds[0].artifact_id' | cut -d ":" -f2 | tr -d '"'`
+                    IMAGE_NAME=`aws ec2 describe-images --region us-west-2 --image-ids ${IMAGE_ID} | jq '.Images[0].Name' | tr -d '"'`
+                    aws ec2 copy-image --source-region us-west-2 --source-image-id ${IMAGE_ID} --name "${IMAGE_NAME}" --region ${AWS_REGION}
+                    aws ec2 deregister-image --image-id ${IMAGE_ID} --region us-west-2
+                  fi
+          
+          artifacts:
+            files:
+              - manifest.json
+        GitCloneDepth: 1
+        Location: https://github.com/awslabs/amazon-eks-ami.git
+        Type: GITHUB
+      SourceVersion: !Ref SourceVersion
+      ServiceRole: !GetAtt CodeBuildRole.Arn
+      TimeoutInMinutes: 30


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-eks-ami/issues/548

*Description of changes:* This PR includes a CloudFormation template that can be used to deploy a CodeBuild project that will execute packer and build the AMI (and then copy the AMI to the region the project is running in if not us-west-2).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
