### PR TITLE
Calculate MaxPods when not present in eni-max-pods.txt

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -434,7 +434,7 @@ if [ -z "$MAX_PODS" ] || [ -z "$INSTANCE_TYPE" ]; then
     # When determining the value of maxPods, we're using the legacy calculation by default since it's more restrictive than
     # the PrefixDelegation based alternative and is likely to be in-use by more customers.
     # The legacy numbers also maintain backwards compatibility when used to calculate `kubeReserved.memory`
-    MAX_PODS=$(./max-pods-calculator.sh --instance-type-from-imds --cni-version 1.10.0 --show-max-allowed)
+    MAX_PODS=$(/etc/eks/max-pods-calculator.sh --instance-type-from-imds --cni-version 1.10.0 --show-max-allowed)
 fi
 
 # calculates the amount of each resource to reserve

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -430,8 +430,11 @@ set +o pipefail
 MAX_PODS=$(cat $MAX_PODS_FILE | awk "/^${INSTANCE_TYPE:-unset}/"' { print $2 }')
 set -o pipefail
 if [ -z "$MAX_PODS" ] || [ -z "$INSTANCE_TYPE" ]; then
-    echo "No entry for type '$INSTANCE_TYPE' in $MAX_PODS_FILE"
-    exit 1
+    echo "No entry for type '$INSTANCE_TYPE' in $MAX_PODS_FILE. Will attempt to auto-discover value."
+    # When determining the value of maxPods, we're using the legacy calculation by default since it's more restrictive than
+    # the PrefixDelegation based alternative and is likely to be in-use by more customers.
+    # The legacy numbers also maintain backwards compatibility when used to calculate `kubeReserved.memory`
+    MAX_PODS=$(./max-pods-calculator.sh --instance-type-from-imds --cni-version 1.10.0 --show-max-allowed)
 fi
 
 # calculates the amount of each resource to reserve
@@ -463,7 +466,7 @@ fi
 if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
     sudo mkdir -p /etc/containerd
     sudo mkdir -p /etc/cni/net.d
-    sudo sed -i s,SANDBOX_IMAGE,$PAUSE_CONTAINER,g /etc/eks/containerd/containerd-config.toml  
+    sudo sed -i s,SANDBOX_IMAGE,$PAUSE_CONTAINER,g /etc/eks/containerd/containerd-config.toml
     sudo mv /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml
     sudo mv /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service
     sudo mv /etc/eks/containerd/kubelet-containerd.service /etc/systemd/system/kubelet.service
@@ -475,7 +478,7 @@ if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
     systemctl restart containerd
     systemctl enable sandbox-image
     systemctl start sandbox-image
-    
+
 elif [[ "$CONTAINER_RUNTIME" = "dockerd" ]]; then
     mkdir -p /etc/docker
     bash -c "/sbin/iptables-save > /etc/sysconfig/iptables"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Each time EC2 launches a new instanceType, we need to calculate the value of maxPods for that instanceType and add [it to this file](https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt). Therefore each time an instanceType is launched, all old AMIs will not be usable to create worker nodes with that new type. 

This now adds a fallback to the EC2 API and calculates the value that would've been present in the `eni-max-pods.txt`. We will continue to update that file so that the cost of the EC2 API call can be prevented on node boot up, but this should help with new nodes coming online on brand new instanceTypes. 

`AmazonEKSWorkerNodePolicy` was recently updated to include the permission for the new EC2 call. See https://docs.aws.amazon.com/eks/latest/userguide/security-iam-awsmanpol.html#security-iam-awsmanpol-updates

Q - Why not just use whatever maxPods override is being passed into the bootstrap script?
One of the main uses of the legacy maxPods value is that we use it to calculate kubeReserved memory. This preserves that logic for AMI users by default. 

#### Testing

* I SSHd into an existing `t3.medium` worker node and removed the entry for `t3.medium` from the `eni-max-pods.txt` file. 
  * I then invoked `sudo /etc/eks/bootstrap.sh myCluster` and saw that fail with `no entry for t3.medium..` which was expected. 
  * I then added the call to the calculator script as this PR is doing. I also did `sudo cp /etc/systemd/system/iptables-restore.service /etc/eks/iptables-restore.service` to make sure the bootstrap script succeeds on a retry. The latter command is because the bootstrap script [lost its idempotency after this PR](https://github.com/awslabs/amazon-eks-ami/pull/698/files). That needs to be fixed independent of this code change. 
  * I then bootstapped the worker node again and saw it succeed. 

```
[ec2-user@ip-192-168-21-237 eks]$ sudo ./bootstrap.sh karp-cluster
No entry for type 't3.medium' in /etc/eks/eni-max-pods.txt. Will attempt to auto-discover value
nvidia-smi not found
```

I verified from the node object that the kubelet was restarted - 
```
Events:
  Type    Reason                   Age   From     Message
  ----    ------                   ----  ----     -------
  Normal  Starting                 3m6s  kubelet  Starting kubelet.
  Normal  NodeAllocatableEnforced  3m5s  kubelet  Updated Node Allocatable limit across pods
  ....
```

I'll try creating an AMI with this change as well to make sure everything is fine, but I don't see any issues so far so publishing the PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
