### PR TITLE
Update eni-max-pods.txt

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-# This file was generated at 2021-12-06T09:52:52-08:00
+# This file was generated at 2022-02-03T21:54:42Z
 #
 # Mapping is calculated from AWS EC2 API using the following formula:
 # * First IP on each ENI is not used for pods
@@ -491,6 +491,12 @@ x2gd.large 29
 x2gd.medium 8
 x2gd.metal 737
 x2gd.xlarge 58
+x2iezn.12xlarge 737
+x2iezn.2xlarge 58
+x2iezn.4xlarge 234
+x2iezn.6xlarge 234
+x2iezn.8xlarge 234
+x2iezn.metal 737
 z1d.12xlarge 737
 z1d.2xlarge 58
 z1d.3xlarge 234

--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -11,7 +11,31 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-# This file was generated at 2022-02-03T21:54:42Z
+# This file was generated at 2022-02-03T16:29:41-08:00
+#
+# The regions queried were:
+# - af-south-1
+# - ap-east-1
+# - ap-northeast-1
+# - ap-northeast-2
+# - ap-northeast-3
+# - ap-south-1
+# - ap-southeast-1
+# - ap-southeast-2
+# - ap-southeast-3
+# - ca-central-1
+# - eu-central-1
+# - eu-north-1
+# - eu-south-1
+# - eu-west-1
+# - eu-west-2
+# - eu-west-3
+# - me-south-1
+# - sa-east-1
+# - us-east-1
+# - us-east-2
+# - us-west-1
+# - us-west-2
 #
 # Mapping is calculated from AWS EC2 API using the following formula:
 # * First IP on each ENI is not used for pods
@@ -174,6 +198,7 @@ h1.16xlarge 737
 h1.2xlarge 58
 h1.4xlarge 234
 h1.8xlarge 234
+hpc6a.48xlarge 100
 hs1.8xlarge 234
 i2.2xlarge 58
 i2.4xlarge 234


### PR DESCRIPTION
*Description of changes:*

Update `eni-max-pods.txt` using the `generate-limits` target on [amazon-vpc-cni-k8s/Makefile](https://github.com/aws/amazon-vpc-cni-k8s/blob/f1728c5fd382ff31f2433a59ba09ce4ae1bb3c98/Makefile)

```sh
dev-dsk-mckdev-2b-f4db609f % make generate-limits
go run  scripts/gen_vpc_ip_limits.go
Adding "u-18tb1.metal": {15 50 unknown} since it is missing from the API
Adding "u-24tb1.metal": {15 50 unknown} since it is missing from the API
Adding "u-6tb1.metal": {5 30 unknown} since it is missing from the API
Adding "c5a.metal": {15 50 unknown} since it is missing from the API
Replacing API value {60 50 nitro} with override {15 50 unknown} for "p4d.24xlarge"
Replacing API value {60 50 nitro} with override {15 50 unknown} for "dl1.24xlarge"
Adding "cr1.8xlarge": {8 30 unknown} since it is missing from the API
Adding "hs1.8xlarge": {8 30 unknown} since it is missing from the API
Adding "c5ad.metal": {15 50 unknown} since it is missing from the API
Adding "u-12tb1.metal": {5 30 unknown} since it is missing from the API
Adding "u-9tb1.metal": {5 30 unknown} since it is missing from the API
{"level":"info","ts":"2022-02-03T21:54:42.312Z","caller":"/usr/lib/golang/src/runtime/proc.go:204","msg":"Generated pkg/awsutils/vpc_ip_resource_limit.go"}
{"level":"info","ts":"2022-02-03T21:54:42.314Z","caller":"/usr/lib/golang/src/runtime/proc.go:204","msg":"Generated misc/eni-max-pods.txt"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.