### PR TITLE
Added Log level Option

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -58,6 +58,11 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
+        --kubelet-log-level)
+            KUBELET_LOG_LEVEL=$2
+            shift
+            shift
+            ;;
         --enable-docker-bridge)
             ENABLE_DOCKER_BRIDGE=$2
             shift
@@ -393,7 +398,7 @@ mkdir -p /etc/systemd/system/kubelet.service.d
 
 cat <<EOF > /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf
 [Service]
-Environment='KUBELET_ARGS=--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER --v=2'
+Environment='KUBELET_ARGS=--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER --v=${KUBELET_LOG_LEVEL:-2}'
 EOF
 
 if [[ -n "$KUBELET_EXTRA_ARGS" ]]; then


### PR DESCRIPTION
*Issue #, if available:*

#733 

*Description of changes:*

Added Option to bootstrap.sh for setting the loglevel of kubelets. Defaults to 2 which was hard encoded before.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
