### PR TITLE
bump docker version to 19.03.13ce-1

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -13,7 +13,7 @@
     "kubernetes_version": null,
     "kubernetes_build_date": null,
     "kernel_version": "",
-    "docker_version": "19.03.6ce-4.amzn2",
+    "docker_version": "19.03.13ce-1.amzn2",
     "containerd_version": "1.4.1-2.amzn2",
     "cni_plugin_version": "v0.8.6",
     "pull_cni_from_github": "true",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates docker version to `19.03.13ce-1`. 
Changelog of docker `19.03.13`: https://github.com/docker/docker-ce/releases/tag/v19.03.13

*testing*
built an AMI with the updated docker version. Node joined the cluster.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
