### PR TITLE
Enable CSIServiceAccountToken feature gate for v1.20

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -214,6 +214,12 @@ sudo mv $TEMPLATE_DIR/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
 sudo chown root:root /var/lib/kubelet/kubeconfig
 sudo mv $TEMPLATE_DIR/kubelet.service /etc/systemd/system/kubelet.service
 sudo chown root:root /etc/systemd/system/kubelet.service
+# Inject CSIServiceAccountToken feature gate to kubelet config if kubernetes version starts with 1.20.
+# This is only injected for 1.20 since CSIServiceAccountToken will be moved to beta starting 1.21.
+if [[ $KUBERNETES_VERSION == "1.20"* ]]; then
+    KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED=$(cat $TEMPLATE_DIR/kubelet-config.json | jq '.featureGates += {CSIServiceAccountToken: true}')
+    echo $KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED > $TEMPLATE_DIR/kubelet-config.json
+fi
 sudo mv $TEMPLATE_DIR/kubelet-config.json /etc/kubernetes/kubelet/kubelet-config.json
 sudo chown root:root /etc/kubernetes/kubelet/kubelet-config.json
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enable CSIServiceAccountToken feature gate for v1.20

*Testing:*
* `cat /etc/kubernetes/kubelet/kubelet-config.json` - feature gates are correctly populated for 1.20 AMI
```
 "featureGates": {
    "RotateKubeletServerCertificate": true,
    "CSIServiceAccountToken": true
  }
```
* log from `journalctl -u kubelet` - `I0326 22:57:54.057748 4510 feature_gate.go:243] feature gates: &{map[CSIServiceAccountToken:true RotateKubeletServerCertificate:true]}`
* `cat /etc/kubernetes/kubelet/kubelet-config.json` - feature gates remain same as before for 1.19 AMI
```
 "featureGates": {
    "RotateKubeletServerCertificate": true
  }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
