### PR TITLE
Update containerd to 1.4.6-8 for CVE-2022-23648

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -14,7 +14,7 @@
     "kubernetes_build_date": null,
     "kernel_version": "",
     "docker_version": "20.10.7-5.amzn2",
-    "containerd_version": "1.4.6-7.amzn2",
+    "containerd_version": "1.4.6-8.amzn2",
     "runc_version": "1.0.0-2.amzn2",
     "cni_plugin_version": "v0.8.6",
     "pull_cni_from_github": "true",


### PR DESCRIPTION
https://alas.aws.amazon.com/cve/html/CVE-2022-23648.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
