### PR TITLE
Update SSM CreateDocument example for AWSCLI v2.

### DIFF
--- a/log-collector-script/linux/README.md
+++ b/log-collector-script/linux/README.md
@@ -89,9 +89,10 @@ Trying to archive gathered information...
 
 #### *To invoke SSM agent to run EKS log collector script and push bundle to S3 from Worker Node(s):*
 
-1. Create the SSM document named "EKSLogCollector" using the following command: <br/>
+1. Create the SSM document named "EKSLogCollector" using the following commands: <br/>
 ```
-aws ssm create-document --name "EKSLogCollector" --document-type "Command" --content https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/log-collector-script/linux/eks-ssm-content.json
+curl -O https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/log-collector-script/linux/eks-ssm-content.json
+aws ssm create-document --name "EKSLogCollector" --document-type "Command" --content file://eks-ssm-content.json
 ```
 2. To execute the bash script in the SSM document and to collect the logs from worker, run the following command: <br/>
 ```


### PR DESCRIPTION
**Description of changes:**

AWSCLI v2 does not have the same semantics for the `--content` flag to `aws ssm create-document`. Previously, you could pass any URL; now the only scheme allowed is `file://`.

Closes #716 .

**Testing Done**

Tested this example command with:
```
aws-cli/2.4.13 Python/3.8.8 Darwin/21.4.0 exe/x86_64 prompt/off
```

Document created successfully. Previous command did not work.