### PR TITLE
Resolves #1024: makes containerd the default and only runtime for k8s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *manifest.json
 *.swp
 .idea
+*version-info.json
+.DS_Store

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -135,18 +135,46 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 CLUSTER_NAME="$1"
 set -u
 
+KUBELET_VERSION=$(kubelet --version | grep -Eo '[0-9]\.[0-9]+\.[0-9]+')
+echo "Using kubelet version $KUBELET_VERSION"
+
+function is_greater_than_or_equal_to_version() {
+    local actual_version="$1"
+    local compared_version="$2"
+
+    [ $actual_version = "`echo -e \"$actual_version\n$compared_version\" | sort -V | tail -n1`" ]
+}
+
+# As of Kubernetes version 1.24, we will start defaulting the container runtime to containerd
+# and no longer support docker as a container runtime.
+IS_124_OR_GREATER=false
+DEFAULT_CONTAINER_RUNTIME=dockerd
+if is_greater_than_or_equal_to_version $KUBELET_VERSION "1.24.0"; then
+    IS_124_OR_GREATER=true
+    DEFAULT_CONTAINER_RUNTIME=containerd
+fi
+
+# Set container runtime related variables
+DOCKER_CONFIG_JSON="${DOCKER_CONFIG_JSON:-}"
+ENABLE_DOCKER_BRIDGE="${ENABLE_DOCKER_BRIDGE:-false}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-$DEFAULT_CONTAINER_RUNTIME}"
+
+echo "Using $CONTAINER_RUNTIME as the container runtime"
+
+if $IS_124_OR_GREATER && [ $CONTAINER_RUNTIME != "containerd" ]; then
+    echo "ERROR: containerd is the only supported container runtime as of Kubernetes version 1.24"
+    exit 1
+fi
+
 USE_MAX_PODS="${USE_MAX_PODS:-true}"
 B64_CLUSTER_CA="${B64_CLUSTER_CA:-}"
 APISERVER_ENDPOINT="${APISERVER_ENDPOINT:-}"
 SERVICE_IPV4_CIDR="${SERVICE_IPV4_CIDR:-}"
 DNS_CLUSTER_IP="${DNS_CLUSTER_IP:-}"
 KUBELET_EXTRA_ARGS="${KUBELET_EXTRA_ARGS:-}"
-ENABLE_DOCKER_BRIDGE="${ENABLE_DOCKER_BRIDGE:-false}"
 API_RETRY_ATTEMPTS="${API_RETRY_ATTEMPTS:-3}"
-DOCKER_CONFIG_JSON="${DOCKER_CONFIG_JSON:-}"
 CONTAINERD_CONFIG_FILE="${CONTAINERD_CONFIG_FILE:-}"
 PAUSE_CONTAINER_VERSION="${PAUSE_CONTAINER_VERSION:-3.5}"
-CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-dockerd}"
 IP_FAMILY="${IP_FAMILY:-}"
 SERVICE_IPV6_CIDR="${SERVICE_IPV6_CIDR:-}"
 ENABLE_LOCAL_OUTPOST="${ENABLE_LOCAL_OUTPOST:-}"
@@ -540,6 +568,14 @@ EOF
 fi
 
 if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
+    if $ENABLE_DOCKER_BRIDGE; then
+        echo "WARNING: Flag --enable-docker-bridge was set but will be ignored as it's not relevant to containerd"
+    fi
+
+    if [ ! -z "$DOCKER_CONFIG_JSON" ]; then
+        echo "WARNING: Flag --docker-config-json was set but will be ignored as it's not relevant to containerd"
+    fi
+
     sudo mkdir -p /etc/containerd
     sudo mkdir -p /etc/cni/net.d
     mkdir -p /etc/systemd/system/containerd.service.d

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -5,22 +5,9 @@ set -o nounset
 set -o errexit
 
 if [[ -z "$KERNEL_VERSION" ]]; then
-    # Save for resetting
-    OLDIFS=$IFS
-    # Makes 5.4 kernel the default on 1.19 and higher
-    IFS='.'
-    # Convert kubernetes version in an array to compare versions
-    read -ra ADDR <<< "$KUBERNETES_VERSION"
-    # Reset
-    IFS=$OLDIFS
+    KERNEL_VERSION=5.4
 
-    if (( ADDR[0] == 1 && ADDR[1] < 19 )); then
-        KERNEL_VERSION=4.14
-    else
-        KERNEL_VERSION=5.4
-    fi
-
-    echo "kernel_version is unset. Setting to $KERNEL_VERSION based on kubernetes_version $KUBERNETES_VERSION"
+    echo "kernel_version is unset. Setting to $KERNEL_VERSION"
 fi
 
 if [[ $KERNEL_VERSION == "4.14" ]]; then

--- a/test/cases/container-runtime-defaults.sh
+++ b/test/cases/container-runtime-defaults.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exit_code=0
+TEMP_DIR=$(mktemp -d)
+
+echo "--> Should allow dockerd as container runtime when below k8s version 1.24"
+KUBELET_VERSION="Kubernetes v1.20.15-eks-ba74326"
+run ${TEMP_DIR} /etc/eks/bootstrap.sh \
+    --b64-cluster-ca dGVzdA== \
+    --apiserver-endpoint http://my-api-endpoint \
+    --container-runtime dockerd \
+    test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+    echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+    exit 1
+fi
+
+echo "--> Should allow containerd as container runtime when below k8s version 1.24"
+KUBELET_VERSION="Kubernetes v1.20.15-eks-ba74326"
+run ${TEMP_DIR} /etc/eks/bootstrap.sh \
+    --b64-cluster-ca dGVzdA== \
+    --apiserver-endpoint http://my-api-endpoint \
+    --container-runtime containerd \
+    test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+    echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+    exit 1
+fi
+
+echo "--> Should have default container runtime when below k8s version 1.24"
+KUBELET_VERSION="Kubernetes v1.20.15-eks-ba74326"
+run ${TEMP_DIR} /etc/eks/bootstrap.sh \
+    --b64-cluster-ca dGVzdA== \
+    --apiserver-endpoint http://my-api-endpoint \
+    test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+    echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+    exit 1
+fi
+
+echo "--> Should not allow dockerd as container runtime when at or above k8s version 1.24"
+export KUBELET_VERSION="Kubernetes v1.24.15-eks-ba74326"
+run ${TEMP_DIR} /etc/eks/bootstrap.sh \
+    --b64-cluster-ca dGVzdA== \
+    --apiserver-endpoint http://my-api-endpoint \
+    --container-runtime dockerd \
+    test || exit_code=$?
+
+echo "EXIT CODE $exit_code"
+if [[ ${exit_code} -eq 0 ]]; then
+    echo "❌ Test Failed: expected a non-zero exit code but got '${exit_code}'"
+    exit 1
+fi
+exit_code=0
+
+echo "--> Should allow containerd as container runtime when at or above k8s version 1.24"
+KUBELET_VERSION="Kubernetes v1.24.15-eks-ba74326"
+run ${TEMP_DIR} /etc/eks/bootstrap.sh \
+    --b64-cluster-ca dGVzdA== \
+    --apiserver-endpoint http://my-api-endpoint \
+    --container-runtime containerd \
+    test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+    echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+    exit 1
+fi
+
+echo "--> Should have default container runtime when at or above k8s version 1.24"
+KUBELET_VERSION="Kubernetes v1.24.15-eks-ba74326"
+run ${TEMP_DIR} /etc/eks/bootstrap.sh \
+    --b64-cluster-ca dGVzdA== \
+    --apiserver-endpoint http://my-api-endpoint \
+    test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+    echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+    exit 1
+fi
+
+echo "--> Should ignore docker-specific flags when at or above k8s version 1.24"
+KUBELET_VERSION="Kubernetes v1.24.15-eks-ba74326"
+run ${TEMP_DIR} /etc/eks/bootstrap.sh \
+    --b64-cluster-ca dGVzdA== \
+    --apiserver-endpoint http://my-api-endpoint \
+    --enable-docker-bridge true \
+    --docker-config-json "{\"some\":\"json\"}" \
+    test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+    echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+    exit 1
+fi

--- a/test/mocks/kubelet
+++ b/test/mocks/kubelet
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The only use of kubelet directly is to get the Kubernetes version,
+# so we'll set a default here to avoid test failures, and you can
+# override by setting the KUBELET_VERSION environment variable.
+some_kubelet_version="Kubernetes v1.20.15-eks-ba74326"
+KUBELET_VERSION="${KUBELET_VERSION:-$some_kubelet_version}"
+echo "$KUBELET_VERSION"

--- a/test/test-harness.sh
+++ b/test/test-harness.sh
@@ -36,12 +36,15 @@ overall_status=0
 function run(){
     local temp_dir=$1
     shift
+    # This variable is used to override the default value in the kubelet mock
+    KUBELET_VERSION="${KUBELET_VERSION:-}"
     cp -f ${SCRIPTPATH}/../files/kubelet-config.json ${temp_dir}/kubelet-config.json
     docker run -v ${SCRIPTPATH}/../files/:/etc/eks/ \
         -v ${temp_dir}/kubelet-config.json:/etc/kubernetes/kubelet/kubelet-config.json \
         --attach STDOUT \
         --attach STDERR \
         --rm \
+        -e KUBELET_VERSION="$KUBELET_VERSION" \
         eks-optimized-ami $@
 }
 export -f run


### PR DESCRIPTION
… version 1.24+

**Issue #, if available:**
#1024

**Description of changes:**
Makes containerd as the default and only runtime for k8s versions 1.24+. If dockerd is passed in to the bootstrap script, it will log an error and fail. Docker-specific flags will be ignored.

As a note, I added [a separate issue](https://github.com/awslabs/amazon-eks-ami/issues/1025) to clean up all other docker installations, configurations, etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

1. `make test` - I added multiple setups to test and verified that logs were as expected
2. `make 1.20`
    * Joined a node to a cluster with no runtime configured
    * Joined a node to a cluster with containerd configured
3. `make 1.24` (locally added only and need to use `client.authentication.k8s.io/v1beta1` as the API version)
    * Joined a node to a cluster with no runtime configured
    * Verified that nodes failed to bootstrap when container runtime set to dockerd

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
