### PR TITLE
change default volume type from gp2 to gp3

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -61,7 +61,7 @@
       "launch_block_device_mappings": [
         {
           "device_name": "/dev/xvda",
-          "volume_type": "gp2",
+          "volume_type": "gp3",
           "volume_size": "{{user `launch_block_device_mappings_volume_size`}}",
           "delete_on_termination": true
         }


### PR DESCRIPTION
*Description of changes:*
This is really small PR. I think it would be better to use gp3 for default volume type which is cheaper than gp2.
I think changing default type of instance(which is m4.large) would also be helpful.