### PR TITLE
Support worker nodes to continue to communicate to local cluster in Outposts even when the Outpost is disconnected from the parent AWS Region

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -404,9 +404,9 @@ if [[ -z "${B64_CLUSTER_CA}" ]] || [[ -z "${APISERVER_ENDPOINT}" ]]; then
     fi
     
     # If the cluster id is returned from describe cluster, let us use it no matter whether cluster id is passed from option
-	if [[ ! -z "${CLUSTER_ID_IN_DESCRIBE_CLUSTER_RESULT}" ]] && [[ "${CLUSTER_ID_IN_DESCRIBE_CLUSTER_RESULT}" != "None" ]]; then
-	    CLUSTER_ID=${CLUSTER_ID_IN_DESCRIBE_CLUSTER_RESULT}
-	fi
+    if [[ ! -z "${CLUSTER_ID_IN_DESCRIBE_CLUSTER_RESULT}" ]] && [[ "${CLUSTER_ID_IN_DESCRIBE_CLUSTER_RESULT}" != "None" ]]; then
+        CLUSTER_ID=${CLUSTER_ID_IN_DESCRIBE_CLUSTER_RESULT}
+    fi
 fi
 
 if [[ -z "${IP_FAMILY}" ]] || [[ "${IP_FAMILY}" == "None" ]]; then

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -119,10 +119,10 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
          --cluster-id)
-	        CLUSTER_ID=$2
-	        shift
-	        shift
-	        ;;
+            CLUSTER_ID=$2
+            shift
+            shift
+            ;;
         *)    # unknown option
             POSITIONAL+=("$1") # save it in an array for later
             shift # past argument
@@ -445,10 +445,10 @@ if [[ "${ENABLE_LOCAL_OUTPOST}" == "true" ]]; then
     ###   - if "aws eks describe-cluster" is bypassed, for local outpost, the value of CLUSTER_NAME parameter will be cluster id.
     ###   - otherwise, the cluster id will use the id returned by "aws eks describe-cluster".
     if [[ -z "${CLUSTER_ID}" ]]; then
-	    echo "Cluster ID is required when local outpost support is enabled"
-	    exit 1
-	else
-	    sed -i s,CLUSTER_NAME,$CLUSTER_ID,g /var/lib/kubelet/kubeconfig
+        echo "Cluster ID is required when local outpost support is enabled"
+        exit 1
+    else
+        sed -i s,CLUSTER_NAME,$CLUSTER_ID,g /var/lib/kubelet/kubeconfig
 
         ### use aws-iam-authenticator as bootstrap auth and download X.509 cert used in kubelet kubeconfig
         mv /var/lib/kubelet/kubeconfig /var/lib/kubelet/bootstrap-kubeconfig

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -30,6 +30,7 @@ function print_help {
     echo "--container-runtime Specify a container runtime (default: dockerd)"
     echo "--ip-family Specify ip family of the cluster"
     echo "--service-ipv6-cidr ipv6 cidr range of the cluster"
+    echo "--enable-local-outpost Enable support for worker nodes to communicate with the local control plane when running on a disconnected Outpost. (true or false)"    
 }
 
 POSITIONAL=()
@@ -111,6 +112,11 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
+        --enable-local-outpost)
+            ENABLE_LOCAL_OUTPOST=$2
+            shift
+            shift
+            ;; 
         *)    # unknown option
             POSITIONAL+=("$1") # save it in an array for later
             shift # past argument
@@ -137,6 +143,7 @@ PAUSE_CONTAINER_VERSION="${PAUSE_CONTAINER_VERSION:-3.1-eksbuild.1}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-dockerd}"
 IP_FAMILY="${IP_FAMILY:-}"
 SERVICE_IPV6_CIDR="${SERVICE_IPV6_CIDR:-}"
+ENABLE_LOCAL_OUTPOST="${ENABLE_LOCAL_OUTPOST:-}"
 
 function get_pause_container_account_for_region () {
     local region="$1"
@@ -360,7 +367,7 @@ if [[ -z "${B64_CLUSTER_CA}" ]] || [[ -z "${APISERVER_ENDPOINT}" ]]; then
             --region=${AWS_DEFAULT_REGION} \
             --name=${CLUSTER_NAME} \
             --output=text \
-            --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint, serviceIpv4Cidr: kubernetesNetworkConfig.serviceIpv4Cidr, serviceIpv6Cidr: kubernetesNetworkConfig.serviceIpv6Cidr, clusterIpFamily: kubernetesNetworkConfig.ipFamily}' > $DESCRIBE_CLUSTER_RESULT || rc=$?
+            --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint, serviceIpv4Cidr: kubernetesNetworkConfig.serviceIpv4Cidr, serviceIpv6Cidr: kubernetesNetworkConfig.serviceIpv6Cidr, clusterIpFamily: kubernetesNetworkConfig.ipFamily, outpostArn: outpostConfig.outpostArns[0], id: id}' > $DESCRIBE_CLUSTER_RESULT || rc=$?
         if [[ $rc -eq 0 ]]; then
             break
         fi
@@ -373,11 +380,20 @@ if [[ -z "${B64_CLUSTER_CA}" ]] || [[ -z "${APISERVER_ENDPOINT}" ]]; then
     done
     B64_CLUSTER_CA=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $1}')
     APISERVER_ENDPOINT=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $3}')
-    SERVICE_IPV4_CIDR=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $4}')
-    SERVICE_IPV6_CIDR=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $5}')
+    CLUSTER_ID=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $4}')
+    OUTPOST_ARN=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $5}')
+    SERVICE_IPV4_CIDR=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $6}')
+    SERVICE_IPV6_CIDR=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $7}')
 
     if [[ -z "${IP_FAMILY}" ]]; then
       IP_FAMILY=$(cat $DESCRIBE_CLUSTER_RESULT | awk '{print $2}')
+    fi
+
+    # Automatically detect local cluster in outpost
+    if [[ -z "${OUTPOST_ARN}" ]] || [[ "${OUTPOST_ARN}" == "None" ]]; then
+        IS_LOCAL_OUTPOST_DETECTED=false
+    else
+        IS_LOCAL_OUTPOST_DETECTED=true
     fi
 fi
 
@@ -389,9 +405,43 @@ fi
 
 echo $B64_CLUSTER_CA | base64 -d > $CA_CERTIFICATE_FILE_PATH
 
-sed -i s,CLUSTER_NAME,$CLUSTER_NAME,g /var/lib/kubelet/kubeconfig
 sed -i s,MASTER_ENDPOINT,$APISERVER_ENDPOINT,g /var/lib/kubelet/kubeconfig
 sed -i s,AWS_REGION,$AWS_DEFAULT_REGION,g /var/lib/kubelet/kubeconfig
+
+if [[ -z "$ENABLE_LOCAL_OUTPOST" ]]; then
+    # Only when "--enable-local-outpost" option is not set explicity on calling bootstrap.sh, it will be assigned with 
+    #    - the result of auto-detectection through describe-cluster
+    #    - or "false" when describe-cluster is bypassed.
+    #  This also means if "--enable-local-outpost" option is set explicity, it will override auto-detection result
+    ENABLE_LOCAL_OUTPOST="${IS_LOCAL_OUTPOST_DETECTED:-false}"    
+fi
+
+### To support worker nodes to continue to communicate and connect to local cluster even when the Outpost 
+### is disconnected from the parent AWS Region, the following specific setup are required:
+###    - append entries to /etc/hosts with the mappings of control plane host IP address and API server 
+###      domain name. So that the domain name can be resolved to IP addresses locally.
+###    - use aws-iam-authenticator as bootstrap auth for kubelet TLS bootstrapping which downloads client 
+###      X.509 certificate and generate kubelet kubeconfig file which uses the cleint cert. So that the 
+###      worker node can be authentiacated through X.509 certificate which works for both connected and 
+####     disconnected state.
+if [[ "${ENABLE_LOCAL_OUTPOST}" == "true" ]]; then
+    ### append to /etc/hosts file with shuffled mappings of "IP address to API server domain name"
+    DOMAIN_NAME=$(echo "$APISERVER_ENDPOINT" | awk -F/ '{print $3}' | awk -F: '{print $1}')
+    getent hosts "$DOMAIN_NAME" | shuf >> /etc/hosts
+
+    ### kubelet bootstrap kubeconfig uses aws-iam-authenticator with cluster id to authenticate to cluster
+    ###   - if "aws eks describe-cluster" is bypassed, for local outpost, the value of CLUSTER_NAME parameter will be cluster id.
+    ###   - otherwise, the cluster id will use the id returned by "aws eks describe-cluster".
+    CLUSTER_ID="${CLUSTER_ID:-$CLUSTER_NAME}" 
+    sed -i s,CLUSTER_NAME,$CLUSTER_ID,g /var/lib/kubelet/kubeconfig
+
+    ### use aws-iam-authenticator as bootstrap auth and download X.509 cert used in kubelet kubeconfig
+    mv /var/lib/kubelet/kubeconfig /var/lib/kubelet/bootstrap-kubeconfig
+    KUBELET_EXTRA_ARGS="--bootstrap-kubeconfig /var/lib/kubelet/bootstrap-kubeconfig $KUBELET_EXTRA_ARGS"
+else
+    sed -i s,CLUSTER_NAME,$CLUSTER_NAME,g /var/lib/kubelet/kubeconfig
+fi
+
 ### kubelet.service configuration
 
 if [[ "${IP_FAMILY}" == "ipv6" ]]; then


### PR DESCRIPTION
Support worker nodes to continue to communicate to local cluster in Outposts even when the Outpost is disconnected from the parent AWS Region.

*Issue #, if available:*

*Description of changes:*
- How the "local cluster in outpost support" is determined?
   - If `--enable-local-outpost` option is be set with `true` or `false` explicitly, it will override the auto-detection of local cluster in the outpost.
   - If `--enable-local-outpost` option is not set and `aws eks describe-clsuter` is not bypassed [1], it will rely on whether the `outpostArn` is returned in the response of `aws eks describe-clsuter`.

- How does it support for worker nodes to continue to communicate and connect to the cluster even when the Outpost is disconnected from the AWS Region?
  - If "local cluster in outpost support" is turned on, it will
    - append entries to /etc/hosts with the mapping of control plane IP addresses to API server domain name so that the domain name can be resolved to IP addresses locally. This will work for both connected and disconnected states.
    - use `aws-iam-authenticator` as bootstrap authentication in kubelet bootstrap kubeconfig to download X.509 certificate which will be used in the generated kubelet kubeconfig. With X.509 certificate, worker node’s kubelet will be able to authenticate to API server during disconnected state.
 
[1] - The DescribeCluster call happens when `B64_CLUSTER_CA` or `APISERVER_ENDPOINT` aren't defined. Note that this PR doesn't change this behavior. 

*Testing:*
Add worker nodes to local outpost cluster successfully and the status is Ready:
```txt
$ kubectl get nodes
NAME                                       STATUS   ROLES                  AGE     VERSION
ip-10-0-2-124.us-west-2.compute.internal   Ready    control-plane,master   4h      v1.21.6
ip-10-0-2-199.us-west-2.compute.internal   Ready    control-plane,master   4h2m    v1.21.6
ip-10-0-2-247.us-west-2.compute.internal   Ready    control-plane,master   3h57m   v1.21.6
ip-10-0-2-136.us-west-2.compute.internal   Ready    <none>                 64s     v1.21.12-eks-5308cf7
ip-10-0-3-210.us-west-2.compute.internal   Ready    <none>                 82s     v1.21.12-eks-5308cf7
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
