### PR TITLE
Remove chacha20 from cipher list, to support FIPS.

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -97,7 +97,7 @@ fi
 ################################################################################
 
 # Disable weak ciphers
-echo -e "\nCiphers chacha20-poly1305@openssh.com,aes128-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com" | sudo tee -a /etc/ssh/sshd_config
+echo -e "\nCiphers aes128-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com" | sudo tee -a /etc/ssh/sshd_config
 sudo systemctl restart sshd.service
 
 ################################################################################


### PR DESCRIPTION
*Description of changes:*

This removes `chacha20-poly1305@openssh.com` from the cipher list, because it is not FIPS-compliant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.