### PR TITLE
Downgrade and lock ec2-utils at 1.2-45 until 1.2-47 is available.

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -59,13 +59,18 @@ sudo yum install -y \
     chrony \
     conntrack \
     curl \
-    jq \
     ec2-instance-connect \
+    ipvsadm \
+    jq \
     nfs-utils \
     socat \
     unzip \
     wget \
-    ipvsadm
+    yum-plugin-versionlock
+
+# Downgrade and lock ec2-utils until 1.2-47 is available: https://github.com/aws/amazon-ec2-utils/issues/22
+sudo yum downgrade -y ec2-utils-1.2-45.amzn2.noarch
+sudo yum versionlock ec2-utils-*
 
 # Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
 if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi
@@ -117,9 +122,6 @@ if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo amazon-linux-extras enable docker
     sudo groupadd -fog 1950 docker
     sudo useradd --gid $(getent group docker | cut -d: -f3) docker
-
-    # install version lock to put a lock on dependecies
-    sudo yum install -y yum-plugin-versionlock
 
     # install runc and lock version
     sudo yum install -y runc-${RUNC_VERSION}


### PR DESCRIPTION
*Description of changes:*

`ec2-utils-1.2.46` introduced a bug related to device symlinks, in which some nvme devices would not have standard symlinks properly maintained. Our latest AMI (`v20220210` at the time of writing) includes this version of `ec2-utils`.

This change downgrades this AMI to `ec2-utils-1.2-45` and locks the version. We'll need to remove this patch once `ec2-utils-1.2-47` is available.

More info available here: https://github.com/aws/amazon-ec2-utils/issues/22

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.