### PR TITLE
Add retry in case 'aws eks wait cluster-active' returns error due to rate limiting

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -300,15 +300,16 @@ if [[ -z "${B64_CLUSTER_CA}" ]] || [[ -z "${APISERVER_ENDPOINT}" ]]; then
 
         aws eks wait cluster-active \
             --region=${AWS_DEFAULT_REGION} \
-            --name=${CLUSTER_NAME}
-
-        aws eks describe-cluster \
-            --region=${AWS_DEFAULT_REGION} \
-            --name=${CLUSTER_NAME} \
-            --output=text \
-            --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint, kubernetesNetworkConfig: kubernetesNetworkConfig.serviceIpv4Cidr}' > $DESCRIBE_CLUSTER_RESULT || rc=$?
+            --name=${CLUSTER_NAME} || rc=$?
         if [[ $rc -eq 0 ]]; then
-            break
+            aws eks describe-cluster \
+                --region=${AWS_DEFAULT_REGION} \
+                --name=${CLUSTER_NAME} \
+                --output=text \
+                --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint, kubernetesNetworkConfig: kubernetesNetworkConfig.serviceIpv4Cidr}' > $DESCRIBE_CLUSTER_RESULT || rc=$?
+            if [[ $rc -eq 0 ]]; then
+                break
+            fi
         fi
         if [[ $attempt -eq $API_RETRY_ATTEMPTS ]]; then
             exit $rc


### PR DESCRIPTION
…rate limiting

*Issue #, if available:*

*Description of changes:*
Adds a check if the command 'aws eks wait cluster-active' fails it should retry. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
