### PR TITLE
eks-log-collector.sh: add timeout to df command

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -210,7 +210,7 @@ is_diskfull() {
 
   # 1.5GB in KB
   threshold=1500000
-  result=$(df / | grep --invert-match "Filesystem" | awk '{ print $4 }')
+  result=$(timeout 75 df / | grep --invert-match "Filesystem" | awk '{ print $4 }')
 
   # If "result" is less than or equal to "threshold", fail.
   if [[ "${result}" -le "${threshold}" ]]; then
@@ -278,9 +278,9 @@ get_mounts_info() {
   try "collect mount points and volume information"
   mount > "${COLLECT_DIR}"/storage/mounts.txt
   echo >> "${COLLECT_DIR}"/storage/mounts.txt
-  df --human-readable >> "${COLLECT_DIR}"/storage/mounts.txt
+  timeout 75 df --human-readable >> "${COLLECT_DIR}"/storage/mounts.txt
   lsblk > "${COLLECT_DIR}"/storage/lsblk.txt
-  lvs > "${COLLECT_DIR}"/storage/lvs.txt
+  m > "${COLLECT_DIR}"/storage/lvs.txt
   pvs > "${COLLECT_DIR}"/storage/pvs.txt
   vgs > "${COLLECT_DIR}"/storage/vgs.txt
 


### PR DESCRIPTION
*Description of changes:*

In some instances, `df` command doesn't work and therefore log collection fails. 
An example scenario, where df hangs is https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/616. 

This change will make sure that our log collector works for the above issue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
