### PR TITLE
Added logic to collect logs on bottlerocket AMI

### DIFF
--- a/log-collector-script/linux/eks-bottlerocket-log-collector.sh
+++ b/log-collector-script/linux/eks-bottlerocket-log-collector.sh
@@ -1,0 +1,74 @@
+export LANG="C"
+export LC_ALL="C"
+
+# Global options
+BOTTLEROCKET_ROOTFS="/.bottlerocket/rootfs"
+readonly CURRENT_TIME=$(date --utc +%Y-%m-%d_%H%M-%Z)
+readonly PROGRAM_VERSION="0.6.2"
+readonly LOG_DIR="/var/log"
+INSTANCE_ID=""
+
+BOTTLEROCKET_UTILS=(
+  tar 
+)
+
+is_diskfull() {
+  local threshold
+  local result
+
+  # 1.5GB in KB
+  threshold=1500000
+  result=$(df / | grep --invert-match "Filesystem" | awk '{ print $4 }')
+
+  # If "result" is less than or equal to "threshold", fail.
+  if [[ "${result}" -le "${threshold}" ]]; then
+    die "Free space on root volume is less than or equal to $((threshold>>10))MB, please ensure adequate disk space to collect and store the log files."
+  fi
+}
+
+collect_logs_bottlerocket() {
+  echo "Fetching INSTANCE_ID"
+  readonly INSTANCE_ID=$(curl --max-time 10 --retry 5 http://169.254.169.254/latest/meta-data/instance-id)
+  if [ 0 -eq $? ]; then # Check if previous command was successful.
+    echo "${INSTANCE_ID}"
+  else
+    warning "Unable to find EC2 Instance Id. Skipped Instance Id."
+  fi
+  
+  if [ ! -d "${BOTTLEROCKET_ROOTFS}/tmp/ekslogs" ]; then
+     echo "Creating ekslogs directory"
+     mkdir ${BOTTLEROCKET_ROOTFS}/tmp/ekslogs
+  fi
+
+  for utils in ${BOTTLEROCKET_UTILS[*]}; do
+    # If exit code of "command -v" not equal to 0, fail
+    if ! command -v "${utils}" >/dev/null 2>&1; then
+       echo -e "\nApplication \"${utils}\" is missing, will install \"${utils}\"."
+       sudo yum install -y "${utils}"
+    fi
+  done
+
+  cp ${BOTTLEROCKET_ROOTFS}/var/log/aws-routed-eni/* ${BOTTLEROCKET_ROOTFS}/tmp/ekslogs/
+  sudo sheltie logdog
+  sudo sheltie cp /var/log/support/bottlerocket-logs.tar.gz /tmp/ekslogs
+  tar -cvzf "${LOG_DIR}"/eks_"${INSTANCE_ID}"_"${CURRENT_TIME}"_"${PROGRAM_VERSION}".tar.gz "${BOTTLEROCKET_ROOTFS}"/tmp/ekslogs > /dev/null 2>&1
+}
+
+finished() {
+  cleanup
+  echo -e "\n\tDone... your bundled logs are located in ${LOG_DIR}/eks_${INSTANCE_ID}_${CURRENT_TIME}_${PROGRAM_VERSION}.tar.gz\n"
+}
+
+cleanup() {
+  # bottlerocket AMI
+  if [ -d "/.bottlerocket/" ]; then
+    rm --recursive --force {BOTTLEROCKET_ROOTFS}/tmp/ekslogs > /dev/null 2>&1  
+  else
+    echo "Unable to Cleanup as {COLLECT_DIR} variable is modified. Please cleanup manually!"
+  fi
+}
+
+echo "Detected Bottlerocket AMI"
+is_diskfull
+collect_logs_bottlerocket
+finished

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -28,6 +28,7 @@ readonly LOG_DIR="/var/log"
 readonly COLLECT_DIR="/tmp/eks-log-collector"
 readonly CURRENT_TIME=$(date --utc +%Y-%m-%d_%H%M-%Z)
 readonly DAYS_10=$(date -d "-10 days" '+%Y-%m-%d %H:%M')
+BOTTLEROCKET_ROOTFS="/.bottlerocket/rootfs"
 INSTANCE_ID=""
 INIT_TYPE=""
 PACKAGE_TYPE=""
@@ -223,8 +224,11 @@ is_diskfull() {
 }
 
 cleanup() {
+  # bottlerocket AMI
+  if [ -d "/.bottlerocket/" ]; then
+    rm --recursive --force {BOTTLEROCKET_ROOTFS}/tmp/ekslogs > /dev/null 2>&1  
   #guard rails to avoid accidental deletion of unknown data
-  if [[ "${COLLECT_DIR}" == "/tmp/eks-log-collector" ]]; then
+  elif [[ "${COLLECT_DIR}" == "/tmp/eks-log-collector" ]]; then
     rm --recursive --force "${COLLECT_DIR}" >/dev/null 2>&1
   else
     echo "Unable to Cleanup as {COLLECT_DIR} variable is modified. Please cleanup manually!"
@@ -279,9 +283,17 @@ finished() {
 }
 
 collect_logs_bottlerocket() {
-  if [ ! -d "/.bottlerocket/rootfs/tmp/ekslogs" ]; then
+  echo "Fetching INSTANCE_ID"
+  readonly INSTANCE_ID=$(curl --max-time 10 --retry 5 http://169.254.169.254/latest/meta-data/instance-id)
+  if [ 0 -eq $? ]; then # Check if previous command was successful.
+    echo "${INSTANCE_ID}"
+  else
+    warning "Unable to find EC2 Instance Id. Skipped Instance Id."
+  fi
+  
+  if [ ! -d "${BOTTLEROCKET_ROOTFS}/tmp/ekslogs" ]; then
      echo "Creating ekslogs directory"
-     mkdir /.bottlerocket/rootfs/tmp/ekslogs
+     mkdir ${BOTTLEROCKET_ROOTFS}/tmp/ekslogs
   fi
 
   for utils in ${BOTTLEROCKET_UTILS[*]}; do
@@ -292,13 +304,10 @@ collect_logs_bottlerocket() {
     fi
   done
 
-  rootfs=/.bottlerocket/rootfs
-  cp ${rootfs}/var/log/aws-routed-eni/* ${rootfs}/tmp/ekslogs/
+  cp ${BOTTLEROCKET_ROOTFS}/var/log/aws-routed-eni/* ${BOTTLEROCKET_ROOTFS}/tmp/ekslogs/
   sudo sheltie logdog
   sudo sheltie cp /var/log/support/bottlerocket-logs.tar.gz /tmp/ekslogs
-  cd ${rootfs}/tmp/
-  tar -cvzf full-logs.tar.gz ${rootfs}/tmp/ekslogs
-  echo "Redirecting logs at ${rootfs}/tmp/full-logs.tar.gz"
+  tar -cvzf "${LOG_DIR}"/eks_"${INSTANCE_ID}"_"${CURRENT_TIME}"_"${PROGRAM_VERSION}".tar.gz "${BOTTLEROCKET_ROOTFS}"/tmp/ekslogs > /dev/null 2>&1
 }
 
 get_mounts_info() {
@@ -617,7 +626,9 @@ parse_options "$@"
 
 if [ -d "/.bottlerocket/" ]; then
   echo "Detected Bottlerocket AMI"
+  is_diskfull
   collect_logs_bottlerocket
+  finished
 else 
   collect
   pack

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -298,6 +298,7 @@ collect_logs_bottlerocket() {
   sudo sheltie cp /var/log/support/bottlerocket-logs.tar.gz /tmp/ekslogs
   cd ${rootfs}/tmp/
   tar -cvzf full-logs.tar.gz ${rootfs}/tmp/ekslogs
+  echo "Redirecting logs at ${rootfs}/tmp/full-logs.tar.gz"
 }
 
 get_mounts_info() {
@@ -615,7 +616,7 @@ get_docker_info() {
 parse_options "$@"
 
 if [ -d "/.bottlerocket/" ]; then
-  echo "Using Bottlerocket AMI"
+  echo "Detected Bottlerocket AMI"
   collect_logs_bottlerocket
 else 
   collect


### PR DESCRIPTION
*Issue #, if available:*
VPC CNI - https://github.com/aws/amazon-vpc-cni-k8s/issues/1316

*Description of changes:*
Added logic to collect logs on bottlerocket AMI
```
sudo bash eks-log-collector.sh 
Detected Bottlerocket AMI
Fetching INSTANCE_ID
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    19  100    19    0     0  16754      0 --:--:-- --:--:-- --:--:-- 19000
i-028cb77de07f468b9
Running: exec containerd-config containerd --config /etc/containerd/config.toml config dump
Running: exec containerd-config-host containerd --config /etc/host-containerd/config.toml config dump
Running: exec df df -h
Running: exec df-inodes df -hi
Running: exec dmesg dmesg --color=never --nopager
Running: exec iptables-filter iptables -nvL -t filter
Running: exec iptables-nat iptables -nvL -t nat
Running: exec journalctl-boots journalctl --list-boots --no-pager
Running: exec journalctl.errors journalctl -p err -a --no-pager
Running: exec journalctl.log journalctl -a --no-pager
Running: exec proc-mounts cat /proc/mounts
Running: exec signpost signpost status
Running: exec wicked wicked show all
Running: file os-release /etc/os-release
Running: glob /var/log/kdump/*
Running: settings settings.json
Running: exec kube-status systemctl status kube* -l --no-pager
Running: file ipamd.log /var/log/aws-routed-eni/ipamd.log
Running: file plugin.log /var/log/aws-routed-eni/plugin.log
logs are at: /var/log/support/bottlerocket-logs.tar.gz

	Done... your bundled logs are located in /var/log/eks_i-028cb77de07f468b9_2022-03-10_1803-UTC_0.6.2.tar.gz
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
