### PR TITLE
Remove 1.16 from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.16 1.17 1.18 1.19 1.20 1.21
+all: 1.17 1.18 1.19 1.20 1.21
 
 .PHONY: validate
 validate:
@@ -42,10 +42,6 @@ k8s: validate
 
 # Build dates and versions taken from https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 
-
-.PHONY: 1.16
-1.16:
-	$(MAKE) k8s kubernetes_version=1.16.15 kubernetes_build_date=2021-09-02 pull_cni_from_github=true
 
 .PHONY: 1.17
 1.17:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I'm removing 1.16 from the Makefile since EKS no longer supports that Kubernetes version. See https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html for more details.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
