### PR TITLE
add packer variable files option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ all: 1.15 1.16 1.17 1.18 1.19 1.20
 
 .PHONY: validate
 validate:
-	$(PACKER_BINARY) validate $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
+	$(PACKER_BINARY) validate $(if $(PACKER_VAR_FILE),--var-file=$(PACKER_VAR_FILE),) $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
 
 .PHONY: k8s
 k8s: validate
 	@echo "$(T_GREEN)Building AMI for version $(T_YELLOW)$(kubernetes_version)$(T_GREEN) on $(T_YELLOW)$(arch)$(T_RESET)"
-	$(PACKER_BINARY) build $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
+	$(PACKER_BINARY) build $(if $(PACKER_VAR_FILE),--var-file=$(PACKER_VAR_FILE),) $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
 
 # Build dates and versions taken from https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add packer variable file environment variables for users to specify the custom variable files for packer. Users now can only set  variables dynamically by setting `PACKER_VARIABLES`. If users want to modify few more variables which are not listed int `PACKER_VARIABLES`, then it would be helpful for them to define variables in json file and specify the file name to `PACKER_VAR_FILE` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
