### PR TITLE
[SSM Agent] Just enable the SSM agent and don't start it

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -269,7 +269,6 @@ if [ "$BINARY_BUCKET_REGION" != "us-iso-east-1" ] && [ "$BINARY_BUCKET_REGION" !
     fi
 
     sudo systemctl enable amazon-ssm-agent
-    sudo systemctl start amazon-ssm-agent
 fi
 
 ################################################################################


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Just enable the SSM agent and don't start it so it will start on boot


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
