### PR TITLE
Adding c6id, m6id, r6id to eni-max-pods.txt

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -11,26 +11,21 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-# This file was generated at 2022-05-09T10:14:37-07:00
+# This file was generated at 2022-06-10T09:23:03-07:00
 #
 # The regions queried were:
-# - af-south-1
-# - ap-east-1
 # - ap-northeast-1
 # - ap-northeast-2
 # - ap-northeast-3
 # - ap-south-1
 # - ap-southeast-1
 # - ap-southeast-2
-# - ap-southeast-3
 # - ca-central-1
 # - eu-central-1
 # - eu-north-1
-# - eu-south-1
 # - eu-west-1
 # - eu-west-2
 # - eu-west-3
-# - me-south-1
 # - sa-east-1
 # - us-east-1
 # - us-east-2
@@ -153,6 +148,16 @@ c6i.8xlarge 234
 c6i.large 29
 c6i.metal 737
 c6i.xlarge 58
+c6id.12xlarge 234
+c6id.16xlarge 737
+c6id.24xlarge 737
+c6id.2xlarge 58
+c6id.32xlarge 737
+c6id.4xlarge 234
+c6id.8xlarge 234
+c6id.large 29
+c6id.metal 737
+c6id.xlarge 58
 c7g.12xlarge 234
 c7g.16xlarge 737
 c7g.2xlarge 58
@@ -245,6 +250,7 @@ i4i.32xlarge 737
 i4i.4xlarge 234
 i4i.8xlarge 234
 i4i.large 29
+i4i.metal 737
 i4i.xlarge 58
 im4gn.16xlarge 737
 im4gn.2xlarge 58
@@ -377,6 +383,16 @@ m6i.8xlarge 234
 m6i.large 29
 m6i.metal 737
 m6i.xlarge 58
+m6id.12xlarge 234
+m6id.16xlarge 737
+m6id.24xlarge 737
+m6id.2xlarge 58
+m6id.32xlarge 737
+m6id.4xlarge 234
+m6id.8xlarge 234
+m6id.large 29
+m6id.metal 737
+m6id.xlarge 58
 mac1.metal 234
 p2.16xlarge 234
 p2.8xlarge 234
@@ -486,6 +502,16 @@ r6i.8xlarge 234
 r6i.large 29
 r6i.metal 737
 r6i.xlarge 58
+r6id.12xlarge 234
+r6id.16xlarge 737
+r6id.24xlarge 737
+r6id.2xlarge 58
+r6id.32xlarge 737
+r6id.4xlarge 234
+r6id.8xlarge 234
+r6id.large 29
+r6id.metal 737
+r6id.xlarge 58
 t1.micro 4
 t2.2xlarge 44
 t2.large 35


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-eks-ami/issues/942

*Description of changes:*
Followed https://github.com/awslabs/amazon-eks-ami/blob/master/USER_GUIDE.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
