### PR TITLE
set kubelet klog verbosity to 2

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -386,7 +386,7 @@ mkdir -p /etc/systemd/system/kubelet.service.d
 
 cat <<EOF > /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf
 [Service]
-Environment='KUBELET_ARGS=--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER'
+Environment='KUBELET_ARGS=--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER --v=2'
 EOF
 
 if [[ -n "$KUBELET_EXTRA_ARGS" ]]; then


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-eks-ami/issues/628

*Description of changes:*
Sets Kubelet klog verbosity to 2 by default. V(2) is the recommended verbosity level by the Kubernetes community. 

If someone wanted to change the verbosity level, specifying `bootstrap.sh --kubelet-extra-args '--v <level>'` takes precedence over this argument.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
