### PR TITLE
[SSM Agent] Install the SSM Agent in the EKS worker AMI

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -258,6 +258,21 @@ if [[ -n "$SONOBUOY_E2E_REGISTRY" ]]; then
 fi
 
 ################################################################################
+### SSM Agent ##################################################################
+################################################################################
+
+if [ "$BINARY_BUCKET_REGION" != "us-iso-east-1" ] && [ "$BINARY_BUCKET_REGION" != "us-isob-east-1" ]; then
+    if [ "$BINARY_BUCKET_REGION" = "cn-north-1" ] || [ "$BINARY_BUCKET_REGION" = "cn-northwest-1" ]; then
+        sudo yum install -y https://s3.cn-north-1.amazonaws.com.cn/amazon-ssm-cn-north-1/latest/linux_$ARCH/amazon-ssm-agent.rpm
+    else
+        sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_$ARCH/amazon-ssm-agent.rpm
+    fi
+
+    sudo systemctl enable amazon-ssm-agent
+    sudo systemctl start amazon-ssm-agent
+fi
+
+################################################################################
 ### AMI Metadata ###############################################################
 ################################################################################
 


### PR DESCRIPTION
This change installs the SSM Agent in the EKS worker AMI by default. The nodeRole used for the worker nodes will need to have the SSM permissions added to it for the SSM agent to be able to report back to SSM. If the SSM permissions aren't present the agent will be active but unable to report to SSM.

*Issue #, if available:* #404

*Description of changes:* Install SSM agent by default

This was tested on a cluster that had an SSM daemonset already running and it still worked.

The s3 files for the SSM agent are based on the public SSM docs:

General: https://docs.aws.amazon.com/systems-manager/latest/userguide/agent-install-al2.html
CN: https://docs.amazonaws.cn/en_us/systems-manager/latest/userguide/agent-install-al2.html

According to the docs in CN, we should use the global aws s3 bucket for ARM


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
