### PR TITLE
Add raw table log for iptables to log collector script

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -20,7 +20,7 @@ export LANG="C"
 export LC_ALL="C"
 
 # Global options
-readonly PROGRAM_VERSION="0.7.0"
+readonly PROGRAM_VERSION="0.7.1"
 readonly PROGRAM_SOURCE="https://github.com/awslabs/amazon-eks-ami/blob/master/log-collector-script/"
 readonly PROGRAM_NAME="$(basename "$0" .sh)"
 readonly PROGRAM_DIR="/opt/log-collector"
@@ -307,10 +307,10 @@ get_iptables_info() {
     echo "IPtables not installed" |tee -a iptables.txt
   else
     try "collect iptables information"
+    iptables --wait 1 --numeric --verbose --list --table raw | tee "${COLLECT_DIR}"/networking/iptables-raw.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-raw.txt
     iptables --wait 1 --numeric --verbose --list --table mangle | tee "${COLLECT_DIR}"/networking/iptables-mangle.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-mangle.txt
     iptables --wait 1 --numeric --verbose --list --table filter | tee "${COLLECT_DIR}"/networking/iptables-filter.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-filter.txt
     iptables --wait 1 --numeric --verbose --list --table nat | tee "${COLLECT_DIR}"/networking/iptables-nat.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-nat.txt
-    iptables --wait 1 --numeric --verbose --list | tee "${COLLECT_DIR}"/networking/iptables.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables.txt
     iptables-save > "${COLLECT_DIR}"/networking/iptables-save.txt
   fi
 


### PR DESCRIPTION
**Description of changes:**

The command "iptables --list" output the result of filter table by default.

```shell
 iptables --list --help
iptables v1.8.4
(snip)
  --table	-t table	table to manipulate (default: `filter')
```

However, the result of filter table has already got in the file "iptables-filter.txt". So the file "iptables.txt" and the file "iptables-filter.txt" are same result.

I believe that the table we want is raw table. Therefore I added it. The raw table is used by security groups for pods.

**Testing Done**

For this verification, I added the following rules to the raw table.


```
sudo iptables -t raw -I PREROUTING -p tcp --dport 8888 -j TRACE
sudo iptables -t raw -I OUTPUT -p tcp --dport 8888  -j TRACE
```

I executed the following commands.

```
curl -O https://raw.githubusercontent.com/hiraken-w/amazon-eks-ami/7ad03c22ff99ba06cecc52c7c52ee1a931b99aa4/log-collector-script/linux/eks-log-collector.sh
sudo bash eks-log-collector.sh
```

As a result, the raw table was output successfully.

```
cat iptables-raw.txt
Chain PREROUTING (policy ACCEPT 1406 packets, 255K bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 TRACE      tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:8888

Chain OUTPUT (policy ACCEPT 774 packets, 85475 bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 TRACE      tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            tcp dpt:8888
=======
Total Number of Rules: 2
```
