### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ Notable changes :
 
 ### AMI Release v20210302
 
-#### GPU AMIs in this release are not compatible with any eksctl version after [eksctl 0.34.0](https://github.com/weaveworks/eksctl/releases/tag/0.34.0)
-* amazon-eks-gpu-node-1.19-v20210302]
+**GPU AMIs in this release are not compatible with any eksctl version after [eksctl 0.34.0](https://github.com/weaveworks/eksctl/releases/tag/0.34.0)**
+
+* amazon-eks-gpu-node-1.19-v20210302
 * amazon-eks-gpu-node-1.18-v20210302
 * amazon-eks-gpu-node-1.17-v20210302
 * amazon-eks-gpu-node-1.16-v20210302

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ Notable changes :
 - GPU AMIs no longer uses `daemon.json` defined in https://github.com/awslabs/amazon-eks-ami/blob/master/files/docker-daemon.json
 
 ### AMI Release v20210302
-* amazon-eks-gpu-node-1.19-v20210302
+
+#### GPU AMIs in this release are not compatible with any eksctl version after [eksctl 0.34.0](https://github.com/weaveworks/eksctl/releases/tag/0.34.0)
+* amazon-eks-gpu-node-1.19-v20210302]
 * amazon-eks-gpu-node-1.18-v20210302
 * amazon-eks-gpu-node-1.17-v20210302
 * amazon-eks-gpu-node-1.16-v20210302


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add line stating that GPU AMIs in release v20210302 are not compatible with any eksctl version after 0.34.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
