### PR TITLE
remove hardcoded gid for docker

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -111,7 +111,8 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
 if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo amazon-linux-extras enable docker
-    sudo groupadd -f docker
+    sudo groupadd -fog 1950 docker
+    sudo useradd --gid $(getent group docker | cut -d: -f3) docker
     sudo yum install -y docker-${DOCKER_VERSION}*
     sudo usermod -aG docker $USER
 

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -111,7 +111,7 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
 if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo amazon-linux-extras enable docker
-    sudo groupadd -fog 1950 docker && sudo useradd --gid 1950 docker
+    sudo groupadd -f docker
     sudo yum install -y docker-${DOCKER_VERSION}*
     sudo usermod -aG docker $USER
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removes explicit gid for docker. This commit fixes builds for GPU AMIs which can have conflicting docker gids.

*Testing*
Built a GPU/nonGPU AMI. Both AMIs were able to join my EKS cluster.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
