### PR TITLE
Adding make command to support 1.23 AMI creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,7 @@ k8s: validate
 .PHONY: 1.22
 1.22:
 	$(MAKE) k8s kubernetes_version=1.22.9 kubernetes_build_date=2022-06-03 pull_cni_from_github=true
+
+.PHONY: 1.23
+1.23:
+	$(MAKE) k8s kubernetes_version=1.23.7 kubernetes_build_date=2022-06-29 pull_cni_from_github=true


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This PR adds support for creating 1.23 AMIs via packer and binaries released in s3 bucket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
