### PR TITLE
Use only secure protocols for SSH

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -99,6 +99,8 @@ fi
 
 # Disable weak ciphers
 echo -e "\nCiphers aes128-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com" | sudo tee -a /etc/ssh/sshd_config
+# Use only secure protocols
+echo -e "\nKexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256" | sudo tee -a /etc/ssh/sshd_config
 sudo systemctl restart sshd.service
 
 ################################################################################


### PR DESCRIPTION
*Issue #, if available:* It is noticed that the SSH server supports the following weak KEX algorithm(s):


KEX algorithm                                        | Reason
diffie-hellman-group-exchange-sha1 | Using SHA-1
diffie-hellman-group1-sha1                  | Using Oakley Group 2 (a 1024-bit MODP group) and SHA-1

Impact: An attacker can quickly break individual connections.
A nation-state can break a 1024-bit prime.

Millions of HTTPS, SSH, and VPN servers all use the same prime numbers for Diffie-Hellman key
exchange. Practitioners believed this was safe as long as new key exchange messages were generated
for every connection. However, the first step in the number field sieve-the most efficient
algorithm for breaking a Diffie-Hellman connection-is dependent only on this prime.


*Description of changes:* Specify sha256 for KEX Algorithms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
