### PR TITLE
Removes deprecated --network-plugin flag

### DIFF
--- a/files/kubelet-containerd.service
+++ b/files/kubelet-containerd.service
@@ -11,7 +11,7 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime remote \
     --container-runtime-endpoint unix:///run/containerd/containerd.sock \
-    --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
+    $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -10,7 +10,7 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime docker \
-    --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
+    $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
 Restart=always
 RestartSec=5


### PR DESCRIPTION
**Description of changes:**
As part of [this PR](https://github.com/kubernetes/kubernetes/pull/106907), the `--network-plugin` flag is getting removed as of Kubernetes version 1.24, and kubelet will fail to come up when it's set. As far as I can tell, it doesn't do anything important here and I've verified that nodes join clusters as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

1. Built 1.20 and 1.24 AMIs
2. Verified that 1.20 nodes join a cluster, with both `containerd` and `docker` as the runtime

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
