### PR TITLE
pinning runc version to 1.0.0-rc92

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -125,6 +125,10 @@ if [[ "$INSTALL_DOCKER" == "true" ]]; then
 
     sudo yum downgrade -y containerd-${CONTAINERD_VERSION}
 
+    # runc `1.0.0-rc93` resulted in a regression: https://github.com/awslabs/amazon-eks-ami/issues/648
+    # pinning it to `1.0.0-rc92`
+    sudo yum downgrade -y runc.${MACHINE} 1.0.0-0.1.20200826.gitff819c7.amzn2
+
     # Enable docker daemon to start on boot.
     sudo systemctl daemon-reload
     sudo systemctl enable docker


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/648

*Description of changes:*
Pinning `runc` version to 1.0.0-rc92

*Testing*
* Built a x86_64 ami, launched a self managed nodegroup (instance type c3.2xlarge) with 3 nodes and deployed some 150 pods. All the pods went into running state and node was not flapping between `Ready` and `NotReady`
* Also sshed into the node to get docker details:
```
[ec2-user@ip-192-168-83-203 ~]$ docker version
Client:
 Version:           19.03.13-ce
 API version:       1.40
 Go version:        go1.13.15
 Git commit:        4484c46
 Built:             Mon Oct 12 18:51:20 2020
 OS/Arch:           linux/amd64
 Experimental:      false

Server:
 Engine:
  Version:          19.03.13-ce
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.13.15
  Git commit:       4484c46
  Built:            Mon Oct 12 18:51:50 2020
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.4.1
  GitCommit:        c623d1b36f09f8ef6536a057bd658b3aa8632828
 runc:
  Version:          1.0.0-rc92
  GitCommit:        ff819c7e9184c13b7c2607fe6c30ae19403a7aff
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```
* Built an ARM AMI, launched an EC2 instance and checked docker details by sshing into the instance:
```
[ec2-user@ip-172-31-55-245 ~]$ docker version
Client:
 Version:           19.03.13-ce
 API version:       1.40
 Go version:        go1.13.15
 Git commit:        4484c46
 Built:             Mon Oct 12 18:51:25 2020
 OS/Arch:           linux/arm64
 Experimental:      false

Server:
 Engine:
  Version:          19.03.13-ce
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.13.15
  Git commit:       4484c46
  Built:            Mon Oct 12 18:51:57 2020
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.4.1
  GitCommit:        c623d1b36f09f8ef6536a057bd658b3aa8632828
 runc:
  Version:          1.0.0-rc92
  GitCommit:        ff819c7e9184c13b7c2607fe6c30ae19403a7aff
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
