### PR TITLE
add c7g support

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -147,6 +147,15 @@ c6i.8xlarge 234
 c6i.large 29
 c6i.metal 737
 c6i.xlarge 58
+c7g.12xlarge 234
+c7g.16xlarge 737
+c7g.2xlarge 58
+c7g.4xlarge 234
+c7g.8xlarge 234
+c7g.large 29
+c7g.medium 8
+c7g.metal 737
+c7g.xlarge 58
 cc2.8xlarge 234
 cr1.8xlarge 234
 d2.2xlarge 58


### PR DESCRIPTION
*Description of changes:*
See https://github.com/aws/amazon-vpc-cni-k8s/pull/1940

Without this change, bootstrap fails:
```
+ /etc/eks/bootstrap.sh dogfood-eks --kubelet-extra-args --node-labels=eks.amazo
naws.com/capacityType=ON_DEMAND,eks.amazonaws.com/nodegroup=custom-shared-0
No entry for type 'c7g.2xlarge' in /etc/eks/eni-max-pods.txt. Will attempt to au
to-discover value.

An error occurred (InvalidInstanceType) when calling the DescribeInstanceTypes o
peration: The following supplied instance types do not exist: [c7g.2xlarge]
Exited with error on line 437
Apr 26 15:42:19 cloud-init[1269]: util.py[WARNING]: Failed running /var/lib/clou
d/instance/scripts/part-001 [255]
Apr 26 15:42:19 cloud-init[1269]: cc_scripts_user.py[WARNING]: Failed to run mod
ule scripts-user (scripts in /var/lib/cloud/instance/scripts)
Apr 26 15:42:19 cloud-init[1269]: util.py[WARNING]: Running module scripts-user 
(<module 'cloudinit.config.cc_scripts_user' from '/usr/lib/python2.7/site-packag
es/cloudinit/config/cc_scripts_user.pyc'>) failed
Cloud-init v. 19.3-45.amzn2 finished at Tue, 26 Apr 2022 15:42:19 +0000. Datasou
rce DataSourceEc2.  Up 70.30 seconds
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.