### PR TITLE
Include max-pods-calculator.sh in image

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -272,6 +272,8 @@ sudo mkdir -p /etc/eks
 sudo mv $TEMPLATE_DIR/eni-max-pods.txt /etc/eks/eni-max-pods.txt
 sudo mv $TEMPLATE_DIR/bootstrap.sh /etc/eks/bootstrap.sh
 sudo chmod +x /etc/eks/bootstrap.sh
+sudo mv $TEMPLATE_DIR/max-pods-calculator.sh /etc/eks/max-pods-calculator.sh
+sudo chmod +x /etc/eks/max-pods-calculator.sh
 
 SONOBUOY_E2E_REGISTRY="${SONOBUOY_E2E_REGISTRY:-}"
 if [[ -n "$SONOBUOY_E2E_REGISTRY" ]]; then


### PR DESCRIPTION
resolves #750

**Include max-pods-calculator.sh**

Currently we have a hard-coded map between instance-type and max pods. Having this very useful script present in the AMI would enable us to automate this calculation in user-data.

This PR simply makes the script _available_ for use in custom user-data scripts. It's not an attempt to automate usage of it, though that may be an interesting idea later.

As noted in #750, it's not really acceptable for us to download it from Github using curl at provision time when it could simply be baked into the AMI.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

