### PR TITLE
cache pause, vpc-cni, and kube-proxy images in the AMI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version runc_version cni_plugin_version source_ami_id source_ami_owners source_ami_filter_name arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry ami_regions volume_type
+PACKER_VARIABLES := $(shell $(PACKER_BINARY) inspect -machine-readable eks-worker-al2.json | grep 'template-variable' | awk -F ',' '{print $$4}')
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -13,6 +13,7 @@
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
+    "cache_container_images": "false",
     "cni_plugin_version": "v0.8.6",
     "containerd_version": "1.6.6-1.amzn2.0.2",
     "creator": "{{env `USER`}}",
@@ -23,7 +24,8 @@
     "kms_key_id": "",
     "kubernetes_build_date": null,
     "kubernetes_version": null,
-    "launch_block_device_mappings_volume_size": "4",
+    "launch_block_device_mappings_volume_size": "8",
+    "pause_container_version": "3.5",
     "pull_cni_from_github": "true",
     "remote_folder": "",
     "runc_version": "1.1.3-1.amzn2.0.2",
@@ -161,7 +163,10 @@
         "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
         "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
-        "SONOBUOY_E2E_REGISTRY={{user `sonobuoy_e2e_registry`}}"
+        "SONOBUOY_E2E_REGISTRY={{user `sonobuoy_e2e_registry`}}",
+        "PAUSE_CONTAINER_VERSION={{user `pause_container_version`}}",
+        "KUBE_PROXY_VERSION_SUFFIX={{user `kube_proxy_version_suffix`}}",
+        "CACHE_CONTAINER_IMAGES={{user `cache_container_images`}}"
       ]
     },
     {

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -178,51 +178,6 @@ SERVICE_IPV6_CIDR="${SERVICE_IPV6_CIDR:-}"
 ENABLE_LOCAL_OUTPOST="${ENABLE_LOCAL_OUTPOST:-}"
 CLUSTER_ID="${CLUSTER_ID:-}"
 
-function get_pause_container_account_for_region() {
-  local region="$1"
-  case "${region}" in
-    ap-east-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-800184023465}"
-      ;;
-    me-south-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-558608220178}"
-      ;;
-    cn-north-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-918309763551}"
-      ;;
-    cn-northwest-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-961992271922}"
-      ;;
-    us-gov-west-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-013241004608}"
-      ;;
-    us-gov-east-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-151742754352}"
-      ;;
-    us-iso-east-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-725322719131}"
-      ;;
-    us-isob-east-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-187977181151}"
-      ;;
-    af-south-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-877085696533}"
-      ;;
-    eu-south-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-590381155156}"
-      ;;
-    ap-southeast-3)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-296578399912}"
-      ;;
-    me-central-1)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-759879836304}"
-      ;;
-    *)
-      echo "${PAUSE_CONTAINER_ACCOUNT:-602401143452}"
-      ;;
-  esac
-}
-
 # Helper function which calculates the amount of the given resource (either CPU or memory)
 # to reserve in a given resource range, specified by a start and end of the range and a percentage
 # of the resource to reserve. Note that we return zero if the start of the resource range is
@@ -314,8 +269,8 @@ if [[ "$MACHINE" != "x86_64" && "$MACHINE" != "aarch64" ]]; then
   exit 1
 fi
 
-PAUSE_CONTAINER_ACCOUNT=$(get_pause_container_account_for_region "${AWS_DEFAULT_REGION}")
-PAUSE_CONTAINER_IMAGE=${PAUSE_CONTAINER_IMAGE:-$PAUSE_CONTAINER_ACCOUNT.dkr.ecr.$AWS_DEFAULT_REGION.$AWS_SERVICES_DOMAIN/eks/pause}
+ECR_URI=$(/etc/eks/get-ecr-uri.sh "${AWS_DEFAULT_REGION}" "${AWS_SERVICES_DOMAIN}" "${PAUSE_CONTAINER_ACCOUNT:-}")
+PAUSE_CONTAINER_IMAGE=${PAUSE_CONTAINER_IMAGE:-$ECR_URI/eks/pause}
 PAUSE_CONTAINER="$PAUSE_CONTAINER_IMAGE:$PAUSE_CONTAINER_VERSION"
 
 ### kubelet kubeconfig
@@ -525,29 +480,26 @@ if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
 
   sudo mkdir -p /etc/containerd
   sudo mkdir -p /etc/cni/net.d
-  mkdir -p /etc/systemd/system/containerd.service.d
-  cat << EOF > /etc/systemd/system/containerd.service.d/10-compat-symlink.conf
-[Service]
-ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
-EOF
   if [[ -n "$CONTAINERD_CONFIG_FILE" ]]; then
     sudo cp -v $CONTAINERD_CONFIG_FILE /etc/eks/containerd/containerd-config.toml
   fi
   echo "$(jq '.cgroupDriver="systemd"' $KUBELET_CONFIG)" > $KUBELET_CONFIG
   sudo sed -i s,SANDBOX_IMAGE,$PAUSE_CONTAINER,g /etc/eks/containerd/containerd-config.toml
-  sudo cp -v /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml
-  sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service
+
+  # Check if the containerd config file is the same as the one used in the image build.
+  # If different, then restart containerd w/ proper config
+  if ! cmp -s /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml; then
+    sudo cp -v /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml
+    sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service
+    sudo chown root:root /etc/systemd/system/sandbox-image.service
+    systemctl daemon-reload
+    systemctl enable containerd sandbox-image
+    systemctl restart sandbox-image containerd
+  fi
   sudo cp -v /etc/eks/containerd/kubelet-containerd.service /etc/systemd/system/kubelet.service
   sudo chown root:root /etc/systemd/system/kubelet.service
-  sudo chown root:root /etc/systemd/system/sandbox-image.service
   # Validate containerd config
   sudo containerd config dump > /dev/null
-  systemctl daemon-reload
-  systemctl enable containerd
-  systemctl restart containerd
-  systemctl enable sandbox-image
-  systemctl start sandbox-image
-
 elif [[ "$CONTAINER_RUNTIME" = "dockerd" ]]; then
   mkdir -p /etc/docker
   bash -c "/sbin/iptables-save > /etc/sysconfig/iptables"

--- a/files/get-ecr-uri.sh
+++ b/files/get-ecr-uri.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# More details about the mappings in this file can be found here https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html
+
+region=$1
+aws_domain=$2
+if [[ $# -eq 3 ]] && [[ ! -z $3 ]]; then
+  acct=$3
+else
+  case "${region}" in
+    ap-east-1)
+      acct="800184023465"
+      ;;
+    me-south-1)
+      acct="558608220178"
+      ;;
+    cn-north-1)
+      acct="918309763551"
+      ;;
+    cn-northwest-1)
+      acct="961992271922"
+      ;;
+    us-gov-west-1)
+      acct="013241004608"
+      ;;
+    us-gov-east-1)
+      acct="151742754352"
+      ;;
+    us-iso-east-1)
+      acct="725322719131"
+      ;;
+    us-isob-east-1)
+      acct="187977181151"
+      ;;
+    af-south-1)
+      acct="877085696533"
+      ;;
+    eu-south-1)
+      acct="590381155156"
+      ;;
+    ap-southeast-3)
+      acct="296578399912"
+      ;;
+    me-central-1)
+      acct="759879836304"
+      ;;
+    *)
+      acct="602401143452"
+      ;;
+  esac
+fi
+
+echo "${acct}.dkr.ecr.${region}.${aws_domain}"

--- a/files/pull-image.sh
+++ b/files/pull-image.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+img=$1
+region=$(echo "${img}" | cut -f4 -d ".")
+MAX_RETRIES=3
+
+function retry() {
+  local rc=0
+  for attempt in $(seq 0 $MAX_RETRIES); do
+    rc=0
+    [[ $attempt -gt 0 ]] && echo "Attempt $attempt of $MAX_RETRIES" 1>&2
+    "$@"
+    rc=$?
+    [[ $rc -eq 0 ]] && break
+    [[ $attempt -eq $MAX_RETRIES ]] && exit $rc
+    local jitter=$((1 + RANDOM % 10))
+    local sleep_sec="$(($((5 << $((1 + $attempt)))) + $jitter))"
+    sleep $sleep_sec
+  done
+}
+
+ecr_password=$(retry aws ecr get-login-password --region $region)
+if [[ -z ${ecr_password} ]]; then
+  echo >&2 "Unable to retrieve the ECR password."
+  exit 1
+fi
+retry sudo ctr --namespace k8s.io image pull "${img}" --user AWS:${ecr_password}

--- a/files/pull-sandbox-image.sh
+++ b/files/pull-sandbox-image.sh
@@ -1,27 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-### fetching sandbox image from /etc/containerd/config.toml
-sandbox_image=$(awk -F'[ ="]+' '$1 == "sandbox_image" { print $2 }' /etc/containerd/config.toml)
-region=$(echo "$sandbox_image" | cut -f4 -d ".")
-ecr_password=$(aws ecr get-login-password --region $region)
-API_RETRY_ATTEMPTS=5
-
-for attempt in $(seq 0 $API_RETRY_ATTEMPTS); do
-  rc=0
-  if [[ $attempt -gt 0 ]]; then
-    echo "Attempt $attempt of $API_RETRY_ATTEMPTS"
-  fi
-  ### pull sandbox image from ecr
-  ### username will always be constant i.e; AWS
-  sudo ctr --namespace k8s.io image pull $sandbox_image --user AWS:$ecr_password
-  rc=$?
-  if [[ $rc -eq 0 ]]; then
-    break
-  fi
-  if [[ $attempt -eq $API_RETRY_ATTEMPTS ]]; then
-    exit $rc
-  fi
-  jitter=$((1 + RANDOM % 10))
-  sleep_sec="$(($((5 << $((1 + $attempt)))) + $jitter))"
-  sleep $sleep_sec
-done
+sandbox_image="$(awk -F'[ ="]+' '$1 == "sandbox_image" { print $2 }' /etc/containerd/config.toml)"
+/etc/eks/containerd/pull-image.sh "${sandbox_image}"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -4,6 +4,7 @@ set -o pipefail
 set -o nounset
 set -o errexit
 IFS=$'\n\t'
+export AWS_DEFAULT_OUTPUT="json"
 
 TEMPLATE_DIR=${TEMPLATE_DIR:-/tmp/worker}
 
@@ -30,6 +31,8 @@ validate_env_set CNI_PLUGIN_VERSION
 validate_env_set KUBERNETES_VERSION
 validate_env_set KUBERNETES_BUILD_DATE
 validate_env_set PULL_CNI_FROM_GITHUB
+validate_env_set PAUSE_CONTAINER_VERSION
+validate_env_set CACHE_CONTAINER_IMAGES
 
 ################################################################################
 ### Machine Architecture #######################################################
@@ -138,45 +141,17 @@ else
   sudo yum install -y awscli
 fi
 
-################################################################################
-### Docker #####################################################################
-################################################################################
-
-sudo yum install -y device-mapper-persistent-data lvm2
-
-INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
-if [[ "$INSTALL_DOCKER" == "true" ]]; then
-  sudo amazon-linux-extras enable docker
-  sudo groupadd -og 1950 docker
-  sudo useradd --gid $(getent group docker | cut -d: -f3) docker
-
-  # install runc and lock version
-  sudo yum install -y runc-${RUNC_VERSION}
-  sudo yum versionlock runc-*
-
-  # install containerd and lock version
-  sudo yum install -y containerd-${CONTAINERD_VERSION}
-  sudo yum versionlock containerd-*
-
-  # install docker and lock version
-  sudo yum install -y docker-${DOCKER_VERSION}*
-  sudo yum versionlock docker-*
-  sudo usermod -aG docker $USER
-
-  # Remove all options from sysconfig docker.
-  sudo sed -i '/OPTIONS/d' /etc/sysconfig/docker
-
-  sudo mkdir -p /etc/docker
-  sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
-  sudo chown root:root /etc/docker/daemon.json
-
-  # Enable docker daemon to start on boot.
-  sudo systemctl daemon-reload
-fi
-
 ###############################################################################
 ### Containerd setup ##########################################################
 ###############################################################################
+
+# install runc and lock version
+sudo yum install -y runc-${RUNC_VERSION}
+sudo yum versionlock runc-*
+
+# install containerd and lock version
+sudo yum install -y containerd-${CONTAINERD_VERSION}
+sudo yum versionlock containerd-*
 
 sudo mkdir -p /etc/eks/containerd
 if [ -f "/etc/eks/containerd/containerd-config.toml" ]; then
@@ -195,7 +170,15 @@ fi
 sudo mv $TEMPLATE_DIR/kubelet-containerd.service /etc/eks/containerd/kubelet-containerd.service
 sudo mv $TEMPLATE_DIR/sandbox-image.service /etc/eks/containerd/sandbox-image.service
 sudo mv $TEMPLATE_DIR/pull-sandbox-image.sh /etc/eks/containerd/pull-sandbox-image.sh
+sudo mv $TEMPLATE_DIR/pull-image.sh /etc/eks/containerd/pull-image.sh
 sudo chmod +x /etc/eks/containerd/pull-sandbox-image.sh
+sudo chmod +x /etc/eks/containerd/pull-image.sh
+
+sudo mkdir -p /etc/systemd/system/containerd.service.d
+cat << EOF | sudo tee /etc/systemd/system/containerd.service.d/10-compat-symlink.conf
+[Service]
+ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
+EOF
 
 cat << EOF | sudo tee -a /etc/modules-load.d/containerd.conf
 overlay
@@ -207,6 +190,34 @@ net.bridge.bridge-nf-call-ip6tables = 1
 net.bridge.bridge-nf-call-iptables = 1
 net.ipv4.ip_forward = 1
 EOF
+
+################################################################################
+### Docker #####################################################################
+################################################################################
+
+sudo yum install -y device-mapper-persistent-data lvm2
+
+INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
+if [[ "$INSTALL_DOCKER" == "true" ]]; then
+  sudo amazon-linux-extras enable docker
+  sudo groupadd -og 1950 docker
+  sudo useradd --gid $(getent group docker | cut -d: -f3) docker
+
+  # install docker and lock version
+  sudo yum install -y docker-${DOCKER_VERSION}*
+  sudo yum versionlock docker-*
+  sudo usermod -aG docker $USER
+
+  # Remove all options from sysconfig docker.
+  sudo sed -i '/OPTIONS/d' /etc/sysconfig/docker
+
+  sudo mkdir -p /etc/docker
+  sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
+  sudo chown root:root /etc/docker/daemon.json
+
+  # Enable docker daemon to start on boot.
+  sudo systemctl daemon-reload
+fi
 
 ################################################################################
 ### Logrotate ##################################################################
@@ -331,6 +342,8 @@ sudo systemctl disable kubelet
 ################################################################################
 
 sudo mkdir -p /etc/eks
+sudo mv $TEMPLATE_DIR/get-ecr-uri.sh /etc/eks/get-ecr-uri.sh
+sudo chmod +x /etc/eks/get-ecr-uri.sh
 sudo mv $TEMPLATE_DIR/eni-max-pods.txt /etc/eks/eni-max-pods.txt
 sudo mv $TEMPLATE_DIR/bootstrap.sh /etc/eks/bootstrap.sh
 sudo chmod +x /etc/eks/bootstrap.sh
@@ -361,6 +374,92 @@ if vercmp "$KUBERNETES_VERSION" gteq "1.22.0"; then
 
   # copying credential provider config file to eks folder
   sudo mv $TEMPLATE_DIR/ecr-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config
+fi
+
+################################################################################
+### Cache Images ###############################################################
+################################################################################
+if [[ "$CACHE_CONTAINER_IMAGES" == "true" && "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "us-isob-east-1" ]]; then
+  AWS_DOMAIN=$(imds 'latest/meta-data/services/domain')
+  ECR_URI=$(/etc/eks/get-ecr-uri.sh "${BINARY_BUCKET_REGION}" "${AWS_DOMAIN}")
+
+  PAUSE_CONTAINER="${ECR_URI}/eks/pause:${PAUSE_CONTAINER_VERSION}"
+  cat /etc/eks/containerd/containerd-config.toml | sed s,SANDBOX_IMAGE,$PAUSE_CONTAINER,g | sudo tee /etc/eks/containerd/containerd-cached-pause-config.toml
+  sudo cp -v /etc/eks/containerd/containerd-cached-pause-config.toml /etc/containerd/config.toml
+  sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service
+  sudo chown root:root /etc/systemd/system/sandbox-image.service
+  sudo systemctl daemon-reload
+  sudo systemctl start containerd
+  sudo systemctl enable containerd sandbox-image
+
+  K8S_MINOR_VERSION=$(echo "${KUBERNETES_VERSION}" | cut -d'.' -f1-2)
+  KUBE_PROXY_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name kube-proxy --kubernetes-version=${K8S_MINOR_VERSION})
+
+  DEFAULT_KUBE_PROXY_FULL_VERSION=$(echo "${KUBE_PROXY_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] | select(.compatibilities[] .defaultVersion==true).addonVersion')
+  DEFAULT_KUBE_PROXY_VERSION=$(echo "${DEFAULT_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f1)
+  DEFAULT_KUBE_PROXY_PLATFORM_VERSION=$(echo "${DEFAULT_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f2)
+
+  LATEST_KUBE_PROXY_FULL_VERSION=$(echo "${KUBE_PROXY_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] .addonVersion' | sort -V | tail -n1)
+  LATEST_KUBE_PROXY_VERSION=$(echo "${LATEST_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f1)
+  LATEST_KUBE_PROXY_PLATFORM_VERSION=$(echo "${LATEST_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f2)
+
+  KUBE_PROXY_IMGS=(
+    ## Default kube-proxy images
+    "${ECR_URI}/eks/kube-proxy:${DEFAULT_KUBE_PROXY_VERSION}-${DEFAULT_KUBE_PROXY_PLATFORM_VERSION}"
+    "${ECR_URI}/eks/kube-proxy:${DEFAULT_KUBE_PROXY_VERSION}-minimal-${DEFAULT_KUBE_PROXY_PLATFORM_VERSION}"
+
+    ## Latest kube-proxy images
+    "${ECR_URI}/eks/kube-proxy:${LATEST_KUBE_PROXY_VERSION}-${LATEST_KUBE_PROXY_PLATFORM_VERSION}"
+    "${ECR_URI}/eks/kube-proxy:${LATEST_KUBE_PROXY_VERSION}-minimal-${LATEST_KUBE_PROXY_PLATFORM_VERSION}"
+  )
+
+  #### Cache VPC CNI images starting with the addon default version and the latest version
+  VPC_CNI_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name vpc-cni --kubernetes-version=${K8S_MINOR_VERSION})
+  DEFAULT_VPC_CNI_VERSION=$(echo "${VPC_CNI_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] | select(.compatibilities[] .defaultVersion==true).addonVersion')
+  LATEST_VPC_CNI_VERSION=$(echo "${VPC_CNI_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] .addonVersion' | sort -V | tail -n1)
+  CNI_IMG="${ECR_URI}/amazon-k8s-cni"
+  CNI_INIT_IMG="${CNI_IMG}-init"
+  CNI_IMGS=(
+    ## Default VPC CNI Images
+    "${CNI_IMG}:${DEFAULT_VPC_CNI_VERSION}"
+    "${CNI_INIT_IMG}:${DEFAULT_VPC_CNI_VERSION}"
+
+    ## Latest VPC CNI Images
+    "${CNI_IMG}:${LATEST_VPC_CNI_VERSION}"
+    "${CNI_INIT_IMG}:${LATEST_VPC_CNI_VERSION}"
+  )
+
+  CACHED_IMGS=(
+    "${PAUSE_CONTAINER}"
+    ${KUBE_PROXY_IMGS[@]}
+    ${CNI_IMGS[@]}
+  )
+
+  for img in "${CACHED_IMGS[@]}"; do
+    ## only kube-proxy-minimal is vended for K8s 1.24+
+    if [[ "${img}" == *"kube-proxy:"* ]] && [[ "${img}" != *"-minimal-"* ]] && vercmp "${K8S_MINOR_VERSION}" gteq "1.24"; then
+      continue
+    fi
+    /etc/eks/containerd/pull-image.sh "${img}"
+  done
+
+  #### Tag the pulled down image for all other regions in the partition
+  for region in $(aws ec2 describe-regions --all-regions | jq -r '.Regions[] .RegionName'); do
+    for img in "${CACHED_IMGS[@]}"; do
+      regional_img="${img/$BINARY_BUCKET_REGION/$region}"
+      sudo ctr -n k8s.io image tag "${img}" "${regional_img}" || :
+      ## Tag ECR fips endpoint for supported regions
+      if [[ "${region}" =~ (us-east-1|us-east-2|us-west-1|us-west-2|us-gov-east-1|us-gov-east-2) ]]; then
+        regional_fips_img="${regional_img/.ecr./.ecr-fips.}"
+        sudo ctr -n k8s.io image tag "${img}" "${regional_fips_img}" || :
+        sudo ctr -n k8s.io image tag "${img}" "${regional_fips_img/-eksbuild.1/}" || :
+      fi
+      ## Cache the non-addon VPC CNI images since "v*.*.*-eksbuild.1" is equivalent to leaving off the eksbuild suffix
+      if [[ "${img}" == *"-cni"*"-eksbuild.1" ]]; then
+        sudo ctr -n k8s.io image tag "${img}" "${regional_img/-eksbuild.1/}" || :
+      fi
+    done
+  done
 fi
 
 ################################################################################


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/1034
https://github.com/awslabs/amazon-eks-ami/issues/990
https://github.com/awslabs/amazon-eks-ami/issues/1099

*Description of changes:*
 - Cache the following images to improve node bootstrapping time:
   - pause
   - aws-node images (init and aws-node)
   - kube-proxy images (minimal and normal)

kubelet logs with image pull timings before caching (v=4):

```
Oct  7 17:05:07 ip-192-168-101-146 pull-sandbox-image.sh: done: 45.698568ms
Oct  7 17:05:17 ip-192-168-101-146 kubelet: I1007 17:05:17.995376    4028 event.go:291] "Event occurred" object="kube-system/kube-proxy-z7s74" kind="Pod" apiVersion="v1" type="Normal" reason="Pulled" message="Successfully pulled image \"602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.22.12-minimal-eksbuild.1\" in 1.712432387s"
Oct  7 17:05:20 ip-192-168-101-146 kubelet: I1007 17:05:20.322544    4028 event.go:291] "Event occurred" object="kube-system/aws-node-c24g9" kind="Pod" apiVersion="v1" type="Normal" reason="Pulled" message="Successfully pulled image \"602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4-eksbuild.1\" in 3.960642579s"
Oct  7 17:05:26 ip-192-168-101-146 kubelet: I1007 17:05:26.913619    4028 event.go:291] "Event occurred" object="kube-system/aws-node-c24g9" kind="Pod" apiVersion="v1" type="Normal" reason="Pulled" message="Successfully pulled image \"60240
1143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4-eksbuild.1\" in 1.390664746s"
```

The total latency in these serial image pulls is ~7 seconds.

After caching all are used from the local host:

``` 
Oct  7 17:05:09 ip-192-168-97-141 kubelet: I1007 17:05:09.666150    4912 event.go:291] "Event occurred" object="kube-system/aws-node-ldvfh" kind="Pod" apiVersion="v1" type="Normal" reason="Pulled" message="Container image \"602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.11.4-eksbuild.1\" already present on machine"
Oct  7 17:05:12 ip-192-168-97-141 kubelet: I1007 17:05:12.375142    4912 event.go:291] "Event occurred" object="kube-system/aws-node-ldvfh" kind="Pod" apiVersion="v1" type="Normal" reason="Pulled" message="Container image \"602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.11.4-eksbuild.1\" already present on machine"
Oct  7 17:05:12 ip-192-168-97-141 kubelet: I1007 17:05:12.493594    4912 event.go:291] "Event occurred" object="kube-system/kube-proxy-79tp5" kind="Pod" apiVersion="v1" type="Normal" reason="Pulled" message="Container image \"602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.22.12-minimal-eksbuild.1\" already present on machine"
```

Since this PR caches the sandbox image (pause), this means we can also enable containerd to start on boot rather than in the bootstrap script which removes the containerd startup time which results in ~3 second latency reduction for when kubelet starts (P50).

![Screen Shot 2022-10-07 at 14 23 42](https://user-images.githubusercontent.com/3503707/194638775-94522051-56ac-4c6e-a52a-4d6d1b82db90.jpg)

This graph shows the combined reduction of the node getting to Ready, starting w/ kube-proxy & pause cached and then adding the vpc cni images to the cache (P50):

![Screen Shot 2022-10-07 at 14 17 08](https://user-images.githubusercontent.com/3503707/194637969-3e0fbabc-b13e-46bf-be24-e190d0c4a986.jpg)

Size of the containerd image cache:

```
du -h /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs
...
1.1G	/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/
```

Size of a running node without any cached images (so the minimal images pulled needed to start the node):

```
du -h /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/
...
470M	/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
