### PR TITLE
Updates 1.19+ kubernetes build date in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,12 @@ k8s: validate
 
 .PHONY: 1.19
 1.19:
-	$(MAKE) k8s kubernetes_version=1.19.13 kubernetes_build_date=2021-09-02 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.19.14 kubernetes_build_date=2021-10-12 pull_cni_from_github=true
 
 .PHONY: 1.20
 1.20:
-	$(MAKE) k8s kubernetes_version=1.20.7 kubernetes_build_date=2021-09-02 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.20.10 kubernetes_build_date=2021-10-12 pull_cni_from_github=true
 
 .PHONY: 1.21
 1.21:
-	$(MAKE) k8s kubernetes_version=1.21.2 kubernetes_build_date=2021-09-02 pull_cni_from_github=true	
+	$(MAKE) k8s kubernetes_version=1.21.4 kubernetes_build_date=2021-10-12 pull_cni_from_github=true


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Updates the kubernetes build data and version for versions 1.19+. I will wait for the binaries to be released before merging this PR as they are not currently released, which is targeted for 10/12/21. They include [this PR](https://github.com/kubernetes/kubernetes/pull/102576), which is expected to resolve a known issue around unmount failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
