### PR TITLE
changes done to add support for containerd runtime in eks worker ami

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -24,6 +24,9 @@ function print_help {
     echo "--aws-api-retry-attempts Number of retry attempts for AWS API call (DescribeCluster) (default: 3)"
     echo "--docker-config-json The contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI"
     echo "--dns-cluster-ip Overrides the IP address to use for DNS queries within the cluster. Defaults to 10.100.0.10 or 172.20.0.10 based on the IP address of the primary interface"
+    echo "--pause-container-account The AWS account (number) to pull the pause container from"
+    echo "--pause-container-version The tag of the pause container"
+    echo "--container-runtime Specify a container runtime (default: dockerd)"
 }
 
 POSITIONAL=()
@@ -85,6 +88,11 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
+        --container-runtime)
+            CONTAINER_RUNTIME=$2
+            shift
+            shift
+            ;;
         *)    # unknown option
             POSITIONAL+=("$1") # save it in an array for later
             shift # past argument
@@ -100,11 +108,14 @@ set -u
 USE_MAX_PODS="${USE_MAX_PODS:-true}"
 B64_CLUSTER_CA="${B64_CLUSTER_CA:-}"
 APISERVER_ENDPOINT="${APISERVER_ENDPOINT:-}"
+SERVICE_IPV4_CIDR="${SERVICE_IPV4_CIDR:-}"
+DNS_CLUSTER_IP="${DNS_CLUSTER_IP:-}"
 KUBELET_EXTRA_ARGS="${KUBELET_EXTRA_ARGS:-}"
 ENABLE_DOCKER_BRIDGE="${ENABLE_DOCKER_BRIDGE:-false}"
 API_RETRY_ATTEMPTS="${API_RETRY_ATTEMPTS:-3}"
 DOCKER_CONFIG_JSON="${DOCKER_CONFIG_JSON:-}"
-PAUSE_CONTAINER_VERSION="${PAUSE_CONTAINER_VERSION:-3.1}"
+PAUSE_CONTAINER_VERSION="${PAUSE_CONTAINER_VERSION:-3.1-eksbuild.1}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-dockerd}"
 
 function get_pause_container_account_for_region () {
     local region="$1"
@@ -121,9 +132,79 @@ function get_pause_container_account_for_region () {
         echo "${PAUSE_CONTAINER_ACCOUNT:-013241004608}";;
     us-gov-east-1)
         echo "${PAUSE_CONTAINER_ACCOUNT:-151742754352}";;
+    af-south-1)
+        echo "${PAUSE_CONTAINER_ACCOUNT:-877085696533}";;
+    eu-south-1)
+        echo "${PAUSE_CONTAINER_ACCOUNT:-590381155156}";;
     *)
         echo "${PAUSE_CONTAINER_ACCOUNT:-602401143452}";;
     esac
+}
+
+function _get_token() {
+  local token_result=
+  local http_result=
+
+  token_result=$(curl -s -w "\n%{http_code}" -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 600" "http://169.254.169.254/latest/api/token")
+  http_result=$(echo "$token_result" | tail -n 1)
+  if [[ "$http_result" != "200" ]]
+  then
+      echo -e "Failed to get token:\n$token_result"
+      return 1
+  else
+      echo "$token_result" | head -n 1
+      return 0
+  fi
+}
+
+function get_token() {
+  local token=
+  local retries=20
+  local result=1
+
+  while [[ retries -gt 0 && $result -ne 0 ]]
+  do
+    retries=$[$retries-1]
+    token=$(_get_token)
+    result=$?
+    [[ $result != 0 ]] && sleep 5
+  done
+  [[ $result == 0 ]] && echo "$token"
+  return $result
+}
+
+function _get_meta_data() {
+  local path=$1
+  local metadata_result=
+
+  metadata_result=$(curl -s -w "\n%{http_code}" -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/$path)
+  http_result=$(echo "$metadata_result" | tail -n 1)
+  if [[ "$http_result" != "200" ]]
+  then
+      echo -e "Failed to get metadata:\n$metadata_result\nhttp://169.254.169.254/$path\n$TOKEN"
+      return 1
+  else
+      local lines=$(echo "$metadata_result" | wc -l)
+      echo "$metadata_result" | head -n $(( lines - 1 ))
+      return 0
+  fi
+}
+
+function get_meta_data() {
+  local metadata=
+  local path=$1
+  local retries=20
+  local result=1
+
+  while [[ retries -gt 0 && $result -ne 0 ]]
+  do
+    retries=$[$retries-1]
+    metadata=$(_get_meta_data $path)
+    result=$?
+    [[ $result != 0 ]] && TOKEN=$(get_token)
+  done
+  [[ $result == 0 ]] && echo "$metadata"
+  return $result
 }
 
 # Helper function which calculates the amount of the given resource (either CPU or memory)
@@ -155,7 +236,7 @@ get_resource_to_reserve_in_range() {
 # density so we are calculating the amount of memory to reserve for Kubernetes systems daemons by
 # considering the maximum number of pods this instance type supports.
 # Args:
-#   $1 the instance type of the worker node
+#   $1 the max number of pods per instance type (MAX_PODS) based on values from /etc/eks/eni-max-pods.txt
 # Return:
 #   memory to reserve in Mi for the kubelet
 get_memory_mebibytes_to_reserve() {
@@ -195,22 +276,18 @@ if [ -z "$CLUSTER_NAME" ]; then
 fi
 
 
-TOKEN=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 600" "http://169.254.169.254/latest/api/token")
-AWS_DEFAULT_REGION=$(curl -s --retry 5 -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/dynamic/instance-identity/document | jq .region -r)
-AWS_SERVICES_DOMAIN=$(curl -s --retry 5 -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/2018-09-24/meta-data/services/domain)
+TOKEN=$(get_token)
+AWS_DEFAULT_REGION=$(get_meta_data 'latest/dynamic/instance-identity/document' | jq .region -r)
+AWS_SERVICES_DOMAIN=$(get_meta_data '2018-09-24/meta-data/services/domain')
 
 MACHINE=$(uname -m)
-if [ "$MACHINE" == "x86_64" ]; then
-    ARCH="amd64"
-elif [ "$MACHINE" == "aarch64" ]; then
-    ARCH="arm64"
-else
+if [[ "$MACHINE" != "x86_64" && "$MACHINE" != "aarch64" ]]; then
     echo "Unknown machine architecture '$MACHINE'" >&2
     exit 1
 fi
 
 PAUSE_CONTAINER_ACCOUNT=$(get_pause_container_account_for_region "${AWS_DEFAULT_REGION}")
-PAUSE_CONTAINER_IMAGE=${PAUSE_CONTAINER_IMAGE:-$PAUSE_CONTAINER_ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.$AWS_SERVICES_DOMAIN/eks/pause-${ARCH}}
+PAUSE_CONTAINER_IMAGE=${PAUSE_CONTAINER_IMAGE:-$PAUSE_CONTAINER_ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.$AWS_SERVICES_DOMAIN/eks/pause}
 PAUSE_CONTAINER="$PAUSE_CONTAINER_IMAGE:$PAUSE_CONTAINER_VERSION"
 
 ### kubelet kubeconfig
@@ -218,7 +295,7 @@ PAUSE_CONTAINER="$PAUSE_CONTAINER_IMAGE:$PAUSE_CONTAINER_VERSION"
 CA_CERTIFICATE_DIRECTORY=/etc/kubernetes/pki
 CA_CERTIFICATE_FILE_PATH=$CA_CERTIFICATE_DIRECTORY/ca.crt
 mkdir -p $CA_CERTIFICATE_DIRECTORY
-if [[ -z "${B64_CLUSTER_CA}" ]] && [[ -z "${APISERVER_ENDPOINT}" ]]; then
+if [[ -z "${B64_CLUSTER_CA}" ]] || [[ -z "${APISERVER_ENDPOINT}" ]]; then
     DESCRIBE_CLUSTER_RESULT="/tmp/describe_cluster_result.txt"
 
     # Retry the DescribeCluster API for API_RETRY_ATTEMPTS
@@ -236,7 +313,7 @@ if [[ -z "${B64_CLUSTER_CA}" ]] && [[ -z "${APISERVER_ENDPOINT}" ]]; then
             --region=${AWS_DEFAULT_REGION} \
             --name=${CLUSTER_NAME} \
             --output=text \
-            --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint}' > $DESCRIBE_CLUSTER_RESULT || rc=$?
+            --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint, kubernetesNetworkConfig: kubernetesNetworkConfig.serviceIpv4Cidr}' > $DESCRIBE_CLUSTER_RESULT || rc=$?
         if [[ $rc -eq 0 ]]; then
             break
         fi
@@ -249,6 +326,7 @@ if [[ -z "${B64_CLUSTER_CA}" ]] && [[ -z "${APISERVER_ENDPOINT}" ]]; then
     done
     B64_CLUSTER_CA=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $1}')
     APISERVER_ENDPOINT=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $2}')
+    SERVICE_IPV4_CIDR=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $3}')
 fi
 
 echo $B64_CLUSTER_CA | base64 -d > $CA_CERTIFICATE_FILE_PATH
@@ -258,22 +336,27 @@ sed -i s,MASTER_ENDPOINT,$APISERVER_ENDPOINT,g /var/lib/kubelet/kubeconfig
 sed -i s,AWS_REGION,$AWS_DEFAULT_REGION,g /var/lib/kubelet/kubeconfig
 ### kubelet.service configuration
 
-if [ -z ${DNS_CLUSTER_IP+x} ]; then
-    MAC=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/ -s | head -n 1 | sed 's/\/$//')
-    TEN_RANGE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks | grep -c '^10\..*' || true )
+if [[ -z "${DNS_CLUSTER_IP}" ]]; then
+  if [[ ! -z "${SERVICE_IPV4_CIDR}" ]] && [[ "${SERVICE_IPV4_CIDR}" != "None" ]] ; then
+    #Sets the DNS Cluster IP address that would be chosen from the serviceIpv4Cidr. (x.y.z.10)
+    DNS_CLUSTER_IP=${SERVICE_IPV4_CIDR%.*}.10
+  else
+    MAC=$(get_meta_data 'latest/meta-data/network/interfaces/macs/' | head -n 1 | sed 's/\/$//')
+    TEN_RANGE=$(get_meta_data "latest/meta-data/network/interfaces/macs/$MAC/vpc-ipv4-cidr-blocks" | grep -c '^10\..*' || true )
     DNS_CLUSTER_IP=10.100.0.10
     if [[ "$TEN_RANGE" != "0" ]]; then
-        DNS_CLUSTER_IP=172.20.0.10
+      DNS_CLUSTER_IP=172.20.0.10
     fi
+  fi
 else
-    DNS_CLUSTER_IP="${DNS_CLUSTER_IP}"
+  DNS_CLUSTER_IP="${DNS_CLUSTER_IP}"
 fi
 
 KUBELET_CONFIG=/etc/kubernetes/kubelet/kubelet-config.json
 echo "$(jq ".clusterDNS=[\"$DNS_CLUSTER_IP\"]" $KUBELET_CONFIG)" > $KUBELET_CONFIG
 
-INTERNAL_IP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/local-ipv4)
-INSTANCE_TYPE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-type)
+INTERNAL_IP=$(get_meta_data 'latest/meta-data/local-ipv4')
+INSTANCE_TYPE=$(get_meta_data 'latest/meta-data/instance-type')
 
 # Sets kubeReserved and evictionHard in /etc/kubernetes/kubelet/kubelet-config.json for worker nodes. The following two function
 # calls calculate the CPU and memory resources to reserve for kubeReserved based on the instance type of the worker node.
@@ -283,10 +366,10 @@ INSTANCE_TYPE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169
 #calculate the max number of pods per instance type
 MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
 set +o pipefail
-MAX_PODS=$(cat $MAX_PODS_FILE | awk "/^$INSTANCE_TYPE/"' { print $2 }')
+MAX_PODS=$(cat $MAX_PODS_FILE | awk "/^${INSTANCE_TYPE:-unset}/"' { print $2 }')
 set -o pipefail
-if [ -z "$MAX_PODS" ]; then
-    echo 'No entry for $INSTANCE_TYPE in $MAX_PODS_FILE'
+if [ -z "$MAX_PODS" ] || [ -z "$INSTANCE_TYPE" ]; then
+    echo "No entry for type '$INSTANCE_TYPE' in $MAX_PODS_FILE"
     exit 1
 fi
 
@@ -299,16 +382,14 @@ echo "$(jq --arg mebibytes_to_reserve "${mebibytes_to_reserve}Mi" --arg cpu_mill
     '. += {kubeReserved: {"cpu": $cpu_millicores_to_reserve, "ephemeral-storage": "1Gi", "memory": $mebibytes_to_reserve}}' $KUBELET_CONFIG)" > $KUBELET_CONFIG
 
 if [[ "$USE_MAX_PODS" = "true" ]]; then
-    if [[ -n "$MAX_PODS" ]]; then
-        echo "$(jq ".maxPods=$MAX_PODS" $KUBELET_CONFIG)" > $KUBELET_CONFIG
-    else
-        echo "No entry for $INSTANCE_TYPE in $MAX_PODS_FILE. Not setting max pods for kubelet"
-    fi
+    echo "$(jq ".maxPods=$MAX_PODS" $KUBELET_CONFIG)" > $KUBELET_CONFIG
 fi
+
+mkdir -p /etc/systemd/system/kubelet.service.d
 
 cat <<EOF > /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf
 [Service]
-Environment='KUBELET_ARGS=--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER'
+Environment='KUBELET_ARGS=--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER --v=2'
 EOF
 
 if [[ -n "$KUBELET_EXTRA_ARGS" ]]; then
@@ -318,19 +399,72 @@ Environment='KUBELET_EXTRA_ARGS=$KUBELET_EXTRA_ARGS'
 EOF
 fi
 
-# Replace with custom docker config contents.
-if [[ -n "$DOCKER_CONFIG_JSON" ]]; then
-    echo "$DOCKER_CONFIG_JSON" > /etc/docker/daemon.json
-    systemctl restart docker
+if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
+    sudo mkdir -p /etc/containerd
+    sudo mkdir -p /etc/cni/net.d
+    sudo mv /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml
+    sudo mv /etc/eks/containerd/kubelet-containerd.service /etc/systemd/system/kubelet.service
+    sudo chown root:root /etc/systemd/system/kubelet.service
+    systemctl daemon-reload
+    systemctl enable containerd
+    systemctl start containerd
+elif [[ "$CONTAINER_RUNTIME" = "dockerd" ]]; then
+    mkdir -p /etc/docker
+    bash -c "/sbin/iptables-save > /etc/sysconfig/iptables"
+    mv /etc/eks/iptables-restore.service /etc/systemd/system/iptables-restore.service
+    sudo chown root:root /etc/systemd/system/iptables-restore.service
+    systemctl daemon-reload
+    systemctl enable iptables-restore
+
+    if [[ -n "$DOCKER_CONFIG_JSON" ]]; then
+        echo "$DOCKER_CONFIG_JSON" > /etc/docker/daemon.json
+    fi
+    if [[ "$ENABLE_DOCKER_BRIDGE" = "true" ]]; then
+          # Enabling the docker bridge network. We have to disable live-restore as it
+          # prevents docker from recreating the default bridge network on restart
+          echo "$(jq '.bridge="docker0" | ."live-restore"=false' /etc/docker/daemon.json)" > /etc/docker/daemon.json
+    fi
+    systemctl daemon-reload
+    systemctl enable docker
+    systemctl start docker
+else
+    echo "Container runtime ${CONTAINER_RUNTIME} is not supported."
+    exit 1
 fi
 
-if [[ "$ENABLE_DOCKER_BRIDGE" = "true" ]]; then
-    # Enabling the docker bridge network. We have to disable live-restore as it
-    # prevents docker from recreating the default bridge network on restart
-    echo "$(jq '.bridge="docker0" | ."live-restore"=false' /etc/docker/daemon.json)" > /etc/docker/daemon.json
-    systemctl restart docker
-fi
 
-systemctl daemon-reload
 systemctl enable kubelet
 systemctl start kubelet
+
+# gpu boost clock
+if  command -v nvidia-smi &>/dev/null ; then
+   echo "nvidia-smi found"
+
+   nvidia-smi -q > /tmp/nvidia-smi-check
+   if [[ "$?" == "0" ]]; then
+      sudo nvidia-smi -pm 1 # set persistence mode
+      sudo nvidia-smi --auto-boost-default=0
+
+      GPUNAME=$(nvidia-smi -L | head -n1)
+      echo $GPUNAME
+
+      # set application clock to maximum
+      if [[ $GPUNAME == *"A100"* ]]; then
+         nvidia-smi -ac 1215,1410
+      elif [[ $GPUNAME == *"V100"* ]]; then
+         nvidia-smi -ac 877,1530
+      elif [[ $GPUNAME == *"K80"* ]]; then
+         nvidia-smi -ac 2505,875
+      elif [[ $GPUNAME == *"T4"* ]]; then
+         nvidia-smi -ac 5001,1590
+      elif [[ $GPUNAME == *"M60"* ]]; then
+         nvidia-smi -ac 2505,1177
+      else
+         echo "unsupported gpu"
+      fi
+   else
+      cat /tmp/nvidia-smi-check
+   fi
+else
+    echo "nvidia-smi not found"
+fi

--- a/files/containerd-config.toml
+++ b/files/containerd-config.toml
@@ -1,0 +1,16 @@
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[grpc]
+address = "/run/dockershim.sock"
+
+[plugins."io.containerd.grpc.v1.cri".containerd]
+default_runtime_name = "runc"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+runtime_type = "io.containerd.runc.v2"
+
+[plugins."io.containerd.grpc.v1.cri".cni]
+bin_dir = "/opt/cni/bin"
+conf_dir = "/etc/cni/net.d"

--- a/files/kubelet-containerd.service
+++ b/files/kubelet-containerd.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Kubernetes Kubelet
+Documentation=https://github.com/kubernetes/kubernetes
+After=containerd.service
+Requires=containerd.service
+
+[Service]
+ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
+ExecStart=/usr/bin/kubelet --cloud-provider aws \
+    --config /etc/kubernetes/kubelet/kubelet-config.json \
+    --kubeconfig /var/lib/kubelet/kubeconfig \
+    --container-runtime remote \
+    --container-runtime-endpoint unix:///run/dockershim.sock \
+    --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
+
+Restart=on-failure
+RestartForceExitStatus=SIGPIPE
+RestartSec=5
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -24,7 +24,8 @@ validate_env_set() {
 validate_env_set BINARY_BUCKET_NAME
 validate_env_set BINARY_BUCKET_REGION
 validate_env_set DOCKER_VERSION
-validate_env_set CNI_VERSION
+validate_env_set CONTAINERD_VERSION
+validate_env_set RUNC_VERSION
 validate_env_set CNI_PLUGIN_VERSION
 validate_env_set KUBERNETES_VERSION
 validate_env_set KUBERNETES_BUILD_DATE
@@ -63,7 +64,8 @@ sudo yum install -y \
     nfs-utils \
     socat \
     unzip \
-    wget
+    wget \
+    ipvsadm
 
 # Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
 if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi
@@ -93,14 +95,8 @@ fi
 ################################################################################
 ### iptables ###################################################################
 ################################################################################
-
-# Enable forwarding via iptables
-sudo bash -c "/sbin/iptables-save > /etc/sysconfig/iptables"
-
-sudo mv $TEMPLATE_DIR/iptables-restore.service /etc/systemd/system/iptables-restore.service
-
-sudo systemctl daemon-reload
-sudo systemctl enable iptables-restore
+sudo mkdir -p /etc/eks
+sudo mv $TEMPLATE_DIR/iptables-restore.service /etc/eks/iptables-restore.service
 
 ################################################################################
 ### Docker #####################################################################
@@ -111,8 +107,23 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
 if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo amazon-linux-extras enable docker
-    sudo groupadd -fog 1950 docker && sudo useradd --gid 1950 docker
+    sudo groupadd -fog 1950 docker
+    sudo useradd --gid $(getent group docker | cut -d: -f3) docker
+
+    # install version lock to put a lock on dependecies
+    sudo yum install -y yum-plugin-versionlock
+
+    # install runc and lock version
+    sudo yum install -y runc-${RUNC_VERSION}
+    sudo yum versionlock runc-*
+
+    # install containerd and lock version
+    sudo yum install -y containerd-${CONTAINERD_VERSION}
+    sudo yum versionlock containerd-*
+
+    # install docker and lock version
     sudo yum install -y docker-${DOCKER_VERSION}*
+    sudo yum versionlock docker-*
     sudo usermod -aG docker $USER
 
     # Remove all options from sysconfig docker.
@@ -124,8 +135,33 @@ if [[ "$INSTALL_DOCKER" == "true" ]]; then
 
     # Enable docker daemon to start on boot.
     sudo systemctl daemon-reload
-    sudo systemctl enable docker
 fi
+
+###############################################################################
+### Containerd setup ##########################################################
+###############################################################################
+
+sudo mkdir -p /etc/eks/containerd
+if [ -f "/etc/eks/containerd/containerd-config.toml" ]; then
+    ## this means we are building a gpu ami and have already placed a containerd configuration file in /etc/eks
+    echo "containerd config is already present"
+else 
+    sudo mv $TEMPLATE_DIR/containerd-config.toml /etc/eks/containerd/containerd-config.toml
+fi
+
+sudo mv $TEMPLATE_DIR/kubelet-containerd.service /etc/eks/containerd/kubelet-containerd.service
+
+cat <<EOF | sudo tee -a /etc/modules-load.d/containerd.conf
+overlay
+br_netfilter
+EOF
+
+cat <<EOF | sudo tee -a /etc/sysctl.d/99-kubernetes-cri.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+net.ipv4.ip_forward = 1
+EOF
+
 
 ################################################################################
 ### Logrotate ##################################################################
@@ -136,6 +172,7 @@ fi
 sudo mv $TEMPLATE_DIR/logrotate-kube-proxy /etc/logrotate.d/kube-proxy
 sudo mv $TEMPLATE_DIR/logrotate.conf /etc/logrotate.conf
 sudo chown root:root /etc/logrotate.d/kube-proxy
+sudo chown root:root /etc/logrotate.conf
 sudo mkdir -p /var/log/journal
 
 ################################################################################
@@ -151,6 +188,10 @@ echo "Downloading binaries from: s3://$BINARY_BUCKET_NAME"
 S3_DOMAIN="amazonaws.com"
 if [ "$BINARY_BUCKET_REGION" = "cn-north-1" ] || [ "$BINARY_BUCKET_REGION" = "cn-northwest-1" ]; then
     S3_DOMAIN="amazonaws.com.cn"
+elif [ "$BINARY_BUCKET_REGION" = "us-iso-east-1" ]; then
+    S3_DOMAIN="c2s.ic.gov"
+elif [ "$BINARY_BUCKET_REGION" = "us-isob-east-1" ]; then
+    S3_DOMAIN="sc2s.sgov.gov"
 fi
 S3_URL_BASE="https://$BINARY_BUCKET_NAME.s3.$BINARY_BUCKET_REGION.$S3_DOMAIN/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
 S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
@@ -160,7 +201,7 @@ BINARIES=(
     aws-iam-authenticator
 )
 for binary in ${BINARIES[*]} ; do
-    if [[ ! -z "$AWS_ACCESS_KEY_ID" ]]; then
+    if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
         echo "AWS cli present - using it to copy binaries from s3."
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
         aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
@@ -174,43 +215,31 @@ for binary in ${BINARIES[*]} ; do
     sudo mv $binary /usr/bin/
 done
 
+# Since CNI 0.7.0, all releases are done in the plugins repo.
+CNI_PLUGIN_FILENAME="cni-plugins-linux-${ARCH}-${CNI_PLUGIN_VERSION}"
+
 if [ "$PULL_CNI_FROM_GITHUB" = "true" ]; then
-    echo "Downloading CNI assets from Github"
-    wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-${ARCH}-${CNI_VERSION}.tgz
-    wget https://github.com/containernetworking/cni/releases/download/${CNI_VERSION}/cni-${ARCH}-${CNI_VERSION}.tgz.sha512
-
-    wget https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz
-    wget https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz.sha512
-    sudo sha512sum -c cni-${ARCH}-${CNI_VERSION}.tgz.sha512
-    sudo sha512sum -c cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz.sha512
-    rm cni-${ARCH}-${CNI_VERSION}.tgz.sha512
-    rm cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz.sha512
+    echo "Downloading CNI plugins from Github"
+    wget "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/${CNI_PLUGIN_FILENAME}.tgz"
+    wget "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/${CNI_PLUGIN_FILENAME}.tgz.sha512"
+    sudo sha512sum -c "${CNI_PLUGIN_FILENAME}.tgz.sha512"
+    rm "${CNI_PLUGIN_FILENAME}.tgz.sha512"
 else
-    CNI_BINARIES=(
-            cni-${ARCH}-${CNI_VERSION}.tgz
-            cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz
-    )
-    for binary in ${CNI_BINARIES[*]} ; do
-        if [[ ! -z "$AWS_ACCESS_KEY_ID" ]]; then
-            echo "AWS cli present - using it to copy binaries from s3."
-            aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
-            aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
-            sudo sha256sum -c $binary.sha256
-        else
-            echo "AWS cli missing - using wget to fetch cni binaries from s3. Note: This won't work for private bucket."
-            sudo wget $S3_URL_BASE/$binary
-            sudo wget $S3_URL_BASE/$binary.sha256
-        fi
-    done
+    if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+        echo "AWS cli present - using it to copy binaries from s3."
+        aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz .
+        aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz.sha256 .
+    else
+        echo "AWS cli missing - using wget to fetch cni binaries from s3. Note: This won't work for private bucket."
+        sudo wget "$S3_URL_BASE/${CNI_PLUGIN_FILENAME}.tgz"
+        sudo wget "$S3_URL_BASE/${CNI_PLUGIN_FILENAME}.tgz.sha256"
+    fi
+    sudo sha256sum -c "${CNI_PLUGIN_FILENAME}.tgz.sha256"
 fi
-sudo tar -xvf cni-${ARCH}-${CNI_VERSION}.tgz -C /opt/cni/bin
-sudo tar -xvf cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz -C /opt/cni/bin
-rm cni-${ARCH}-${CNI_VERSION}.tgz
-rm cni-plugins-${ARCH}-${CNI_PLUGIN_VERSION}.tgz
+sudo tar -xvf "${CNI_PLUGIN_FILENAME}.tgz" -C /opt/cni/bin
+rm "${CNI_PLUGIN_FILENAME}.tgz"
 
-sudo rm *.sha256
-
-KUBERNETES_MINOR_VERSION=${KUBERNETES_VERSION%.*}
+sudo rm ./*.sha256
 
 sudo mkdir -p /etc/kubernetes/kubelet
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
@@ -218,6 +247,12 @@ sudo mv $TEMPLATE_DIR/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
 sudo chown root:root /var/lib/kubelet/kubeconfig
 sudo mv $TEMPLATE_DIR/kubelet.service /etc/systemd/system/kubelet.service
 sudo chown root:root /etc/systemd/system/kubelet.service
+# Inject CSIServiceAccountToken feature gate to kubelet config if kubernetes version starts with 1.20.
+# This is only injected for 1.20 since CSIServiceAccountToken will be moved to beta starting 1.21.
+if [[ $KUBERNETES_VERSION == "1.20"* ]]; then
+    KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED=$(cat $TEMPLATE_DIR/kubelet-config.json | jq '.featureGates += {CSIServiceAccountToken: true}')
+    echo $KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED > $TEMPLATE_DIR/kubelet-config.json
+fi
 sudo mv $TEMPLATE_DIR/kubelet-config.json /etc/kubernetes/kubelet/kubelet-config.json
 sudo chown root:root /etc/kubernetes/kubelet/kubelet-config.json
 
@@ -234,6 +269,26 @@ sudo mkdir -p /etc/eks
 sudo mv $TEMPLATE_DIR/eni-max-pods.txt /etc/eks/eni-max-pods.txt
 sudo mv $TEMPLATE_DIR/bootstrap.sh /etc/eks/bootstrap.sh
 sudo chmod +x /etc/eks/bootstrap.sh
+
+SONOBUOY_E2E_REGISTRY="${SONOBUOY_E2E_REGISTRY:-}"
+if [[ -n "$SONOBUOY_E2E_REGISTRY" ]]; then
+    sudo mv $TEMPLATE_DIR/sonobuoy-e2e-registry-config /etc/eks/sonobuoy-e2e-registry-config
+    sudo sed -i s,SONOBUOY_E2E_REGISTRY,$SONOBUOY_E2E_REGISTRY,g /etc/eks/sonobuoy-e2e-registry-config
+fi
+
+################################################################################
+### SSM Agent ##################################################################
+################################################################################
+
+if [ "$BINARY_BUCKET_REGION" != "us-iso-east-1" ] && [ "$BINARY_BUCKET_REGION" != "us-isob-east-1" ]; then
+    if [ "$BINARY_BUCKET_REGION" = "cn-north-1" ] || [ "$BINARY_BUCKET_REGION" = "cn-northwest-1" ]; then
+        sudo yum install -y https://s3.cn-north-1.amazonaws.com.cn/amazon-ssm-cn-north-1/latest/linux_$ARCH/amazon-ssm-agent.rpm
+    else
+        sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_$ARCH/amazon-ssm-agent.rpm
+    fi
+
+    sudo systemctl enable amazon-ssm-agent
+fi
 
 ################################################################################
 ### AMI Metadata ###############################################################
@@ -260,33 +315,45 @@ kernel.panic_on_oops=1
 EOF
 
 ################################################################################
+### Setting up sysctl properties ###############################################
+################################################################################
+
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
+echo fs.inotify.max_user_instances=8192 | sudo tee -a /etc/sysctl.conf
+echo vm.max_map_count=524288 | sudo tee -a /etc/sysctl.conf
+
+
+################################################################################
 ### Cleanup ####################################################################
 ################################################################################
 
-# Clean up yum caches to reduce the image size
-sudo yum clean all
-sudo rm -rf \
-    $TEMPLATE_DIR  \
-    /var/cache/yum
+CLEANUP_IMAGE="${CLEANUP_IMAGE:-true}"
+if [[ "$CLEANUP_IMAGE" == "true" ]]; then
+    # Clean up yum caches to reduce the image size
+    sudo yum clean all
+    sudo rm -rf \
+        $TEMPLATE_DIR  \
+        /var/cache/yum
 
-# Clean up files to reduce confusion during debug
-sudo rm -rf \
-    /etc/hostname \
-    /etc/machine-id \
-    /etc/resolv.conf \
-    /etc/ssh/ssh_host* \
-    /home/ec2-user/.ssh/authorized_keys \
-    /root/.ssh/authorized_keys \
-    /var/lib/cloud/data \
-    /var/lib/cloud/instance \
-    /var/lib/cloud/instances \
-    /var/lib/cloud/sem \
-    /var/lib/dhclient/* \
-    /var/lib/dhcp/dhclient.* \
-    /var/lib/yum/history \
-    /var/log/cloud-init-output.log \
-    /var/log/cloud-init.log \
-    /var/log/secure \
-    /var/log/wtmp
+    # Clean up files to reduce confusion during debug
+    sudo rm -rf \
+        /etc/hostname \
+        /etc/machine-id \
+        /etc/resolv.conf \
+        /etc/ssh/ssh_host* \
+        /home/ec2-user/.ssh/authorized_keys \
+        /root/.ssh/authorized_keys \
+        /var/lib/cloud/data \
+        /var/lib/cloud/instance \
+        /var/lib/cloud/instances \
+        /var/lib/cloud/sem \
+        /var/lib/dhclient/* \
+        /var/lib/dhcp/dhclient.* \
+        /var/lib/yum/history \
+        /var/log/cloud-init-output.log \
+        /var/log/cloud-init.log \
+        /var/log/secure \
+        /var/log/wtmp
+fi
 
 sudo touch /etc/machine-id


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
changes done to add support for containerd runtime in eks worker ami. This is done by:
* Adding a new optional parameter to specify container-runtime in the bootstrap script.
* The default value of this parameter is `dockerd` to make it backward compatible to existing behavior.
* docker process wouldn't be running on the host when containerd runtime is choosen on the node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
