### PR TITLE
Use default containerd socket path

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -412,6 +412,7 @@ if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
     sudo mv /etc/eks/containerd/kubelet-containerd.service /etc/systemd/system/kubelet.service
     sudo chown root:root /etc/systemd/system/kubelet.service
     sudo chown root:root /etc/systemd/system/sandbox-image.service
+    ln -sf /run/containerd/containerd.sock /run/dockershim.sock
     systemctl daemon-reload
     systemctl enable containerd
     systemctl restart containerd

--- a/files/containerd-config.toml
+++ b/files/containerd-config.toml
@@ -3,7 +3,7 @@ root = "/var/lib/containerd"
 state = "/run/containerd"
 
 [grpc]
-address = "/run/dockershim.sock"
+address = "/run/containerd/containerd.sock"
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
 default_runtime_name = "runc"

--- a/files/kubelet-containerd.service
+++ b/files/kubelet-containerd.service
@@ -10,7 +10,7 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime remote \
-    --container-runtime-endpoint unix:///run/dockershim.sock \
+    --container-runtime-endpoint unix:///run/containerd/containerd.sock \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
 Restart=on-failure


### PR DESCRIPTION
*Description of changes:*

The new containerd option as runtime uses `/run/dockershim.sock` as the path for the socket, that is very confusing for people migrating to containerd just because Kubernetes is deprecating dockershim.

But the main issue is that the containerd doesn't live in the default place where it's expected to be, and that breaks for example Datadog integration. Even if I supply the correct path to CRI socket it doesn't realise it's a containerd socket and therefore doesn't collect containerd metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
