### PR TITLE
Adds info on adding instance types to eni-max-pods.txt

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,0 +1,25 @@
+## User Guide
+
+This guide will provide more detailed usage information on this repo.
+
+## Updating known instance types
+
+`files/bootstrap.sh` configures the maximum number of pods on a node based off of the number of ENIs available, which is determined by the instance type. Larger instances generally have more ENIs. The number of ENIs limits how many IPV4 addresses are available on an instance, and we need one IP address per pod. You can [see this file](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/scripts/gen_vpc_ip_limits.go) for the code that calculates the max pods for more information.
+
+To add support for new instance types, at a minimum, we need to update `files/eni-max-pods.txt` using the [amazon-vpc-cni-k8s package.](https://github.com/aws/amazon-vpc-cni-k8s) to set the number of max pods available for those instance types. If the instance type is not on the list, `bootstrap.sh` will fail when the node is started.
+
+```
+$ git clone git@github.com:aws/amazon-vpc-cni-k8s.git
+
+# AWS credentials required at this point
+$ make generate-limits
+# misc/eni-max-pods.txt should be generated
+
+# Copy the generated file to this repo, something like this:
+$ cp misc/eni-max-pods.txt ../amazon-eks-ami/files/
+
+# Verify that expected types were added
+$ git diff
+```
+
+At this point, you can build an AMI and it will include the updated list of instance types.

--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-# This file was generated at 2021-01-13T12:54:18-08:00
+# This file was generated at 2021-03-16T15:26:13-07:00
 #
 # Mapping is calculated from AWS EC2 API using the following formula:
 # * First IP on each ENI is not used for pods
@@ -229,6 +229,7 @@ m5dn.2xlarge 58
 m5dn.4xlarge 234
 m5dn.8xlarge 234
 m5dn.large 29
+m5dn.metal 737
 m5dn.xlarge 58
 m5n.12xlarge 234
 m5n.16xlarge 737
@@ -237,6 +238,7 @@ m5n.2xlarge 58
 m5n.4xlarge 234
 m5n.8xlarge 234
 m5n.large 29
+m5n.metal 737
 m5n.xlarge 58
 m5zn.12xlarge 737
 m5zn.2xlarge 58
@@ -333,6 +335,7 @@ r5dn.2xlarge 58
 r5dn.4xlarge 234
 r5dn.8xlarge 234
 r5dn.large 29
+r5dn.metal 737
 r5dn.xlarge 58
 r5n.12xlarge 234
 r5n.16xlarge 737
@@ -341,6 +344,7 @@ r5n.2xlarge 58
 r5n.4xlarge 234
 r5n.8xlarge 234
 r5n.large 29
+r5n.metal 737
 r5n.xlarge 58
 r6g.12xlarge 234
 r6g.16xlarge 737
@@ -402,6 +406,15 @@ x1e.32xlarge 234
 x1e.4xlarge 58
 x1e.8xlarge 58
 x1e.xlarge 29
+x2gd.12xlarge 234
+x2gd.16xlarge 737
+x2gd.2xlarge 58
+x2gd.4xlarge 234
+x2gd.8xlarge 234
+x2gd.large 29
+x2gd.medium 8
+x2gd.metal 737
+x2gd.xlarge 58
 z1d.12xlarge 737
 z1d.2xlarge 58
 z1d.3xlarge 234


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I created `USER_GUIDE.md` to add more detailed usage information to avoid make the README too cumbersome with information most people won't care about. I also validated those instructions by running the script to generate the max pods file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
