### PR TITLE
update containerd version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ k8s: validate
 
 .PHONY: 1.22
 1.22:
-	$(MAKE) k8s kubernetes_version=1.22.9 kubernetes_build_date=2022-06-03 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.22.9 containerd_version=1.6.6-1.amzn2 kubernetes_build_date=2022-06-03 pull_cni_from_github=true
 
 .PHONY: 1.23
 1.23:
-	$(MAKE) k8s kubernetes_version=1.23.7 kubernetes_build_date=2022-06-29 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.23.7 containerd_version=1.6.6-1.amzn2 kubernetes_build_date=2022-06-29 pull_cni_from_github=true


### PR DESCRIPTION
according to containerd [recommendations](https://containerd.io/releases/#kubernetes-support) for kubernetes versions, current containerd version 1.4.13 is not recommended for EKS kubernetes version 1.20+

I propose for EKS 1.22+ use containerd 1.6

also latest containerd have significant improvements in pulling images

Closes: #985 