### PR TITLE
Include source AMI details in tags and manifest

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -91,9 +91,11 @@
       "tags": {
         "Name": "{{user `ami_name`}}",
         "created": "{{timestamp}}",
+        "build_region": "{{ .BuildRegion }}",
+        "source_ami_id": "{{ .SourceAMI }}",
+        "source_ami_name": "{{ .SourceAMIName }}",
         "docker_version": "{{ user `docker_version`}}",
         "containerd_version": "{{ user `containerd_version`}}",
-        "source_ami_id": "{{ user `source_ami_id`}}",
         "kubernetes": "{{ user `kubernetes_version`}}/{{ user `kubernetes_build_date` }}/bin/linux/{{ user `arch` }}",
         "cni_plugin_version": "{{ user `cni_plugin_version`}}"
       },
@@ -192,12 +194,20 @@
     {
       "type": "manifest",
       "output": "manifest.json",
-      "strip_path": true
+      "strip_path": true,
+      "custom_data": {
+        "source_ami_name": "{{ build `SourceAMIName` }}",
+        "source_ami_id": "{{ build `SourceAMI` }}"
+      }
     },
     {
       "type": "manifest",
       "output": "{{user `ami_name`}}-manifest.json",
-      "strip_path": true
+      "strip_path": true,
+      "custom_data": {
+        "source_ami_name": "{{ build `SourceAMIName` }}",
+        "source_ami_id": "{{ build `SourceAMI` }}"
+      }
     }
   ]
 }


### PR DESCRIPTION
**Description of changes:**

This includes the source AMI name and ID in the final AMI tags and the manifest.json file produced by Packer's manifest post-processor.

**Testing Done**

I did `make 1.23` and the contents of `amazon-eks-node-1.23-v20220822-manifest.json` are:
```
{
  "builds": [
    {
      "name": "amazon-ebs",
      "builder_type": "amazon-ebs",
      "build_time": 1661209061,
      "files": null,
      "artifact_id": "us-west-2:ami-0ceea365abab6254f",
      "packer_run_uuid": "9905d643-921d-d728-b776-005aaed0dbf6",
      "custom_data": {
        "source_ami_id": "ami-0f51d4d93d5bee36b",
        "source_ami_name": "amzn2-ami-minimal-hvm-2.0.20220805.0-x86_64-ebs"
      }
    }
  ],
  "last_run_uuid": "9905d643-921d-d728-b776-005aaed0dbf6"
}
```

The tags on the image are:
```
            "Tags": [
                {
                    "Key": "build_region",
                    "Value": "us-west-2"
                },
                {
                    "Key": "source_ami_id",
                    "Value": "ami-0f51d4d93d5bee36b"
                },
                {
                    "Key": "Name",
                    "Value": "amazon-eks-node-1.23-v20220822"
                },
                {
                    "Key": "created",
                    "Value": "1661208333"
                },
                {
                    "Key": "docker_version",
                    "Value": "20.10.17-1.amzn2"
                },
                {
                    "Key": "source_ami_name",
                    "Value": "amzn2-ami-minimal-hvm-2.0.20220805.0-x86_64-ebs"
                },
                {
                    "Key": "cni_plugin_version",
                    "Value": "v0.8.6"
                },
                {
                    "Key": "kubernetes",
                    "Value": "1.23.9/2022-07-27/bin/linux/x86_64"
                },
                {
                    "Key": "containerd_version",
                    "Value": "1.6.6-1.amzn2"
                }
            ],

```