### PR TITLE
imdsv2 when building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 *version-info.json
 .DS_Store
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.swp
 .idea
 *version-info.json
+*manifest.json
 .DS_Store
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version runc_version cni_plugin_version source_ami_id source_ami_owners source_ami_filter_name arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry ami_regions aws_iam_instance_profile
+PACKER_VARIABLES := $(shell $(PACKER_BINARY) inspect -machine-readable eks-worker-al2.json | grep 'template-variable' | awk -F ',' '{print $$4}')
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version runc_version cni_plugin_version source_ami_id source_ami_owners source_ami_filter_name arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry ami_regions
+PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version runc_version cni_plugin_version source_ami_id source_ami_owners source_ami_filter_name arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry ami_regions aws_iam_instance_profile
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -2,6 +2,7 @@
   "variables": {
     "aws_region": "us-west-2",
     "ami_name": null,
+    "aws_iam_instance_profile": "",
     "creator": "{{env `USER`}}",
     "encrypted": "false",
     "kms_key_id": "",
@@ -42,6 +43,12 @@
       "type": "amazon-ebs",
       "region": "{{user `aws_region`}}",
       "source_ami": "{{user `source_ami_id`}}",
+      "iam_instance_profile": "{{user `aws_iam_instance_profile`}}",
+      "metadata_options": {
+        "http_endpoint": "enabled",
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
+      },
       "ami_users": "{{user `ami_users`}}",
       "snapshot_users": "{{user `ami_users`}}",
       "source_ami_filter": {


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
 - Use IMDSv2 when building the image and restrict IMDS v1 in the packer config
 - Add optional `aws_iam_instance_profile` to more conveniently build the image without needing access credentials exported within the packer execution environment. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*

 Built w/ exported AWS credentials:
```
binary_bucket_region=us-west-2 ami_name=exportedcreds make 1.21
...
2022-09-01T16:49:50-05:00: Build 'amazon-ebs' finished after 8 minutes 26 seconds.
```

Tested joining node to cluster and pods running on the node ✅

Built w/ no credentials exported (federation assumed identity) and specified an instance profile to packer:
```
aws_iam_profile_name=eks-optimized-build-profile binary_bucket_region=us-west-2 ami_name=buildprofile make 1.21
...
2022-09-01T16:58:27-05:00: Build 'amazon-ebs' finished after 6 minutes 53 seconds.
```

Tested joining node to cluster and pods running on the node ✅
