### PR TITLE
Adds --network-plugin back to docker kubelet.service

### DIFF
--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -10,7 +10,7 @@ ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime docker \
-    $KUBELET_ARGS $KUBELET_EXTRA_ARGS
+    --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
 Restart=always
 RestartSec=5


### PR DESCRIPTION
**Description of changes:**
The `--network-plugin` flag is required for docker as coredns doesn't come up without it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
None
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
