### PR TITLE
fix bug for the permission of  /etc/logrotate.conf 

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -184,6 +184,7 @@ sudo mv $TEMPLATE_DIR/logrotate-kube-proxy /etc/logrotate.d/kube-proxy
 sudo mv $TEMPLATE_DIR/logrotate.conf /etc/logrotate.conf
 sudo chown root:root /etc/logrotate.d/kube-proxy
 sudo chown root:root /etc/logrotate.conf
+sudo chmod 644 /etc/logrotate.conf
 sudo mkdir -p /var/log/journal
 
 ################################################################################


### PR DESCRIPTION
permission of  /etc/logrotate.conf  is not right, which result in fail for all logrotate

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
