### PR TITLE
'sudo' redundant in boostrap.sh for nvidia-smi

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -419,8 +419,8 @@ if  command -v nvidia-smi &>/dev/null ; then
 
    nvidia-smi -q > /tmp/nvidia-smi-check
    if [[ "$?" == "0" ]]; then
-      sudo nvidia-smi -pm 1 # set persistence mode
-      sudo nvidia-smi --auto-boost-default=0
+      nvidia-smi -pm 1 # set persistence mode
+      nvidia-smi --auto-boost-default=0
 
       GPUNAME=$(nvidia-smi -L | head -n1)
       echo $GPUNAME


### PR DESCRIPTION
Is not "sudo" redundant here?

*Issue #, if available:*
Our log management tool triggers on sudo events on the servers. And this one feels redundant.

*Description of changes:*
Removed "sudo" from two lines, as the bootstrap is run by root.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
