### PR TITLE
Adding that 1.21 GPU and ARM AMIs aren't in us-gov-west-1 and us-gov-east-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * amazon-eks-node-1.16-v20210716
 * amazon-eks-node-1.15-v20210716
 
-EKS AMI release for Kubernetes version 1.21.
+EKS AMI release for Kubernetes version 1.21 (1.21 AMIs for GPU and ARM in us-gov-west-1 and us-gov-east-1 aren't a part of this release)
 * Note: The containerd has patch for CVE-2-21-32760
 
 Containerd runtime support


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding that 1.21 GPU and ARM AMIs aren't in us-gov-west-1 and us-gov-east-1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
