### PR TITLE
Removes reference to CFN template in ArchiveBuildConfig.yaml

### DIFF
--- a/ArchiveBuildConfig.yaml
+++ b/ArchiveBuildConfig.yaml
@@ -13,7 +13,6 @@ dependencies:
     files:
       - src: Makefile
       - src: eks-worker-al2.json
-      - src: amazon-eks-nodegroup.yaml
 archive:
   name: amazon-eks-ami.tar.gz
   type: tgz


### PR DESCRIPTION
**Description of changes:**
Removes reference to CFN template in ArchiveBuildConfig.yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
None
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
