### PR TITLE
Insignificance of  /etc/sysconfig/iptables

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -565,7 +565,6 @@ EOF
 
 elif [[ "$CONTAINER_RUNTIME" = "dockerd" ]]; then
     mkdir -p /etc/docker
-    bash -c "/sbin/iptables-save > /etc/sysconfig/iptables"
     cp -v /etc/eks/iptables-restore.service /etc/systemd/system/iptables-restore.service
     sudo chown root:root /etc/systemd/system/iptables-restore.service
     systemctl daemon-reload


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Removing the line 568 'bash -c "/sbin/iptables-save > /etc/sysconfig/iptables" in bootstrap.sh' as it is insignificant

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
The line 568 bash -c "/sbin/iptables-save > /etc/sysconfig/iptables" is insignificant.
Because kubelet is starting in 592 and then kube-proxy gets activated which manages the iptables rules dynamically in an EKS worker node. Because of this the /etc/sysconfig/iptables is empty.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->
I have tested this by creating AL2 worker nodes and when I run $cat /etc/sysconfig/iptables it returns nothing as it is empty.
Therefore the line can be removed as it is leading to confusion because it indicates the iptables rules should be present in /etc/sysconfig/iptables which is not happening in this case.
If I execute /sbin/iptables-save > /etc/sysconfig/iptables again manually in my worker node then I see there are iptables rule in /etc/sysconfig/iptables because kube-proxy should have started by then.

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
