### PR TITLE
Use kernel 5.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ templates in the same bucket under the path `s3://amazon-eks/1.10.3/2018-06-05/`
 
 By default, the `amazon-eks-ami` uses a [source_ami_filter](https://github.com/awslabs/amazon-eks-ami/blob/e3f1b910f83ad1f27e68312e50474ea6059f052d/eks-worker-al2.json#L46) that selects the latest [hvm](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html) AL2 AMI for the given architecture as the base AMI. For more information on what kernel versions are running on published Amazon EKS optimized Linux AMIs, see [the public documentation](https://docs.aws.amazon.com/eks/latest/userguide/eks-linux-ami-versions.html).
 
-When building an AMI, you can set the `kernel_version` to `4.14` or `5.4` to customize the kernel version. The [upgrade_kernel.sh script](https://github.com/awslabs/amazon-eks-ami/blob/master/scripts/upgrade_kernel.sh#L26) contains the logic for updating and upgrading the kernel. For Kubernetes versions 1.18 and below, it uses the `4.14` kernel if not set, and it will install the latest patches. For Kubernetes version 1.19 and above, it uses the `5.4` kernel if not set.
+When building an AMI, you can set the `kernel_version` to `4.14`, `5.4` or `5.10` to customize the kernel version. The [upgrade_kernel.sh script](https://github.com/awslabs/amazon-eks-ami/blob/master/scripts/upgrade_kernel.sh#L26) contains the logic for updating and upgrading the kernel. For Kubernetes versions 1.18 and below, it uses the `4.14` kernel if not set, and it will install the latest patches. For Kubernetes version 1.19 and above, it uses the `5.4` kernel if not set. For Kubernetes version 1.22 and above, it uses the `5.10` kernel if not set.
 
 ## Security
 

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -16,8 +16,10 @@ if [[ -z "$KERNEL_VERSION" ]]; then
 
     if (( ADDR[0] == 1 && ADDR[1] < 19 )); then
         KERNEL_VERSION=4.14
-    else
+    elif (( ADDR[0] == 1 && ADDR[1] < 22 )); then
         KERNEL_VERSION=5.4
+    else
+        KERNEL_VERSION=5.10
     fi
 
     echo "kernel_version is unset. Setting to $KERNEL_VERSION based on kubernetes_version $KUBERNETES_VERSION"


### PR DESCRIPTION
*Issue #, if available:*
#857 

*Description of changes:*
Upgrade kernel version to 5.10 for kubernetes version above ~~1.19~~ 1.22.
It's useful for wireguard transparent encryption, it also includes performance improvements for Intel Ice Lake processors and AWS Graviton2 processors.

More details [here](https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-linux-2-ami-kernel-5-10/?nc1=h_ls)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
