### PR TITLE
Add support iSCSI persistent volumes

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -63,6 +63,7 @@ sudo yum install -y \
     ipvsadm \
     jq \
     nfs-utils \
+    iscsi-initiator-utils \
     socat \
     unzip \
     wget \


### PR DESCRIPTION
*Description of changes:*
Support high availability block volumes that can be mounted by ISCSI protocol to kubernetes pods. Ceph or Longhorn support ISCSI protocol, this PR can help users to mount HA volumes to their EKS clusters by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>
