### PR TITLE
Updating pull-sandbox-image.sh permission from 777 to +x. 

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -152,7 +152,7 @@ fi
 sudo mv $TEMPLATE_DIR/kubelet-containerd.service /etc/eks/containerd/kubelet-containerd.service
 sudo mv $TEMPLATE_DIR/sandbox-image.service /etc/eks/containerd/sandbox-image.service
 sudo mv $TEMPLATE_DIR/pull-sandbox-image.sh /etc/eks/containerd/pull-sandbox-image.sh
-sudo chmod 777 /etc/eks/containerd/pull-sandbox-image.sh
+sudo chmod +x /etc/eks/containerd/pull-sandbox-image.sh
 
 cat <<EOF | sudo tee -a /etc/modules-load.d/containerd.conf
 overlay


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We recently made a change and added 777 permission to pull-sandbox-image.sh script which seems un-necessary. Hence, fixing it in this CR. 

### Testing
* Can see updated permission 
```
-rwxr-xr-x 1 root root 886 Aug 25 19:59 pull-sandbox-image.sh
```

* sandbox-image service came up properly:
```
[ec2-user@ip-192-168-23-164 containerd]$ systemctl status sandbox-image
● sandbox-image.service - pull sandbox image defined in containerd config.toml
   Loaded: loaded (/etc/systemd/system/sandbox-image.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Wed 2021-08-25 20:35:42 UTC; 4min 7s ago
  Process: 3777 ExecStart=/etc/eks/containerd/pull-sandbox-image.sh (code=exited, status=0/SUCCESS)
 Main PID: 3777 (code=exited, status=0/SUCCESS)

Aug 25 20:35:42 ip-192-168-23-164.us-west-2.compute.internal pull-sandbox-image.sh[3777]: elapsed: 0.1 s                                                                 total:   0.0 B (0.0 B/s)
Aug 25 20:35:42 ip-192-168-23-164.us-west-2.compute.internal pull-sandbox-image.sh[3777]: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.1-eksbuild.1:            resolved       |++++++++++++++++++++++++++++++++++++++|
Aug 25 20:35:42 ip-192-168-23-164.us-west-2.compute.internal pull-sandbox-image.sh[3777]: index-sha256:1cb4ab85a3480446f9243178395e6bee7350f0d71296daeb6a9fdd221e23aea6:    exists         |++++++++++++++++++++++++++++++++++++++|
Aug 25 20:35:42 ip-192-168-23-164.us-west-2.compute.internal pull-sandbox-image.sh[3777]: manifest-sha256:234b8785dd78afc0fbb27edad009e7eb253e5685fb7387d4f0145f65c00873ac: done           |++++++++++++++++++++++++++++++++++++++|
Aug 25 20:35:42 ip-192-168-23-164.us-west-2.compute.internal pull-sandbox-image.sh[3777]: config-sha256:106a8e54d5eb3f70fcd1ed46255bdf232b3f169e89e68e13e4e67b25f59c1315:   done           |++++++++++++++++++++++++++++++++++++++|
Aug 25 20:35:42 ip-192-168-23-164.us-west-2.compute.internal pull-sandbox-image.sh[3777]: layer-sha256:41d8806bd3d23e1ffb7e9825fa56a0c2e851dfeeb405477ab1d6bc3a34bc0da2:    done           |++++++++++++++++++++++++++++++++++++++|
Aug 25 20:35:42 ip-192-168-23-164.us-west-2.compute.internal pull-sandbox-image.sh[3777]: elapsed: 0.2 s                                                                    total:   0.0 B (0.0 B/s)
Aug 25 20:35:42 ip-192-168-23-164.us-west-2.compute.internal pull-sandbox-image.sh[3777]: unpacking linux/amd64 sha256:1cb4ab85a3480446f9243178395e6bee7350f0d71296daeb6a9fdd221e23aea6...
Aug 25 20:35:42 ip-192-168-23-164.us-west-2.compute.internal pull-sandbox-image.sh[3777]: done
Aug 25 20:35:42 ip-192-168-23-164.us-west-2.compute.internal systemd[1]: Started pull sandbox image defined in containerd config.toml.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
