### PR TITLE
Add PRIVATE_BIN_REPO support for pulling binaries

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -172,7 +172,11 @@ BINARIES=(
     aws-iam-authenticator
 )
 for binary in ${BINARIES[*]} ; do
-    if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+    if [ "${PRIVATE_BIN_REPO}" != "" ]; then
+        echo "Using PRIVATE_BIN_REPO ${PRIVATE_BIN_REPO} as source for coping binaries."
+        sudo wget ${PRIVATE_BIN_REPO}/$binary
+        sudo wget ${PRIVATE_BIN_REPO}/$binary.sha256
+    elif [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
         echo "AWS cli present - using it to copy binaries from s3."
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
@@ -196,7 +200,11 @@ if [ "$PULL_CNI_FROM_GITHUB" = "true" ]; then
     sudo sha512sum -c "${CNI_PLUGIN_FILENAME}.tgz.sha512"
     rm "${CNI_PLUGIN_FILENAME}.tgz.sha512"
 else
-    if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+    if [ "${PRIVATE_BIN_REPO}" != "" ]; then
+        echo "Using PRIVATE_BIN_REPO ${PRIVATE_BIN_REPO} as source for coping binaries"
+        sudo wget ${PRIVATE_BIN_REPO}/${CNI_PLUGIN_FILENAME}.tgz
+        sudo wget ${PRIVATE_BIN_REPO}/${CNI_PLUGIN_FILENAME}.tgz.sha256
+    elif [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
         echo "AWS cli present - using it to copy binaries from s3."
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz .
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz.sha256 .

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -173,7 +173,7 @@ BINARIES=(
 )
 for binary in ${BINARIES[*]} ; do
     if [ "${PRIVATE_BIN_REPO}" != "" ]; then
-        echo "Using PRIVATE_BIN_REPO ${PRIVATE_BIN_REPO} as source for coping binaries."
+        echo "Using PRIVATE_BIN_REPO ${PRIVATE_BIN_REPO} as source for copying binaries."
         sudo wget ${PRIVATE_BIN_REPO}/$binary
         sudo wget ${PRIVATE_BIN_REPO}/$binary.sha256
     elif [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
@@ -201,7 +201,7 @@ if [ "$PULL_CNI_FROM_GITHUB" = "true" ]; then
     rm "${CNI_PLUGIN_FILENAME}.tgz.sha512"
 else
     if [ "${PRIVATE_BIN_REPO}" != "" ]; then
-        echo "Using PRIVATE_BIN_REPO ${PRIVATE_BIN_REPO} as source for coping binaries"
+        echo "Using PRIVATE_BIN_REPO ${PRIVATE_BIN_REPO} as source for copying binaries"
         sudo wget ${PRIVATE_BIN_REPO}/${CNI_PLUGIN_FILENAME}.tgz
         sudo wget ${PRIVATE_BIN_REPO}/${CNI_PLUGIN_FILENAME}.tgz.sha256
     elif [[ -n "$AWS_ACCESS_KEY_ID" ]]; then


### PR DESCRIPTION
As a EKS ami builder, I want to be able to pull binaries from my own repo of cached artifacts so that I can ensure availability, reproducibility, and security.

In my particular case, the binaries are not currently available in s3://amazon-eks.s3.us-gov-west-1.amazonaws.com and egress rules are tightly controlled.

How to use:

1. User caches/stages the binaries in their own artifact repo.  At present, these are:
     - kubelet
     - aws-iam-authenticator
     - cni-plugins-linux

2. User adds the PRIVATE_BIN_REPO variable to their custom eks-worker config

Given that this is an edge uncommon use case, the PRIVATE_BIN_REPO user variable has not been added to the eks-worker config.  Users will continue to use the existing behavior by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
