### PR TITLE
Adding support for new k8s version 1.22 and credential provider support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,7 @@ k8s: validate
 .PHONY: 1.21
 1.21:
 	$(MAKE) k8s kubernetes_version=1.21.5 kubernetes_build_date=2022-01-21 pull_cni_from_github=true
+
+.PHONY: 1.22
+1.22:
+	$(MAKE) k8s kubernetes_version=1.22.6 kubernetes_build_date=2022-02-22 pull_cni_from_github=true

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.18 1.19 1.20 1.21
+all: 1.18 1.19 1.20 1.21 1.22
 
 .PHONY: validate
 validate:
@@ -60,4 +60,4 @@ k8s: validate
 
 .PHONY: 1.22
 1.22:
-	$(MAKE) k8s kubernetes_version=1.22.6 kubernetes_build_date=2022-02-22 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.22.6 kubernetes_build_date=2022-03-09 pull_cni_from_github=true

--- a/files/ecr-credential-provider-config
+++ b/files/ecr-credential-provider-config
@@ -1,0 +1,14 @@
+apiVersion: kubelet.config.k8s.io/v1alpha1
+kind: CredentialProviderConfig
+providers:
+  - name: ecr-credential-provider
+    matchImages:
+      - "*.dkr.ecr.*.amazonaws.com"
+      - "*.dkr.ecr.*.amazonaws.cn"
+      - "*.dkr.ecr-fips.*.amazonaws.com"
+      - "*.dkr.ecr.us-iso-east-1.c2s.ic.gov"
+      - "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
+    defaultCacheDuration: "12h"
+    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    args:
+      - get-credentials

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -155,6 +155,12 @@ else
     sudo mv $TEMPLATE_DIR/containerd-config.toml /etc/eks/containerd/containerd-config.toml
 fi
 
+if [[ $KUBERNETES_VERSION == "1.22"* ]]; then
+    # enable CredentialProviders features in kubelet-containerd service file
+    IMAGE_CREDENTIAL_PROVIDER_FLAGS='\\\n    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \\\n   --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider'
+    sudo sed -i s,"aws","aws $IMAGE_CREDENTIAL_PROVIDER_FLAGS", $TEMPLATE_DIR/kubelet-containerd.service
+fi
+
 sudo mv $TEMPLATE_DIR/kubelet-containerd.service /etc/eks/containerd/kubelet-containerd.service
 sudo mv $TEMPLATE_DIR/sandbox-image.service /etc/eks/containerd/sandbox-image.service
 sudo mv $TEMPLATE_DIR/pull-sandbox-image.sh /etc/eks/containerd/pull-sandbox-image.sh
@@ -254,14 +260,25 @@ sudo mkdir -p /etc/kubernetes/kubelet
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 sudo mv $TEMPLATE_DIR/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
 sudo chown root:root /var/lib/kubelet/kubeconfig
-sudo mv $TEMPLATE_DIR/kubelet.service /etc/systemd/system/kubelet.service
-sudo chown root:root /etc/systemd/system/kubelet.service
+
 # Inject CSIServiceAccountToken feature gate to kubelet config if kubernetes version starts with 1.20.
 # This is only injected for 1.20 since CSIServiceAccountToken will be moved to beta starting 1.21.
 if [[ $KUBERNETES_VERSION == "1.20"* ]]; then
     KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED=$(cat $TEMPLATE_DIR/kubelet-config.json | jq '.featureGates += {CSIServiceAccountToken: true}')
     echo $KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED > $TEMPLATE_DIR/kubelet-config.json
 fi
+
+if [[ $KUBERNETES_VERSION == "1.22"* ]]; then
+    # enable CredentialProviders feature flags in kubelet service file
+    IMAGE_CREDENTIAL_PROVIDER_FLAGS='\\\n    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \\\n    --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider'
+    sudo sed -i s,"aws","aws $IMAGE_CREDENTIAL_PROVIDER_FLAGS", $TEMPLATE_DIR/kubelet.service
+    # enable KubeletCredentialProviders features in kubelet configuration
+    KUBELET_CREDENTIAL_PROVIDERS_FEATURES=$(cat $TEMPLATE_DIR/kubelet-config.json | jq '.featureGates += {KubeletCredentialProviders: true}')
+    printf "%s" "$KUBELET_CREDENTIAL_PROVIDERS_FEATURES" > "$TEMPLATE_DIR/kubelet-config.json"
+fi
+
+sudo mv $TEMPLATE_DIR/kubelet.service /etc/systemd/system/kubelet.service
+sudo chown root:root /etc/systemd/system/kubelet.service
 sudo mv $TEMPLATE_DIR/kubelet-config.json /etc/kubernetes/kubelet/kubelet-config.json
 sudo chown root:root /etc/kubernetes/kubelet/kubelet-config.json
 
@@ -285,6 +302,26 @@ SONOBUOY_E2E_REGISTRY="${SONOBUOY_E2E_REGISTRY:-}"
 if [[ -n "$SONOBUOY_E2E_REGISTRY" ]]; then
     sudo mv $TEMPLATE_DIR/sonobuoy-e2e-registry-config /etc/eks/sonobuoy-e2e-registry-config
     sudo sed -i s,SONOBUOY_E2E_REGISTRY,$SONOBUOY_E2E_REGISTRY,g /etc/eks/sonobuoy-e2e-registry-config
+fi
+
+################################################################################
+### ECR CREDENTIAL PROVIDER ####################################################
+################################################################################
+if [[ $KUBERNETES_VERSION == "1.22"* ]]; then
+    ECR_BINARY="ecr-credential-provider"
+    if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+        echo "AWS cli present - using it to copy ecr-credential-provider binaries from s3."
+        aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_BINARY .
+    else
+        echo "AWS cli missing - using wget to fetch ecr-credential-provider binaries from s3. Note: This won't work for private bucket."
+        sudo wget "$S3_URL_BASE/$ECR_BINARY"
+    fi
+    sudo chmod +x $ECR_BINARY
+    sudo mkdir -p /etc/eks/ecr-credential-provider
+    sudo mv $ECR_BINARY /etc/eks/ecr-credential-provider
+
+    # copying credential provider config file to eks folder
+    sudo mv $TEMPLATE_DIR/ecr-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config
 fi
 
 ################################################################################


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

This CR adds changes to the kubelet config file to add support for credential provider and its feature flags. With this change, we are also adding a sample ecr credential provider config file and the credential-provider binary.

The credential provider binary artifacts will be available in the same public s3 bucket where we currently upload kubelet binaries.

These changes are applicable to only 1.22 version and need to applied to both docker and container kubelet files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
