### PR TITLE
Updates 1.21 binary in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ k8s: validate
 
 .PHONY: 1.21
 1.21:
-	$(MAKE) k8s kubernetes_version=1.21.5 kubernetes_build_date=2022-01-21 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.21.12 kubernetes_build_date=2022-05-20 pull_cni_from_github=true
 
 .PHONY: 1.22
 1.22:


### PR DESCRIPTION
*Issue #, if available:*
Updates 1.21 kubelet to 1.21.12.

*Description of changes:*
The new binary includes bug fixes and improvements from the 1.21.12 upstream branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**NOTE: May need to update the build date after the binaries are published.**