### PR TITLE
Add timestamps to packer console output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ validate:
 .PHONY: k8s
 k8s: validate
 	@echo "$(T_GREEN)Building AMI for version $(T_YELLOW)$(kubernetes_version)$(T_GREEN) on $(T_YELLOW)$(arch)$(T_RESET)"
-	$(PACKER_BINARY) build $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
+	$(PACKER_BINARY) build -timestamp-ui $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
 
 # Build dates and versions taken from https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 


### PR DESCRIPTION
Lack of timestamps in console output hinders troubleshooting. Enabling debug output (`-debug`) is too verbose.

**Description of changes:**

Adds `-timestamp-ui` to `packer build` calls.

```
> packer build --help

Usage: packer build [options] TEMPLATE

  Will execute multiple builds in parallel as defined in the template.
  The various artifacts created by the template will be outputted.

Options:

  -color=false                  Disable color output. (Default: color)
  -debug                        Debug mode enabled for builds.
  -except=foo,bar,baz           Run all builds and post-processors other than these.
  -only=foo,bar,baz             Build only the specified builds.
  -force                        Force a build to continue if artifacts exist, deletes existing artifacts.
  -machine-readable             Produce machine-readable output.
  -on-error=[cleanup|abort|ask|run-cleanup-provisioner] If the build fails do: clean up (default), abort, ask, or run-cleanup-provisioner.
  -parallel-builds=1            Number of builds to run in parallel. 1 disables parallelization. 0 means no limit (Default: 0)
  -timestamp-ui                 Enable prefixing of each ui output with an RFC3339 timestamp.
  -var 'key=value'              Variable for templates, can be used multiple times.
  -var-file=path                JSON or HCL2 file containing user variables.

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

I did `make 1.22` without changes:
```
==> amazon-ebs: Prevalidating any provided VPC information
==> amazon-ebs: Prevalidating AMI Name: amazon-eks-node-1.22-v20220808
    amazon-ebs: Found Image ID: ami-022ef5294726d1825
==> amazon-ebs: Creating temporary keypair: packer_62f173b7-cd12-ff87-a14a-0b9caf3b78ad
==> amazon-ebs: Creating temporary security group for this instance: packer_62f173bc-01ea-5588-1b22-c38b73e0203a
==> amazon-ebs: Authorizing access to port 22 from [0.0.0.0/0] in the temporary security groups...
==> amazon-ebs: Launching a source AWS instance...
...
```

And with changes:
```
2022-08-08T13:28:50-07:00: ==> amazon-ebs: Prevalidating any provided VPC information
2022-08-08T13:28:50-07:00: ==> amazon-ebs: Prevalidating AMI Name: amazon-eks-node-1.22-v20220808
2022-08-08T13:28:53-07:00:     amazon-ebs: Found Image ID: ami-022ef5294726d1825
2022-08-08T13:28:53-07:00: ==> amazon-ebs: Creating temporary keypair: packer_62f171fe-04eb-e290-5f57-64cdd1a6c1b0
2022-08-08T13:28:55-07:00: ==> amazon-ebs: Creating temporary security group for this instance: packer_62f17207-460e-3b8c-54b4-edbefb2a9ad9
2022-08-08T13:28:58-07:00: ==> amazon-ebs: Authorizing access to port 22 from [0.0.0.0/0] in the temporary security groups...
2022-08-08T13:28:59-07:00: ==> amazon-ebs: Launching a source AWS instance...

```