### PR TITLE
adding log-collector-script directory as dependency dir

### DIFF
--- a/ArchiveBuildConfig.yaml
+++ b/ArchiveBuildConfig.yaml
@@ -9,6 +9,7 @@ dependencies:
     dirs:
       - src: files/
       - src: scripts/
+      - src: log-collector-script/
     files:
       - src: Makefile
       - src: eks-worker-al2.json


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding log-collector-script directory as dependency dir. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
