### PR TITLE
Fail build if docker GID isn't 1950

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -116,7 +116,7 @@ sudo yum install -y yum-utils device-mapper-persistent-data lvm2
 INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
 if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo amazon-linux-extras enable docker
-    sudo groupadd -fog 1950 docker
+    sudo groupadd -og 1950 docker
     sudo useradd --gid $(getent group docker | cut -d: -f3) docker
 
     # install runc and lock version


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Some users rely on the GID of the `docker` group, and the build should fail if that expectation isn't met. The `-f` flag causes `groupadd` to succeed when the `docker` group already exists:
```
       -f, --force
           This option causes the command to simply exit with success status if the specified group already exists.
           When used with -g, and the specified GID already exists, another (unique) GID is chosen (i.e.  -g is
           turned off).
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.