### PR TITLE
Fixing permissioned denied issue on generate-version-info.sh script l…

### DIFF
--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -14,7 +14,7 @@ fi
 OUTPUT_FILE="$1"
 
 # packages
-rpm --query --all --queryformat '\{"%{NAME}": "%{VERSION}-%{RELEASE}"\}\n' | jq --slurp --sort-keys 'add | {packages:(.)}' > "$OUTPUT_FILE"
+sudo rpm --query --all --queryformat '\{"%{NAME}": "%{VERSION}-%{RELEASE}"\}\n' | jq --slurp --sort-keys 'add | {packages:(.)}' > "$OUTPUT_FILE"
 
 # binaries
 echo $(jq ".binaries.kubelet = \"$(kubelet --version | awk '{print $2}')\"" $OUTPUT_FILE) > $OUTPUT_FILE


### PR DESCRIPTION
…ine 17

**Issue #, if available:**
When building new AMI getting permissions error on from line 17 of generate-version-info.sh
`error: cannot open Packages index using db5 - Permission denied (13)`

**Description of changes:**

Added `sudo` to line 17 in generate-version-info.sh.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Tested build with changes and works fine.

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
