### PR TITLE
eks-log-collector.sh: collect information regarding throttled processes

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -591,23 +591,23 @@ get_cpu_throttled_processes() {
   readonly THROTTLE_LOG="${COLLECT_DIR}"/system/cpu_throttling.txt
   command find /sys/fs/cgroup -iname "cpu.stat" -print0 | while IFS= read -r -d '' cs
   do
-        # look for a non-zero nr_throttled value
-        if grep -q "nr_throttled [1-9]" "${cs}"; then
-                pids=${cs/cpu.stat/cgroup.procs}
-                lines=$(wc -l < "${pids}")
-                # ignore if no PIDs are listed
-                if [ "${lines}" -eq "0" ] ; then
-                        continue
-                fi
+    # look for a non-zero nr_throttled value
+    if grep -q "nr_throttled [1-9]" "${cs}"; then
+      pids=${cs/cpu.stat/cgroup.procs}
+      lines=$(wc -l < "${pids}")
+      # ignore if no PIDs are listed
+      if [ "${lines}" -eq "0" ] ; then
+        continue
+      fi
 
-                echo "$cs" >> "${THROTTLE_LOG}"
-                cat "${cs}" >> "${THROTTLE_LOG}"
-                while IFS= read -r pid
-                do
-                        command ps ax | grep "^${pid}" >> "${THROTTLE_LOG}"
-                done < "${pids}"
-                echo "" >>  "${THROTTLE_LOG}"
-        fi
+      echo "$cs" >> "${THROTTLE_LOG}"
+      cat "${cs}" >> "${THROTTLE_LOG}"
+      while IFS= read -r pid
+      do
+        command ps ax | grep "^${pid}" >> "${THROTTLE_LOG}"
+        done < "${pids}"
+        echo "" >>  "${THROTTLE_LOG}"
+      fi
   done
   if [ ! -e "${THROTTLE_LOG}" ]; then
     echo "No CPU Throttling Found" >>  "${THROTTLE_LOG}"


### PR DESCRIPTION
Collects process throttling information from /sys/fs/cgroup. In the event
of detected CPU throttling, the log will show the amount of throttling,
the pod and container UIDs if applicable and the processes being throttled:

```
$ cat system/cpu_throttling.txt
/sys/fs/cgroup/cpu,cpuacct/kubepods/burstable/poda207af95-18de-463f-a3f6-181f78900fc7/071f5ea890c12c15f98a8fdc3c60cd0fd31df4788194effd9add9713442adb23/cpu.stat
nr_periods 104065
nr_throttled 103964
throttled_time 18601742785642
12248 ?        SLs    0:00 /bin/stress-ng --cpu 0 --metrics-brief -v
12325 ?        R     10:39 /bin/stress-ng --cpu 0 --metrics-brief -v
12326 ?        R     11:01 /bin/stress-ng --cpu 0 --metrics-brief -v
12327 ?        R     11:04 /bin/stress-ng --cpu 0 --metrics-brief -v
12328 ?        R     10:36 /bin/stress-ng --cpu 0 --metrics-brief -v
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Tested on nodes using the EKS AL2 AMI