### PR TITLE
update log-collector-script to pull configure-multicard-interfaces logs

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -470,6 +470,9 @@ get_networking_info() {
   timeout 75 ip rule show > "${COLLECT_DIR}"/networking/iprule.txt
   timeout 75 ip route show table all >> "${COLLECT_DIR}"/networking/iproute.txt
 
+  # configure-multicard-interfaces
+  timeout 75 journalctl -u configure-multicard-interfaces > "${COLLECT_DIR}"/networking/configure-multicard-interfaces.txt || echo -e "\tTimed out, ignoring \"configure-multicard-interfaces unit output \" "
+
   ok
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update `log-collector-script` to pull `configure-multicard-interfaces` unit logs. This script is responsible for configuring networking for secondary network interfaces on p4d instance types. 

### Testing
```
sudo bash eks-log-collector.sh

Trying to collect common operating system logs...
Trying to collect kernel logs...
Trying to collect mount points and volume information...
Trying to collect SELinux status...
Trying to collect iptables information...
Trying to collect installed packages...
Trying to collect active system services...
Trying to Collect Containerd daemon information...
Trying to collect Docker daemon information...
Trying to collect kubelet information...
Trying to collect L-IPAMD introspection information... Trying to collect L-IPAMD prometheus metrics... Trying to collect L-IPAMD checkpoint...
Trying to collect sysctls information...
Trying to collect networking infomation... conntrack v1.4.4 (conntrack-tools): 168 flow entries have been shown.

Trying to collect CNI configuration information...
Trying to collect Docker daemon logs...
Trying to archive gathered information...

        Done... your bundled logs are located in /var/log/eks_i-06e068bb3aecc1683_2021-03-11_1711-UTC_0.6.2.tar.gz

sudo mv /var/log/eks_i-06e068bb3aecc1683_2021-03-11_1711-UTC_0.6.2.tar.gz .
sudo tar -zxvf eks_i-06e068bb3aecc1683_2021-03-11_1711-UTC_0.6.2.tar.gz

ls -l networking|grep configure
-rw-r--r-- 1 root root  1206 Mar 11 17:11 configure-multicard-interfaces.txt

cat networking/configure-multicard-interfaces.txt
-- Logs begin at Wed 2021-03-10 22:58:25 UTC, end at Thu 2021-03-11 17:11:55 UTC. --
Mar 10 22:59:01 ip-192-168-10-243.us-west-2.compute.internal systemd[1]: Starting Configure multicard interfaces...
Mar 10 22:59:01 ip-192-168-10-243.us-west-2.compute.internal configure-multicard-interfaces.sh[4748]: % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Mar 10 22:59:01 ip-192-168-10-243.us-west-2.compute.internal configure-multicard-interfaces.sh[4748]: Dload  Upload   Total   Spent    Left  Speed
Mar 10 22:59:01 ip-192-168-10-243.us-west-2.compute.internal configure-multicard-interfaces.sh[4748]: [155B blob data]
Mar 10 22:59:01 ip-192-168-10-243.us-west-2.compute.internal configure-multicard-interfaces.sh[4748]: % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Mar 10 22:59:01 ip-192-168-10-243.us-west-2.compute.internal configure-multicard-interfaces.sh[4748]: Dload  Upload   Total   Spent    Left  Speed
Mar 10 22:59:01 ip-192-168-10-243.us-west-2.compute.internal configure-multicard-interfaces.sh[4748]: [155B blob data]
Mar 10 22:59:01 ip-192-168-10-243.us-west-2.compute.internal systemd[1]: Started Configure multicard interfaces.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
