### PR TITLE
Add --max-pods param for bootstrap script

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -368,13 +368,13 @@ MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
 set +o pipefail
 MAX_PODS_PER_INSTANCE=$(cat $MAX_PODS_FILE | awk "/^${INSTANCE_TYPE:-unset}/"' { print $2 }')
 set -o pipefail
-if [ -z "$MAX_PODS" ] || [ -z "$INSTANCE_TYPE" ]; then
-   echo "No entry for type '$INSTANCE_TYPE' in $MAX_PODS_FILE"
-   exit 1
+if [ -z "$MAX_PODS_PER_INSTANCE" ] || [ -z "$INSTANCE_TYPE" ]; then
+    echo "No entry for type '$INSTANCE_TYPE' in $MAX_PODS_FILE"
+    exit 1
 fi
 
 if [ -z "$MAX_PODS" ] || [ "$MAX_PODS" -gt "$MAX_PODS_PER_INSTANCE" ]; then
-  MAX_PODS=$MAX_PODS_PER_INSTANCE
+    MAX_PODS=$MAX_PODS_PER_INSTANCE
 fi
 
 # calculates the amount of each resource to reserve


### PR DESCRIPTION
Maximum number of pods per node specified at /etc/eks/eni-max-pods.txt
and it is the limit of network interfaces for the instance type. This
number form an amount of memory in Mi kubernetes reserved with formula
11 * $max_num_pods + 255.

Nodes could have a setup when maximum number of pods defined and
it is less than value at the file. Here I add an ability to use
command line value to cover such cases.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
