### PR TITLE
preload docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version runc_version cni_plugin_version source_ami_id source_ami_owners source_ami_filter_name arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry
+PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version runc_version cni_plugin_version source_ami_id source_ami_owners source_ami_filter_name arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry launch_block_device_mappings_volume_size
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})

--- a/files/docker-preload-images
+++ b/files/docker-preload-images
@@ -1,0 +1,1 @@
+# docker images for preloading

--- a/files/docker-preload-images-login
+++ b/files/docker-preload-images-login
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# login to private docker registry before pulling
+# sudo docker login -u <login1> -p <password2> <registry1>
+# sudo docker login -u <login1> -p <password2> <registry2>

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -295,6 +295,27 @@ echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
 echo fs.inotify.max_user_instances=8192 | sudo tee -a /etc/sysctl.conf
 echo vm.max_map_count=524288 | sudo tee -a /etc/sysctl.conf
 
+################################################################################
+### Preload docker images ######################################################
+################################################################################
+
+# start docker for image pulling
+sudo systemctl start docker
+
+# (optional) login to private docker
+bash $TEMPLATE_DIR/docker-preload-images-login
+
+# remove comments and empty lines from docker images list
+sed -i -e '/^#/d' -e '/^$/d' $TEMPLATE_DIR/docker-preload-images
+
+# preload docker images
+for line in $(cat $TEMPLATE_DIR/docker-preload-images); do
+  echo "Pulling... $line"
+  sudo docker pull $line
+done
+
+# gracefull docker shutdown
+sudo systemctl stop docker
 
 ################################################################################
 ### Cleanup ####################################################################


### PR DESCRIPTION
*Description of changes:*
To reduce image pull time in pod creation - it's will be great to have some preloaded docker images in AMI. For cluster that have spot instances there are many docker pull operation on kubernetes node creation (daemonsets). Preloaded docker images make cluster more reliable

Default volume size for `amazon-eks-ami` is 4Gb - it will be not enough for preloaded images - this change also add parameter `launch_block_device_mappings_volume_size` for custom user values

