### PR TITLE
Update Makefile to reflect latest 1.20 binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ k8s: validate
 
 .PHONY: 1.20
 1.20:
-	$(MAKE) k8s kubernetes_version=1.20.11 kubernetes_build_date=2021-11-10 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.20.15 kubernetes_build_date=2022-06-20 pull_cni_from_github=true
 
 .PHONY: 1.21
 1.21:


### PR DESCRIPTION
We recently updated the 1.20 binaries with latest build dates and those respective binaries have been uploaded to the s3 bucket.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
