### PR TITLE
Remove 1.17.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.17 1.18 1.19 1.20 1.21
+all: 1.18 1.19 1.20 1.21
 
 .PHONY: validate
 validate:
@@ -41,10 +41,6 @@ k8s: validate
 	$(PACKER_BINARY) build $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
 
 # Build dates and versions taken from https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
-
-.PHONY: 1.17
-1.17:
-	$(MAKE) k8s kubernetes_version=1.17.17 kubernetes_build_date=2021-09-02 pull_cni_from_github=true
 
 .PHONY: 1.18
 1.18:


### PR DESCRIPTION
*Description of changes:*

This removes 1.17, as support for this version ended on November 2, 2021. [Learn more about Kubernetes version support for EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.