### PR TITLE
Updating eni-max-pods.txt

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-# This file was generated at 2021-06-08T13:46:17-07:00
+# This file was generated at 2021-08-31T18:22:52Z
 #
 # Mapping is calculated from AWS EC2 API using the following formula:
 # * First IP on each ENI is not used for pods
@@ -134,8 +134,10 @@ g3.4xlarge 234
 g3.8xlarge 234
 g3s.xlarge 58
 g4ad.16xlarge 234
+g4ad.2xlarge 8
 g4ad.4xlarge 29
 g4ad.8xlarge 58
+g4ad.xlarge 8
 g4dn.12xlarge 234
 g4dn.16xlarge 58
 g4dn.2xlarge 29
@@ -265,6 +267,15 @@ m6gd.large 29
 m6gd.medium 8
 m6gd.metal 737
 m6gd.xlarge 58
+m6i.12xlarge 234
+m6i.16xlarge 737
+m6i.24xlarge 737
+m6i.2xlarge 58
+m6i.32xlarge 737
+m6i.4xlarge 234
+m6i.8xlarge 234
+m6i.large 29
+m6i.xlarge 58
 mac1.metal 234
 p2.16xlarge 234
 p2.8xlarge 234


### PR DESCRIPTION
Generated using `make generate-limits`

https://github.com/aws/amazon-vpc-cni-k8s/blob/master/Makefile#L208-L210

*Description of changes:*
```
dev-dsk-abeers-2a-f754d54f % make generate-limits  
go run  scripts/gen_vpc_ip_limits.go
Adding "c5a.metal": {15 50 unkown} since it is missing from the API
Adding "c5ad.metal": {15 50 unkown} since it is missing from the API
Adding "u-12tb1.metal": {5 30 unkown} since it is missing from the API
Adding "u-24tb1.metal": {15 50 unkown} since it is missing from the API
Adding "u-9tb1.metal": {5 30 unkown} since it is missing from the API
Adding "u-6tb1.metal": {5 30 unkown} since it is missing from the API
Replacing API value {60 50 nitro} with override {15 50 unkown} for "p4d.24xlarge"
Adding "cr1.8xlarge": {8 30 unkown} since it is missing from the API
Adding "hs1.8xlarge": {8 30 unkown} since it is missing from the API
Adding "u-18tb1.metal": {15 50 unkown} since it is missing from the API
{"level":"info","ts":"2021-08-31T18:22:52.678Z","caller":"/usr/lib/golang/src/runtime/proc.go:204","msg":"Generated pkg/awsutils/vpc_ip_resource_limit.go"}
{"level":"info","ts":"2021-08-31T18:22:52.680Z","caller":"/usr/lib/golang/src/runtime/proc.go:204","msg":"Generated misc/eni-max-pods.txt"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
