### PR TITLE
remove iptables from required

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -42,8 +42,6 @@ REQUIRED_UTILS=(
   tar
   date
   mkdir
-  iptables
-  iptables-save
   grep
   awk
   df
@@ -154,7 +152,7 @@ check_required_utils() {
   for utils in ${REQUIRED_UTILS[*]}; do
     # If exit code of "command -v" not equal to 0, fail
     if ! command -v "${utils}" >/dev/null 2>&1; then
-      die "Application \"${utils}\" is missing, please install \"${utils}\" as this script requires it, and will not function without it."
+      echo -e "\nApplication \"${utils}\" is missing, please install \"${utils}\" as this script requires it."
     fi
   done
 }
@@ -301,13 +299,16 @@ get_selinux_info() {
 }
 
 get_iptables_info() {
-  try "collect iptables information"
-
-  iptables --wait 1 --numeric --verbose --list --table mangle | tee "${COLLECT_DIR}"/networking/iptables-mangle.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-mangle.txt
-  iptables --wait 1 --numeric --verbose --list --table filter | tee "${COLLECT_DIR}"/networking/iptables-filter.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-filter.txt
-  iptables --wait 1 --numeric --verbose --list --table nat | tee "${COLLECT_DIR}"/networking/iptables-nat.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-nat.txt
-  iptables --wait 1 --numeric --verbose --list | tee "${COLLECT_DIR}"/networking/iptables.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables.txt
-  iptables-save > "${COLLECT_DIR}"/networking/iptables-save.txt
+  if ! command -v iptables >/dev/null 2>&1; then
+    echo "IPtables not installed" |tee -a iptables.txt
+  else
+    try "collect iptables information"
+    iptables --wait 1 --numeric --verbose --list --table mangle | tee "${COLLECT_DIR}"/networking/iptables-mangle.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-mangle.txt
+    iptables --wait 1 --numeric --verbose --list --table filter | tee "${COLLECT_DIR}"/networking/iptables-filter.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-filter.txt
+    iptables --wait 1 --numeric --verbose --list --table nat | tee "${COLLECT_DIR}"/networking/iptables-nat.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-nat.txt
+    iptables --wait 1 --numeric --verbose --list | tee "${COLLECT_DIR}"/networking/iptables.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables.txt
+    iptables-save > "${COLLECT_DIR}"/networking/iptables-save.txt
+  fi
 
   ok
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Remove iptables from required and echo that a required command is missing instead of killing the entire script. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

```
without iptables
[root@ip-10-0-2-19 ec2-user]# bash test.sh

Application "iptables" is missing, please install "iptables" as this script requires it.

Application "iptables-save" is missing, please install "iptables-save" as this script requires it.

	This is version 0.6.1. New versions can be found at https://github.com/awslabs/amazon-eks-ami/blob/master/log-collector-script/

Trying to collect common operating system logs...
Trying to collect kernel logs...
Trying to collect mount points and volume information...
Trying to collect SELinux status...

Trying to collect installed packages...
Trying to collect active system services...
Trying to collect Docker daemon information...

	Warning: The Docker daemon is not running.

Trying to collect kubelet information...
Trying to collect L-IPAMD introspectioon information... Trying to collect L-IPAMD prometheus metrics...
Trying to collect sysctls information...
Trying to collect networking infomation...
Trying to collect CNI configuration information... cp: cannot stat '/etc/cni/net.d/*': No such file or directory

Trying to collect Docker daemon logs...
Trying to archive gathered information...

	Done... your bundled logs are located in /var/log/eks_i-00fd8fe78c0731912_2021-08-26_2233-UTC_0.6.1.tar.gz
````	
```
with iptables
	This is version 0.6.1. New versions can be found at https://github.com/awslabs/amazon-eks-ami/blob/master/log-collector-script/

Trying to collect common operating system logs...
Trying to collect kernel logs...
Trying to collect mount points and volume information...
Trying to collect SELinux status...
Trying to collect iptables information...
Trying to collect installed packages...
Trying to collect active system services...
Trying to collect Docker daemon information...
Trying to collect kubelet information...
Trying to collect L-IPAMD introspectioon information... Trying to collect L-IPAMD prometheus metrics...
Trying to collect sysctls information...
Trying to collect networking infomation...
Trying to collect CNI configuration information...
Trying to collect Docker daemon logs...
Trying to archive gathered information...

	Done... your bundled logs are located in /var/log/eks_i-004aa62865dd17bd2_2021-08-26_2326-UTC_0.6.1.tar.gz
```
<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
