### PR TITLE
Adding FIPS 140-2 Support to EKS AMI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version runc_version cni_plugin_version source_ami_id source_ami_owners source_ami_filter_name arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry
+PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version runc_version cni_plugin_version source_ami_id source_ami_owners source_ami_filter_name arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry enable_fips_mode
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})
@@ -46,14 +46,30 @@ k8s: validate
 1.19:
 	$(MAKE) k8s kubernetes_version=1.19.15 kubernetes_build_date=2021-11-10 pull_cni_from_github=true
 
+.PHONY: 1.19-fips
+1.19-fips:
+	$(MAKE) k8s kubernetes_version=1.19.15 kubernetes_build_date=2021-11-10 pull_cni_from_github=true enable_fips_mode=true
+
 .PHONY: 1.20
 1.20:
 	$(MAKE) k8s kubernetes_version=1.20.11 kubernetes_build_date=2021-11-10 pull_cni_from_github=true
+
+.PHONY: 1.20
+1.20-fips:
+	$(MAKE) k8s kubernetes_version=1.20.11 kubernetes_build_date=2021-11-10 pull_cni_from_github=true enable_fips_mode=true
 
 .PHONY: 1.21
 1.21:
 	$(MAKE) k8s kubernetes_version=1.21.5 kubernetes_build_date=2022-01-21 pull_cni_from_github=true
 
+.PHONY: 1.21-fips
+1.21-fips:
+	$(MAKE) k8s kubernetes_version=1.21.5 kubernetes_build_date=2022-01-21 pull_cni_from_github=true enable_fips_mode=true
+
 .PHONY: 1.22
 1.22:
 	$(MAKE) k8s kubernetes_version=1.22.6 kubernetes_build_date=2022-03-09 pull_cni_from_github=true
+
+.PHONY: 1.22-fips
+1.22-fips:
+	$(MAKE) k8s kubernetes_version=1.22.6 kubernetes_build_date=2022-03-09 pull_cni_from_github=true enable_fips_mode=true

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -18,6 +18,7 @@
     "runc_version": "1.0.0-2.amzn2",
     "cni_plugin_version": "v0.8.6",
     "pull_cni_from_github": "true",
+    "enable_fips_mode": "false",
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
     "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
@@ -93,7 +94,8 @@
         "containerd_version": "{{ user `containerd_version`}}",
         "source_ami_id": "{{ user `source_ami_id`}}",
         "kubernetes": "{{ user `kubernetes_version`}}/{{ user `kubernetes_build_date` }}/bin/linux/{{ user `arch` }}",
-        "cni_plugin_version": "{{ user `cni_plugin_version`}}"
+        "cni_plugin_version": "{{ user `cni_plugin_version`}}",
+        "enable_fips_mode": "{{user `enable_fips_mode`}}"
       },
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "{{ user `ami_description` }}, (k8s: {{ user `kubernetes_version` }}, docker: {{ user `docker_version` }}, containerd: {{ user `containerd_version` }})"
@@ -115,7 +117,8 @@
       "script": "{{template_dir}}/scripts/upgrade_kernel.sh",
       "environment_vars": [
         "KUBERNETES_VERSION={{user `kubernetes_version`}}",
-        "KERNEL_VERSION={{user `kernel_version`}}"
+        "KERNEL_VERSION={{user `kernel_version`}}",
+        "ENABLE_FIPS_MODE={{user `enable_fips_mode`}}"
       ]
     },
     {

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -34,4 +34,16 @@ else
     exit 1
 fi
 
+if [[ "$ENABLE_FIPS_MODE" == "true" ]]; then
+    # install and enable fips modules
+    sudo yum install -y dracut-fips openssl
+    sudo dracut -f
+
+    # enable fips in the boot command
+    sudo sed -i 's/^\(GRUB_CMDLINE_LINUX_DEFAULT=.*\)"$/\1 fips=1"/' /etc/default/grub
+
+    # rebuild grub
+    sudo grub2-mkconfig -o /etc/grub2.cfg
+fi
+
 sudo reboot


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds support for enabling FIPS 140-2 mode in the Kernel. FIPS 140-2 is required by customers looking to achieve FedRAMP and/or DoD CC SRG compliance.

This brings up to date with the latest master.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
