### PR TITLE
Revert "Revert "Removing dependency on Authenticator binary" (#446)"

### DIFF
--- a/files/kubelet-kubeconfig
+++ b/files/kubelet-kubeconfig
@@ -16,10 +16,14 @@ users:
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
-      command: /usr/bin/aws-iam-authenticator
+      command: aws
+      env:
+        - name: AWS_STS_REGIONAL_ENDPOINTS
+          value: regional
       args:
-        - "token"
-        - "-i"
-        - "CLUSTER_NAME"
+        - eks
         - --region
         - "AWS_REGION"
+        - get-token
+        - --cluster-name
+        - "CLUSTER_NAME"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -169,7 +169,6 @@ S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin
 
 BINARIES=(
     kubelet
-    aws-iam-authenticator
 )
 for binary in ${BINARIES[*]} ; do
     if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then


### PR DESCRIPTION
This reintroduces the switch to use "aws eks get-token" instead of the
aws-iam-authenticator. The reason (see [0]) why that switch got
reverted was, that eksctl wasn't able to handle the situation where
aws-iam-authenticator was not there. But that changed (see [1] and
[2]) so switching to aws-cli for getting a token should be good now.

This reverts commit d6e021b87edb9861fd478dece0e09cfe4bead8c4.

[0] https://github.com/awslabs/amazon-eks-ami/pull/446
[1] https://github.com/weaveworks/eksctl/issues/788
[2] https://github.com/weaveworks/eksctl/pull/993
