### PR TITLE
containerd restart instead of start

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -411,7 +411,7 @@ if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
     sudo chown root:root /etc/systemd/system/kubelet.service
     systemctl daemon-reload
     systemctl enable containerd
-    systemctl start containerd
+    systemctl restart containerd
 elif [[ "$CONTAINER_RUNTIME" = "dockerd" ]]; then
     mkdir -p /etc/docker
     bash -c "/sbin/iptables-save > /etc/sysconfig/iptables"


### PR DESCRIPTION
*Issue #, if available:*  

*Description of changes:*

If containerd service is already started it doesn't pickup the config changes.  Similar to what this script already does for docker, replacing `systemctl start containerd` with `systemctl restart containerd`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
