### PR TITLE
remove static docker group

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -111,8 +111,6 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
 if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo amazon-linux-extras enable docker
-    sudo groupadd -fog 1950 docker
-    sudo useradd --gid $(getent group docker | cut -d: -f3) docker
     sudo yum install -y docker-${DOCKER_VERSION}*
     sudo usermod -aG docker $USER
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove static docker group gid in favor of the docker group that `yum install docker` creates. 

We'll still add `$USER` to the `docker` group to allow docker commands without `sudo`. 

Note that it's recommended and standard practice to use the group name instead of gid for any commands that add to or edit the group. 

To use the previous configuration for docker, one can add the following to their launchTemplate userData before calling `bootstrap.sh`:
```
sudo groupmod --gid 1950 docker
sudo usermod -aG docker $USER
sudo systemctl restart docker
```

### Testing
Built an AMI with these changes.
```
cat /etc/group |grep docker
docker:x:993:ec2-user
```
```
docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
