### PR TITLE
Update eks-log-collector.sh

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -320,7 +320,7 @@ get_common_logs() {
   for entry in ${COMMON_LOGS[*]}; do
     if [[ -e "/var/log/${entry}" ]]; then
         if [[ "${entry}" == "messages" ]]; then
-          tail -c 10M /var/log/messages > "${COLLECT_DIR}"/var_log/messages
+          cat /var/log/messages > "${COLLECT_DIR}"/var_log/messages
           continue
         fi
         if [[ "${entry}" == "containers" ]]; then

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -320,7 +320,7 @@ get_common_logs() {
   for entry in ${COMMON_LOGS[*]}; do
     if [[ -e "/var/log/${entry}" ]]; then
         if [[ "${entry}" == "messages" ]]; then
-          cat /var/log/messages > "${COLLECT_DIR}"/var_log/messages
+          tail -c 100M /var/log/messages > "${COLLECT_DIR}"/var_log/messages
           continue
         fi
         if [[ "${entry}" == "containers" ]]; then


### PR DESCRIPTION
Removed 10MB limit on messages log file collection

*Issue #, if available:*

*Description of changes:*
Removing 10MB limit on Messages file collection as it might not capture the required information due to only capturing the last 10MB lines

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
