### PR TITLE
Adds basic uname validation based on kernel version passed in

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -163,7 +163,10 @@
     {
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
-      "script": "{{template_dir}}/scripts/validate.sh"
+      "script": "{{template_dir}}/scripts/validate.sh",
+      "environment_vars": [
+        "KERNEL_VERSION={{user `kernel_version`}}"
+      ]
     }
   ],
   "post-processors": [

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -34,3 +34,14 @@ validate_file_nonexists '/var/log/cloud-init-output.log'
 validate_file_nonexists '/var/log/cloud-init.log'
 validate_file_nonexists '/var/log/secure'
 validate_file_nonexists '/var/log/wtmp'
+
+actual_kernel=$(uname -r)
+echo "Verifying that kernel version $actual_kernel matches $KERNEL_VERSION"
+
+if [[ $actual_kernel == $KERNEL_VERSION* ]]
+then
+    echo "Kernel matches expected version"
+else
+    echo "Kernel does not match expected version."
+    exit 1
+fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Resolves #817 by verifying that if kernel version is set, the actual kernel version matches that.

Tested the following scenarios:
1. `make 1.18`, no kernel version set -> builds with 4.14, but no validation because kernel not explicitly set
2. `make 1.21`, no kernel version set -> builds with 5.4, but no validation because kernel not explicitly set
3. `make 1.18` kernel version set to 4.14 -> passes
3. `make 1.18`, set 5.10 kernel as base AMI, kernel version set to 4.14 -> fails due to validation error
4. `make 1.21`, set kernel to 5.4 -> passes
5. `make 1.21`, set 5.10 kernel as base, kernel version to 5.4, commented up attempt to upgrade to 5.4 -> fails due to new validation error.

One rough edge here is that we have k8s version specific knowledge in the [upgrade kernel script](https://github.com/awslabs/amazon-eks-ami/blob/master/scripts/upgrade_kernel.sh), and this validation doesn't do any checks based on what that does. However, I didn't want to duplicate the logic here and consider it sufficient to only guarantee that if you explicitly pass in a kernel version, the build will fail if it doesn't match that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
