### PR TITLE
Adds option to upgrade to 5.10 kernel

### DIFF
--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -27,6 +27,8 @@ if [[ $KERNEL_VERSION == "4.14" ]]; then
     sudo yum update -y kernel
 elif [[ $KERNEL_VERSION == "5.4" ]]; then
     sudo amazon-linux-extras install -y kernel-5.4
+elif [[ $KERNEL_VERSION == "5.10" ]]; then
+    sudo amazon-linux-extras install -y kernel-5.10
 else
     echo "$KERNEL_VERSION is not a valid kernel version"
     exit 1


### PR DESCRIPTION
*Description of changes:*

The 5.10 kernel is fully supported by AmazonLinux and is available for installation with `amazon-linux-extras`. I verified that the change works by building a 1.21 AMI and setting `kernel_version` to 0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
