### PR TITLE
Use default containerd address in pull-sandbox-image.sh

### DIFF
--- a/files/pull-sandbox-image.sh
+++ b/files/pull-sandbox-image.sh
@@ -13,7 +13,7 @@ for attempt in `seq 0 $API_RETRY_ATTEMPTS`; do
     fi
 	### pull sandbox image from ecr
 	### username will always be constant i.e; AWS
-	sudo ctr --address=/run/dockershim.sock --namespace k8s.io image pull $sandbox_image --user AWS:$ecr_password
+	sudo ctr --namespace k8s.io image pull $sandbox_image --user AWS:$ecr_password
 	rc=$?;
 	if [[ $rc -eq 0 ]]; then
 		break


### PR DESCRIPTION
*Issue #, if available:*

Fixes #784.

*Description of changes:*

Remove explicit containerd address in `pull-sandbox-image.sh`, causing default `/run/containerd/containerd.sock` to be used. For future reference, this is also configurable via `$CONTAINERD_ADDRESS`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.