### PR TITLE
Implement --containerd-extra-config-toml in bootstrap.sh

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -23,6 +23,7 @@ function print_help {
     echo "--enable-docker-bridge Restores the docker default bridge network. (default: false)"
     echo "--aws-api-retry-attempts Number of retry attempts for AWS API call (DescribeCluster) (default: 3)"
     echo "--docker-config-json The contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI"
+    echo "--containerd-extra-config-toml Extra configuration to append to the containerd configuration. Useful if you want a custom config differing from the default one in the AMI"
     echo "--dns-cluster-ip Overrides the IP address to use for DNS queries within the cluster. Defaults to 10.100.0.10 or 172.20.0.10 based on the IP address of the primary interface"
     echo "--pause-container-account The AWS account (number) to pull the pause container from"
     echo "--pause-container-version The tag of the pause container"
@@ -72,6 +73,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         --docker-config-json)
             DOCKER_CONFIG_JSON=$2
+            shift
+            shift
+            ;;
+        --containerd-extra-config-toml)
+            CONTAINERD_EXTRA_CONFIG_TOML=$2
             shift
             shift
             ;;
@@ -126,6 +132,7 @@ KUBELET_EXTRA_ARGS="${KUBELET_EXTRA_ARGS:-}"
 ENABLE_DOCKER_BRIDGE="${ENABLE_DOCKER_BRIDGE:-false}"
 API_RETRY_ATTEMPTS="${API_RETRY_ATTEMPTS:-3}"
 DOCKER_CONFIG_JSON="${DOCKER_CONFIG_JSON:-}"
+CONTAINERD_EXTRA_CONFIG_TOML="${CONTAINERD_EXTRA_CONFIG_TOML:-}"
 PAUSE_CONTAINER_VERSION="${PAUSE_CONTAINER_VERSION:-3.1-eksbuild.1}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-dockerd}"
 IP_FAMILY="${IP_FAMILY:-}"
@@ -471,6 +478,9 @@ if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
 [Service]
 ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
 EOF
+    if [[ -n "$CONTAINERD_EXTRA_CONFIG_TOML" ]]; then
+        echo "$CONTAINERD_EXTRA_CONFIG_TOML" >> /etc/eks/containerd/containerd-config.toml
+    fi
     sudo sed -i s,SANDBOX_IMAGE,$PAUSE_CONTAINER,g /etc/eks/containerd/containerd-config.toml
     sudo cp -v /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml
     sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service


### PR DESCRIPTION
This flag allows to pass extra configuration for containerd, which is
appended to /etc/containerd/config.toml. This allows to specify things
like mirros/pull-through-caches without interfering with the EKS provided
config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
