### PR TITLE
eks-log-collector.sh: record inode usage

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -279,6 +279,7 @@ get_mounts_info() {
   mount > "${COLLECT_DIR}"/storage/mounts.txt
   echo >> "${COLLECT_DIR}"/storage/mounts.txt
   timeout 75 df --human-readable >> "${COLLECT_DIR}"/storage/mounts.txt
+  timeout 75 df --inodes >> "${COLLECT_DIR}"/storage/inodes.txt
   lsblk > "${COLLECT_DIR}"/storage/lsblk.txt
   lvs > "${COLLECT_DIR}"/storage/lvs.txt
   pvs > "${COLLECT_DIR}"/storage/pvs.txt


### PR DESCRIPTION
**Description of changes:**

Record inode usage to a separate file in ./storage/. This will allow diagnosing issues where we run out of inodes
instead of disk space more easily.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Tested on an EKS node.
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
