### PR TITLE
Extend support for containerd log collecting

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -559,11 +559,25 @@ get_containerd_info() {
         warning "The Containerd daemon is not running."
     fi
 
-   ok
+    ok
+
+    try "Collect Containerd running information"
+    if ! command -v ctr >/dev/null 2>&1; then
+        warning "ctr not installed"
+    else
+        timeout 75 ctr version > "${COLLECT_DIR}"/containerd/containerd-version.txt 2>&1 || echo -e "\tTimed out, ignoring \"containerd info output \" "
+        timeout 75 ctr namespaces list > "${COLLECT_DIR}"/containerd/containerd-namespaces.txt 2>&1 || echo -e "\tTimed out, ignoring \"containerd info output \" "
+        timeout 75 ctr --namespace k8s.io images list > "${COLLECT_DIR}"/containerd/containerd-images.txt 2>&1 || echo -e "\tTimed out, ignoring \"containerd info output \" "
+        timeout 75 ctr --namespace k8s.io containers list > "${COLLECT_DIR}"/containerd/containerd-containers.txt 2>&1 || echo -e "\tTimed out, ignoring \"containerd info output \" "
+        timeout 75 ctr --namespace k8s.io tasks list > "${COLLECT_DIR}"/containerd/containerd-tasks.txt 2>&1 || echo -e "\tTimed out, ignoring \"containerd info output \" "
+        timeout 75 ctr --namespace k8s.io plugins list > "${COLLECT_DIR}"/containerd/containerd-plugins.txt 2>&1 || echo -e "\tTimed out, ignoring \"containerd info output \" "
+    fi
+
+    ok
 }
 
 get_sandboxImage_info() {
-    try "Collect sandbox-image daemon information"      
+    try "Collect sandbox-image daemon information"
       timeout 75 journalctl -u sandbox-image > "${COLLECT_DIR}"/sandbox-image/sandbox-image-log.txt 2>&1 || echo -e "\tTimed out, ignoring \"sandbox-image info output \" "
    ok
 }


### PR DESCRIPTION
*Description of changes:*

EKS node with `--container-runtime containerd` flag set, will use `containerd` as runtime. However, `eks-log-collector.sh`  currently only support containerd daemon log collecting but no container images, running containers, container namespace, etc. With this pull-request, enable `eks-log-collector.sh` to collect more useful information which will be helpful while debugging.

**Before Change:**
```
// ...
├── containerd
│   ├── containerd-config.txt
│   └── containerd-log.txt
├── docker
│   └── docker.log
// ...
```

```
$ cat docker/docker.log
-- No entries -- # <----- empty, since we are using "containerd" as container runtime.
```

**After Change:**
```
// ...
├── containerd
│   ├── containerd-config.txt
│   ├── containerd-containers.txt
│   ├── containerd-images.txt
│   ├── containerd-log.txt
│   ├── containerd-namespaces.txt
│   ├── containerd-plugins.txt
│   ├── containerd-tasks.txt
│   └── containerd-version.txt
├── docker
│   └── docker.log
// ...
```