### PR TITLE
Updating Makefile and install script for 1.23 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.19 1.20 1.21 1.22
+all: 1.19 1.20 1.21 1.22 1.23
 
 .PHONY: validate
 validate:
@@ -57,3 +57,7 @@ k8s: validate
 .PHONY: 1.22
 1.22:
 	$(MAKE) k8s kubernetes_version=1.22.6 kubernetes_build_date=2022-03-09 pull_cni_from_github=true
+
+.PHONY: 1.23
+1.23:
+	$(MAKE) k8s kubernetes_version=1.23.6 kubernetes_build_date=2022-06-01 pull_cni_from_github=true

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: all
-all: 1.19 1.20 1.21 1.22 1.23
+all: 1.19 1.20 1.21 1.22
 
 .PHONY: validate
 validate:
@@ -57,7 +57,3 @@ k8s: validate
 .PHONY: 1.22
 1.22:
 	$(MAKE) k8s kubernetes_version=1.22.6 kubernetes_build_date=2022-03-09 pull_cni_from_github=true
-
-.PHONY: 1.23
-1.23:
-	$(MAKE) k8s kubernetes_version=1.23.6 kubernetes_build_date=2022-06-01 pull_cni_from_github=true

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -159,7 +159,7 @@ else
     sudo mv $TEMPLATE_DIR/containerd-config.toml /etc/eks/containerd/containerd-config.toml
 fi
 
-if [[ $KUBERNETES_VERSION == "1.22"* ]]; then
+if [[ ! $KUBERNETES_VERSION =~ "1.19"* || ! $KUBERNETES_VERSION =~ "1.20"* || ! $KUBERNETES_VERSION =~ "1.21"* ]]; then
     # enable CredentialProviders features in kubelet-containerd service file
     IMAGE_CREDENTIAL_PROVIDER_FLAGS='\\\n    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \\\n   --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider'
     sudo sed -i s,"aws","aws $IMAGE_CREDENTIAL_PROVIDER_FLAGS", $TEMPLATE_DIR/kubelet-containerd.service
@@ -272,7 +272,7 @@ if [[ $KUBERNETES_VERSION == "1.20"* ]]; then
     echo $KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED > $TEMPLATE_DIR/kubelet-config.json
 fi
 
-if [[ $KUBERNETES_VERSION == "1.22"* ]]; then
+if [[ ! $KUBERNETES_VERSION =~ "1.19"* || ! $KUBERNETES_VERSION =~ "1.20"* || ! $KUBERNETES_VERSION =~ "1.21"* ]]; then
     # enable CredentialProviders feature flags in kubelet service file
     IMAGE_CREDENTIAL_PROVIDER_FLAGS='\\\n    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \\\n    --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider'
     sudo sed -i s,"aws","aws $IMAGE_CREDENTIAL_PROVIDER_FLAGS", $TEMPLATE_DIR/kubelet.service
@@ -311,7 +311,7 @@ fi
 ################################################################################
 ### ECR CREDENTIAL PROVIDER ####################################################
 ################################################################################
-if [[ $KUBERNETES_VERSION == "1.22"* ]]; then
+if [[ ! $KUBERNETES_VERSION =~ "1.19"* || ! $KUBERNETES_VERSION =~ "1.20"* || ! $KUBERNETES_VERSION =~ "1.21"* ]]; then
     ECR_BINARY="ecr-credential-provider"
     if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
         echo "AWS cli present - using it to copy ecr-credential-provider binaries from s3."


### PR DESCRIPTION
*Issue #, if available:*

Adding support for 1.23 

*Description of changes:*

This PR updates the Makefile to add 1.23 support. And also updates the install-worker script to make ecr-credential flag work for all versions beginning 1.22

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
