### PR TITLE
Generate version-info.json during build

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -174,6 +174,18 @@
       "environment_vars": [
         "KERNEL_VERSION={{user `kernel_version`}}"
       ]
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "script": "{{template_dir}}/scripts/generate-version-info.sh",
+      "execute_command": "chmod +x {{ .Path }}; {{ .Path }} /tmp/version-info.json"
+    },
+    {
+      "type": "file",
+      "direction": "download",
+      "source": "/tmp/version-info.json",
+      "destination": "{{ user `ami_name` }}-version-info.json"
     }
   ],
   "post-processors": [

--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -14,7 +14,7 @@ fi
 OUTPUT_FILE="$1"
 
 # packages
-yum list installed --quiet | awk '{print $1, $2}' | jq -R 'inputs | split(" ") | {(.[0]):(.[1])}' | jq -s add  | jq '{packages:(.)}' > "$OUTPUT_FILE"
+rpm --query --all --queryformat '\{"%{NAME}": "%{VERSION}-%{RELEASE}"\}\n' | jq --slurp --sort-keys 'add | {packages:(.)}' > "$OUTPUT_FILE"
 
 # binaries
 echo $(jq ".binaries.kubelet = \"$(kubelet --version | awk '{print $2}')\"" $OUTPUT_FILE) > $OUTPUT_FILE

--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -2,6 +2,9 @@
 
 # generates a JSON file containing version information for the software in this AMI
 
+set -o errexit
+set -o pipefail
+
 if [ "$#" -ne 1 ]
 then
   echo "usage: $0 OUTPUT_FILE"
@@ -14,4 +17,4 @@ OUTPUT_FILE="$1"
 yum list installed --quiet | awk '{print $1, $2}' | jq -R 'inputs | split(" ") | {(.[0]):(.[1])}' | jq -s add  | jq '{packages:(.)}' > "$OUTPUT_FILE"
 
 # binaries
-echo $(jq ".binaries.kubelet = $(kubelet --version | awk '{print $2}')" $OUTPUT_FILE) > $OUTPUT_FILE
+echo $(jq ".binaries.kubelet = \"$(kubelet --version | awk '{print $2}')\"" $OUTPUT_FILE) > $OUTPUT_FILE

--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# generates a JSON file containing version information for the software in this AMI
+
+if [ "$#" -ne 1 ]
+then
+  echo "usage: $0 OUTPUT_FILE"
+  exit 1
+fi
+
+OUTPUT_FILE="$1"
+
+# packages
+yum list installed --quiet | awk '{print $1, $2}' | jq -R 'inputs | split(" ") | {(.[0]):(.[1])}' | jq -s add  | jq '{packages:(.)}' > "$OUTPUT_FILE"
+
+# binaries
+echo $(jq ".binaries.kubelet = $(kubelet --version | awk '{print $2}')" $OUTPUT_FILE) > $OUTPUT_FILE


### PR DESCRIPTION
**Description of changes:**

To help streamline our release process, this generates and downloads a `version-info.json` file from the built AMI that looks like:
```
{
  "packages": {
    "containerd": "1.4.13-1.amzn2",
    "docker": "20.10.13-2.amzn2",
    "runc": "1.0.0-2.amzn2"
  },
  "binaries": {
    "kubelet": "v1.25.0-alpha.0.563+92285fd74e8906"
  }
}
```

The file will be named similarly to the packer `manifest.json` (prefixed by AMI name).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

`make 1.22` and got resulting file `amazon-eks-node-1.22-v20220801-version-info.json` containing:
```
{
  "packages": {
    "PyYAML": "3.10-11.amzn2.0.2",
    "acl": "2.2.51-14.amzn2",
    "amazon-linux-extras": "2.0.1-1.amzn2",
    "amazon-ssm-agent": "3.1.1575.0-1.amzn2",
    "audit": "2.8.1-3.amzn2.1",
    "audit-libs": "2.8.1-3.amzn2.1",
    "authconfig": "6.2.8-30.amzn2.0.2",
    "aws-cfn-bootstrap": "2.0-10.amzn2",
    "awscli": "1.18.147-1.amzn2.0.1",
    "basesystem": "10.0-7.amzn2.0.1",
    "bash": "4.2.46-34.amzn2",
    "bind-export-libs": "9.11.4-26.P2.amzn2.5.2",
    "bzip2-libs": "1.0.6-13.amzn2.0.3",
    "ca-certificates": "2021.2.50-72.amzn2.0.3",
    "chkconfig": "1.7.4-1.amzn2.0.2",
    "chrony": "4.0-3.amzn2.0.2",
    "cloud-init": "19.3-45.amzn2",
    "cloud-utils-growpart": "0.31-3.amzn2",
    "conntrack-tools": "1.4.4-5.amzn2.2",
    "containerd": "1.4.13-3.amzn2",
    "coreutils": "8.22-24.amzn2",
    "cpio": "2.11-28.amzn2",
    "cracklib": "2.9.0-11.amzn2.0.2",
    "cracklib-dicts": "2.9.0-11.amzn2.0.2",
    "cronie": "1.4.11-23.amzn2",
    "cronie-anacron": "1.4.11-23.amzn2",
    "crontabs": "1.11-6.20121102git.amzn2",
    "cryptsetup-libs": "1.7.4-4.amzn2",
    "curl": "7.79.1-4.amzn2.0.1",
    "cyrus-sasl-lib": "2.1.26-24.amzn2",
    "dbus": "1.10.24-7.amzn2",
    "dbus-libs": "1.10.24-7.amzn2",
    "device-mapper": "1.02.170-6.amzn2.5",
    "device-mapper-event": "1.02.170-6.amzn2.5",
    "device-mapper-event-libs": "1.02.170-6.amzn2.5",
    "device-mapper-libs": "1.02.170-6.amzn2.5",
    "device-mapper-persistent-data": "0.7.3-3.amzn2",
    "dhclient": "4.2.5-77.amzn2.1.6",
    "dhcp-common": "4.2.5-77.amzn2.1.6",
    "dhcp-libs": "4.2.5-77.amzn2.1.6",
    "diffutils": "3.3-5.amzn2",
    "docker": "20.10.13-2.amzn2",
    "dracut": "033-535.amzn2.1.6",
    "dracut-config-ec2": "2.0-3.amzn2",
    "dracut-config-generic": "033-535.amzn2.1.6",
    "e2fsprogs": "1.42.9-19.amzn2",
    "e2fsprogs-libs": "1.42.9-19.amzn2",
    "ec2-instance-connect": "1.1-15.amzn2",
    "ec2-utils": "1.2-47.amzn2",
    "elfutils-default-yama-scope": "0.176-2.amzn2",
    "elfutils-libelf": "0.176-2.amzn2",
    "elfutils-libs": "0.176-2.amzn2",
    "expat": "2.1.0-14.amzn2.0.1",
    "file": "5.11-36.amzn2.0.1",
    "file-libs": "5.11-36.amzn2.0.1",
    "filesystem": "3.2-25.amzn2.0.4",
    "findutils": "4.5.11-6.amzn2",
    "fipscheck": "1.4.1-6.amzn2.0.2",
    "fipscheck-lib": "1.4.1-6.amzn2.0.2",
    "freetype": "2.8-14.amzn2.1",
    "fuse-libs": "2.9.2-11.amzn2",
    "gawk": "4.0.2-4.amzn2.1.2",
    "gdbm": "1.13-6.amzn2.0.2",
    "gdisk": "0.8.10-3.amzn2",
    "gettext": "0.19.8.1-3.amzn2",
    "gettext-libs": "0.19.8.1-3.amzn2",
    "glib2": "2.56.1-9.amzn2.0.2",
    "glibc": "2.26-59.amzn2",
    "glibc-all-langpacks": "2.26-59.amzn2",
    "glibc-common": "2.26-59.amzn2",
    "glibc-locale-source": "2.26-59.amzn2",
    "glibc-minimal-langpack": "2.26-59.amzn2",
    "gmp": "6.0.0-15.amzn2.0.2",
    "gnupg2": "2.0.22-5.amzn2.0.4",
    "gpg-pubkey": "c87f5b1a-593863f8",
    "gpgme": "1.3.2-5.amzn2.0.2",
    "grep": "2.20-3.amzn2.0.2",
    "groff-base": "1.22.2-8.amzn2.0.2",
    "grub2": "2.06-9.amzn2.0.1",
    "grub2-common": "2.06-9.amzn2.0.1",
    "grub2-efi-x64-ec2": "2.06-9.amzn2.0.1",
    "grub2-pc": "2.06-9.amzn2.0.1",
    "grub2-pc-modules": "2.06-9.amzn2.0.1",
    "grub2-tools": "2.06-9.amzn2.0.1",
    "grub2-tools-minimal": "2.06-9.amzn2.0.1",
    "grubby": "8.28-23.amzn2.0.3",
    "gssproxy": "0.7.0-17.amzn2",
    "gzip": "1.5-10.amzn2.0.1",
    "hardlink": "1.3-3.amzn2",
    "hostname": "3.13-3.amzn2.0.2",
    "info": "5.1-5.amzn2",
    "initscripts": "9.49.47-1.amzn2.0.2",
    "iproute": "5.10.0-2.amzn2.0.3",
    "iptables": "1.8.4-10.amzn2.1.2",
    "iptables-libs": "1.8.4-10.amzn2.1.2",
    "iputils": "20160308-10.amzn2.0.2",
    "ipvsadm": "1.27-7.amzn2.0.2",
    "irqbalance": "1.7.0-4.amzn2.0.1",
    "jbigkit-libs": "2.0-11.amzn2.0.2",
    "jq": "1.5-1.amzn2.0.2",
    "kernel": "5.4.204-113.362.amzn2",
    "keyutils": "1.5.8-3.amzn2.0.2",
    "keyutils-libs": "1.5.8-3.amzn2.0.2",
    "kmod": "25-3.amzn2.0.2",
    "kmod-libs": "25-3.amzn2.0.2",
    "kpartx": "0.4.9-127.amzn2",
    "krb5-libs": "1.15.1-37.amzn2.2.4",
    "less": "458-9.amzn2.0.2",
    "libacl": "2.2.51-14.amzn2",
    "libaio": "0.3.109-13.amzn2.0.2",
    "libassuan": "2.1.0-3.amzn2.0.2",
    "libattr": "2.4.46-12.amzn2.0.2",
    "libbasicobjects": "0.1.1-29.amzn2",
    "libblkid": "2.30.2-2.amzn2.0.7",
    "libcap": "2.54-1.amzn2.0.1",
    "libcap-ng": "0.7.5-4.amzn2.0.4",
    "libcgroup": "0.41-21.amzn2",
    "libcollection": "0.7.0-29.amzn2",
    "libcom_err": "1.42.9-19.amzn2",
    "libcroco": "0.6.12-6.amzn2",
    "libcrypt": "2.26-59.amzn2",
    "libcurl": "7.79.1-4.amzn2.0.1",
    "libdb": "5.3.21-24.amzn2.0.3",
    "libdb-utils": "5.3.21-24.amzn2.0.3",
    "libedit": "3.0-12.20121213cvs.amzn2.0.2",
    "libestr": "0.1.9-2.amzn2.0.2",
    "libevent": "2.0.21-4.amzn2.0.3",
    "libfastjson": "0.99.4-3.amzn2",
    "libfdisk": "2.30.2-2.amzn2.0.7",
    "libffi": "3.0.13-18.amzn2.0.2",
    "libgcc": "7.3.1-15.amzn2",
    "libgcrypt": "1.5.3-14.amzn2.0.3",
    "libgomp": "7.3.1-15.amzn2",
    "libgpg-error": "1.12-3.amzn2.0.3",
    "libicu": "50.2-4.amzn2",
    "libidn": "1.28-4.amzn2.0.2",
    "libidn2": "2.3.0-1.amzn2",
    "libini_config": "1.3.1-29.amzn2",
    "libjpeg-turbo": "2.0.90-2.amzn2.0.1",
    "libmetalink": "0.1.3-13.amzn2",
    "libmnl": "1.0.3-7.amzn2.0.2",
    "libmount": "2.30.2-2.amzn2.0.7",
    "libnetfilter_conntrack": "1.0.6-1.amzn2.0.2",
    "libnetfilter_cthelper": "1.0.0-10.amzn2.1",
    "libnetfilter_cttimeout": "1.0.0-6.amzn2.1",
    "libnetfilter_queue": "1.0.2-2.amzn2.0.2",
    "libnfnetlink": "1.0.1-4.amzn2.0.2",
    "libnfsidmap": "0.25-19.amzn2",
    "libnghttp2": "1.41.0-1.amzn2",
    "libnl3": "3.2.28-4.amzn2.0.1",
    "libpath_utils": "0.2.1-29.amzn2",
    "libpcap": "1.5.3-11.amzn2",
    "libpipeline": "1.2.3-3.amzn2.0.2",
    "libpng": "1.5.13-8.amzn2",
    "libpwquality": "1.2.3-5.amzn2",
    "libref_array": "0.1.5-29.amzn2",
    "libseccomp": "2.4.1-1.amzn2",
    "libselinux": "2.5-12.amzn2.0.2",
    "libselinux-utils": "2.5-12.amzn2.0.2",
    "libsemanage": "2.5-11.amzn2",
    "libsepol": "2.5-8.1.amzn2.0.2",
    "libsmartcols": "2.30.2-2.amzn2.0.7",
    "libss": "1.42.9-19.amzn2",
    "libssh2": "1.4.3-12.amzn2.2.3",
    "libstdc++": "7.3.1-15.amzn2",
    "libsysfs": "2.1.0-16.amzn2.0.2",
    "libtasn1": "4.10-1.amzn2.0.2",
    "libtiff": "4.0.3-35.amzn2.0.2",
    "libtirpc": "0.2.4-0.16.amzn2",
    "libunistring": "0.9.3-9.amzn2.0.2",
    "libuser": "0.60-9.amzn2",
    "libutempter": "1.1.6-4.amzn2.0.2",
    "libuuid": "2.30.2-2.amzn2.0.7",
    "libverto": "0.2.5-4.amzn2.0.2",
    "libverto-libevent": "0.2.5-4.amzn2.0.2",
    "libwebp": "0.3.0-10.amzn2",
    "libxml2": "2.9.1-6.amzn2.5.5",
    "libxml2-python": "2.9.1-6.amzn2.5.5",
    "libyaml": "0.1.4-11.amzn2.0.2",
    "logrotate": "3.8.6-15.amzn2",
    "lua": "5.1.4-15.amzn2.0.2",
    "lvm2": "2.02.187-6.amzn2.5",
    "lvm2-libs": "2.02.187-6.amzn2.5",
    "lz4": "1.7.5-2.amzn2.0.1",
    "make": "3.82-24.amzn2",
    "man-db": "2.6.3-9.amzn2.0.3",
    "mariadb-libs": "5.5.68-1.amzn2",
    "microcode_ctl": "2.1-47.amzn2.0.12",
    "ncurses": "6.0-8.20170212.amzn2.1.3",
    "ncurses-base": "6.0-8.20170212.amzn2.1.3",
    "ncurses-libs": "6.0-8.20170212.amzn2.1.3",
    "net-tools": "2.0-0.22.20131004git.amzn2.0.2",
    "nettle": "2.7.1-9.amzn2",
    "newt": "0.52.15-4.amzn2.0.2",
    "newt-python": "0.52.15-4.amzn2.0.2",
    "nfs-utils": "1.3.0-0.54.amzn2.0.2",
    "nspr": "4.32.0-1.amzn2.0.1",
    "nss": "3.67.0-4.amzn2.0.2",
    "nss-pem": "1.0.3-5.amzn2",
    "nss-softokn": "3.67.0-3.amzn2.0.1",
    "nss-softokn-freebl": "3.67.0-3.amzn2.0.1",
    "nss-sysinit": "3.67.0-4.amzn2.0.2",
    "nss-tools": "3.67.0-4.amzn2.0.2",
    "nss-util": "3.67.0-1.amzn2.0.1",
    "numactl-libs": "2.0.9-7.amzn2",
    "oniguruma": "5.9.6-1.amzn2.0.4",
    "openldap": "2.4.44-23.amzn2.0.4",
    "openssh": "7.4p1-22.amzn2.0.1",
    "openssh-clients": "7.4p1-22.amzn2.0.1",
    "openssh-server": "7.4p1-22.amzn2.0.1",
    "openssl": "1.0.2k-24.amzn2.0.3",
    "openssl-libs": "1.0.2k-24.amzn2.0.3",
    "os-prober": "1.58-9.amzn2.0.2",
    "p11-kit": "0.23.22-1.amzn2.0.1",
    "p11-kit-trust": "0.23.22-1.amzn2.0.1",
    "pam": "1.1.8-23.amzn2.0.1",
    "passwd": "0.79-5.amzn2",
    "pcre": "8.32-17.amzn2.0.2",
    "pcre2": "10.23-2.amzn2.0.2",
    "pigz": "2.3.4-1.amzn2.0.1",
    "pinentry": "0.8.1-17.amzn2.0.2",
    "pkgconfig": "0.27.1-4.amzn2.0.2",
    "policycoreutils": "2.5-22.amzn2",
    "popt": "1.13-16.amzn2.0.2",
    "postfix": "2.10.1-6.amzn2.0.3",
    "procps-ng": "3.3.10-26.amzn2",
    "psmisc": "22.20-15.amzn2.0.2",
    "pth": "2.0.7-23.amzn2.0.2",
    "pygpgme": "0.3-9.amzn2.0.3",
    "pyliblzma": "0.5.3-25.amzn2",
    "python": "2.7.18-1.amzn2.0.5",
    "python-babel": "0.9.6-8.amzn2.0.1",
    "python-backports": "1.0-8.amzn2.0.2",
    "python-backports-ssl_match_hostname": "3.5.0.1-1.amzn2",
    "python-cffi": "1.6.0-5.amzn2.0.2",
    "python-chardet": "2.2.1-1.amzn2",
    "python-colorama": "0.3.2-3.amzn2",
    "python-configobj": "4.7.2-7.amzn2",
    "python-devel": "2.7.18-1.amzn2.0.5",
    "python-docutils": "0.12-0.2.20140510svn7747.amzn2",
    "python-enum34": "1.0.4-1.amzn2",
    "python-idna": "2.4-1.amzn2",
    "python-iniparse": "0.4-9.amzn2",
    "python-ipaddress": "1.0.16-2.amzn2",
    "python-jinja2": "2.7.2-3.amzn2",
    "python-jsonpatch": "1.2-4.amzn2",
    "python-jsonpointer": "1.9-2.amzn2",
    "python-jwcrypto": "0.4.2-1.amzn2",
    "python-kitchen": "1.1.1-5.amzn2",
    "python-libs": "2.7.18-1.amzn2.0.5",
    "python-markupsafe": "0.11-10.amzn2.0.2",
    "python-pillow": "2.0.0-23.gitd1c6db8.amzn2.0.1",
    "python-ply": "3.4-11.amzn2",
    "python-pycparser": "2.14-1.amzn2",
    "python-pycurl": "7.19.0-19.amzn2.0.2",
    "python-repoze-lru": "0.4-3.amzn2",
    "python-requests": "2.6.0-7.amzn2",
    "python-six": "1.9.0-2.amzn2",
    "python-urlgrabber": "3.10-9.amzn2.0.1",
    "python-urllib3": "1.25.9-1.amzn2.0.2",
    "python2-botocore": "1.18.6-1.amzn2.0.1",
    "python2-cryptography": "1.7.2-2.amzn2",
    "python2-dateutil": "2.6.0-3.amzn2.0.1",
    "python2-futures": "3.0.5-1.amzn2",
    "python2-jmespath": "0.9.3-1.amzn2.0.1",
    "python2-jsonschema": "2.5.1-3.amzn2.0.1",
    "python2-oauthlib": "2.0.1-8.amzn2.0.1",
    "python2-pyasn1": "0.1.9-7.amzn2.0.1",
    "python2-rpm": "4.11.3-48.amzn2.0.2",
    "python2-rsa": "3.4.1-1.amzn2.0.1",
    "python2-s3transfer": "0.3.3-1.amzn2.0.1",
    "python2-setuptools": "41.2.0-4.amzn2.0.2",
    "python3": "3.7.10-1.amzn2.0.1",
    "python3-daemon": "2.2.3-8.amzn2.0.2",
    "python3-docutils": "0.14-1.amzn2.0.2",
    "python3-libs": "3.7.10-1.amzn2.0.1",
    "python3-lockfile": "0.11.0-17.amzn2.0.2",
    "python3-pip": "20.2.2-1.amzn2.0.3",
    "python3-pystache": "0.5.4-12.amzn2.0.1",
    "python3-setuptools": "49.1.3-1.amzn2.0.2",
    "python3-simplejson": "3.2.0-1.amzn2.0.2",
    "pyxattr": "0.5.1-5.amzn2.0.2",
    "qrencode-libs": "3.4.1-3.amzn2.0.2",
    "quota": "4.01-17.amzn2",
    "quota-nls": "4.01-17.amzn2",
    "readline": "6.2-10.amzn2.0.2",
    "rng-tools": "6.8-3.amzn2.0.5",
    "rootfiles": "8.1-11.amzn2",
    "rpcbind": "0.2.0-44.amzn2",
    "rpm": "4.11.3-48.amzn2.0.2",
    "rpm-build-libs": "4.11.3-48.amzn2.0.2",
    "rpm-libs": "4.11.3-48.amzn2.0.2",
    "rpm-plugin-systemd-inhibit": "4.11.3-48.amzn2.0.2",
    "rsyslog": "8.24.0-57.amzn2.2.0.1",
    "runc": "1.0.3-2.amzn2",
    "sed": "4.2.2-5.amzn2.0.2",
    "selinux-policy": "3.13.1-192.amzn2.6.8",
    "selinux-policy-targeted": "3.13.1-192.amzn2.6.8",
    "setup": "2.8.71-10.amzn2.0.1",
    "shadow-utils": "4.1.5.1-24.amzn2.0.2",
    "shared-mime-info": "1.8-4.amzn2",
    "slang": "2.2.4-11.amzn2.0.2",
    "socat": "1.7.3.2-2.amzn2.0.1",
    "sqlite": "3.7.17-8.amzn2.1.1",
    "sudo": "1.8.23-10.amzn2.1",
    "sysctl-defaults": "1.0-3.amzn2",
    "system-release": "2-14.amzn2",
    "systemd": "219-78.amzn2.0.18",
    "systemd-libs": "219-78.amzn2.0.18",
    "systemd-sysv": "219-78.amzn2.0.18",
    "sysvinit-tools": "2.88-14.dsf.amzn2.0.2",
    "tar": "1.26-35.amzn2",
    "tcp_wrappers": "7.6-77.amzn2.0.2",
    "tcp_wrappers-libs": "7.6-77.amzn2.0.2",
    "tzdata": "2022a-1.amzn2",
    "unzip": "6.0-43.amzn2",
    "update-motd": "1.1.2-2.amzn2.0.2",
    "ustr": "1.0.4-16.amzn2.0.3",
    "util-linux": "2.30.2-2.amzn2.0.7",
    "vim-data": "8.2.5172-1.amzn2.0.1",
    "vim-minimal": "8.2.5172-1.amzn2.0.1",
    "wget": "1.14-18.amzn2.1",
    "which": "2.20-7.amzn2.0.2",
    "xfsprogs": "4.5.0-18.amzn2.0.1",
    "xz": "5.2.2-1.amzn2.0.3",
    "xz-libs": "5.2.2-1.amzn2.0.3",
    "yum": "3.4.3-158.amzn2.0.6",
    "yum-metadata-parser": "1.1.4-10.amzn2.0.2",
    "yum-plugin-priorities": "1.1.31-46.amzn2.0.1",
    "yum-plugin-versionlock": "1.1.31-46.amzn2.0.1",
    "yum-utils": "1.1.31-46.amzn2.0.1",
    "zlib": "1.2.7-19.amzn2.0.1"
  },
  "binaries": {
    "kubelet": "v1.22.9-eks-810597c"
  }
}
```