### PR TITLE
Use systemd as the containerd cgroup driver

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -402,7 +402,7 @@ if [[ -z "${B64_CLUSTER_CA}" ]] || [[ -z "${APISERVER_ENDPOINT}" ]]; then
     else
         IS_LOCAL_OUTPOST_DETECTED=true
     fi
-    
+
     # If the cluster id is returned from describe cluster, let us use it no matter whether cluster id is passed from option
     if [[ ! -z "${CLUSTER_ID_IN_DESCRIBE_CLUSTER_RESULT}" ]] && [[ "${CLUSTER_ID_IN_DESCRIBE_CLUSTER_RESULT}" != "None" ]]; then
         CLUSTER_ID=${CLUSTER_ID_IN_DESCRIBE_CLUSTER_RESULT}
@@ -421,20 +421,20 @@ sed -i s,MASTER_ENDPOINT,$APISERVER_ENDPOINT,g /var/lib/kubelet/kubeconfig
 sed -i s,AWS_REGION,$AWS_DEFAULT_REGION,g /var/lib/kubelet/kubeconfig
 
 if [[ -z "$ENABLE_LOCAL_OUTPOST" ]]; then
-    # Only when "--enable-local-outpost" option is not set explicity on calling bootstrap.sh, it will be assigned with 
+    # Only when "--enable-local-outpost" option is not set explicity on calling bootstrap.sh, it will be assigned with
     #    - the result of auto-detectection through describe-cluster
     #    - or "false" when describe-cluster is bypassed.
     #  This also means if "--enable-local-outpost" option is set explicity, it will override auto-detection result
-    ENABLE_LOCAL_OUTPOST="${IS_LOCAL_OUTPOST_DETECTED:-false}"    
+    ENABLE_LOCAL_OUTPOST="${IS_LOCAL_OUTPOST_DETECTED:-false}"
 fi
 
-### To support worker nodes to continue to communicate and connect to local cluster even when the Outpost 
+### To support worker nodes to continue to communicate and connect to local cluster even when the Outpost
 ### is disconnected from the parent AWS Region, the following specific setup are required:
-###    - append entries to /etc/hosts with the mappings of control plane host IP address and API server 
+###    - append entries to /etc/hosts with the mappings of control plane host IP address and API server
 ###      domain name. So that the domain name can be resolved to IP addresses locally.
-###    - use aws-iam-authenticator as bootstrap auth for kubelet TLS bootstrapping which downloads client 
-###      X.509 certificate and generate kubelet kubeconfig file which uses the cleint cert. So that the 
-###      worker node can be authentiacated through X.509 certificate which works for both connected and 
+###    - use aws-iam-authenticator as bootstrap auth for kubelet TLS bootstrapping which downloads client
+###      X.509 certificate and generate kubelet kubeconfig file which uses the cleint cert. So that the
+###      worker node can be authentiacated through X.509 certificate which works for both connected and
 ####     disconnected state.
 if [[ "${ENABLE_LOCAL_OUTPOST}" == "true" ]]; then
     ### append to /etc/hosts file with shuffled mappings of "IP address to API server domain name"
@@ -547,6 +547,7 @@ EOF
     if [[ -n "$CONTAINERD_CONFIG_FILE" ]]; then
         sudo cp -v $CONTAINERD_CONFIG_FILE /etc/eks/containerd/containerd-config.toml
     fi
+    echo "$(jq '.cgroupDriver="systemd"' $KUBELET_CONFIG)" > $KUBELET_CONFIG
     sudo sed -i s,SANDBOX_IMAGE,$PAUSE_CONTAINER,g /etc/eks/containerd/containerd-config.toml
     sudo cp -v /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml
     sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service

--- a/files/containerd-config.toml
+++ b/files/containerd-config.toml
@@ -14,6 +14,9 @@ sandbox_image = "SANDBOX_IMAGE"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
 runtime_type = "io.containerd.runc.v2"
 
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+SystemdCgroup = true
+
 [plugins."io.containerd.grpc.v1.cri".cni]
 bin_dir = "/opt/cni/bin"
 conf_dir = "/etc/cni/net.d"


### PR DESCRIPTION
https://github.com/aws/containers-roadmap/issues/1210

*Description of changes:*
This PR sets systemd as the cgroup driver when using containerd, as recommended by the [Kubernetes docs](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#cgroup-drivers). This is complimentary to https://github.com/awslabs/amazon-eks-ami/pull/593 which adds support for the systemd cgroup driver to Docker but shouldn't be blocked by legacy `eksctl` constraints as containerd is newer than the systemd cgroup support there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
