### PR TITLE
DNS_CLUSTER_IP cannot be specified in IPv6 Cluster

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -385,7 +385,7 @@ MAC=$(get_meta_data 'latest/meta-data/network/interfaces/macs/' | head -n 1 | se
 if [[ -z "${DNS_CLUSTER_IP}" ]]; then
   if [[ "${IP_FAMILY}" == "ipv6" ]]; then
     if [[ -z "${SERVICE_IPV6_CIDR}" ]]; then
-      echo "Service Ipv6 Cidr must be provided when ip-family is specified as IPV6"
+      echo "Either --service-ipv6-cidr or --cluster-dns-ip must be provided when --ip-family is set to ipv6"
       exit 1
     fi
     DNS_CLUSTER_IP=$(awk -F/ '{print $1}' <<< $SERVICE_IPV6_CIDR)a

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -299,11 +299,6 @@ if [[ ! -z "${IP_FAMILY}" ]]; then
         echo "Invalid IpFamily. Only ipv4 or ipv6 are allowed"
         exit 1
   fi
-
-  if [[ "${IP_FAMILY}" == "ipv6" ]] && [[ ! -z "${B64_CLUSTER_CA}" ]] && [[ ! -z "${APISERVER_ENDPOINT}" ]] && [[ -z "${SERVICE_IPV6_CIDR}" ]]; then
-        echo "Service Ipv6 Cidr must be provided when ip-family is specified as IPV6"
-        exit 1
-  fi
 fi
 
 if [[ ! -z "${SERVICE_IPV6_CIDR}" ]]; then
@@ -385,13 +380,17 @@ sed -i s,MASTER_ENDPOINT,$APISERVER_ENDPOINT,g /var/lib/kubelet/kubeconfig
 sed -i s,AWS_REGION,$AWS_DEFAULT_REGION,g /var/lib/kubelet/kubeconfig
 ### kubelet.service configuration
 
-if [[ "${IP_FAMILY}" == "ipv6" ]]; then
-      DNS_CLUSTER_IP=$(awk -F/ '{print $1}' <<< $SERVICE_IPV6_CIDR)a
-fi
-
 MAC=$(get_meta_data 'latest/meta-data/network/interfaces/macs/' | head -n 1 | sed 's/\/$//')
 
 if [[ -z "${DNS_CLUSTER_IP}" ]]; then
+  if [[ "${IP_FAMILY}" == "ipv6" ]]; then
+    if [[ -z "${SERVICE_IPV6_CIDR}" ]]; then
+      echo "Service Ipv6 Cidr must be provided when ip-family is specified as IPV6"
+      exit 1
+    fi
+    DNS_CLUSTER_IP=$(awk -F/ '{print $1}' <<< $SERVICE_IPV6_CIDR)a
+  fi
+
   if [[ ! -z "${SERVICE_IPV4_CIDR}" ]] && [[ "${SERVICE_IPV4_CIDR}" != "None" ]] ; then
     #Sets the DNS Cluster IP address that would be chosen from the serviceIpv4Cidr. (x.y.z.10)
     DNS_CLUSTER_IP=${SERVICE_IPV4_CIDR%.*}.10


### PR DESCRIPTION
*Description of changes:*

`DNS_CLUSTER_IP` isn't recognized in a IPv6 cluster. It is fixed to the IP from `SERVICE_IPV6_CIDR`.

The PR enables setting `DNS_CLUSTER_IP` or `--dns-cluster-ip` in IPv6 env.