### PR TITLE
increase the kube-api-server QPS from 5/10 to 10/20

### DIFF
--- a/test/cases/api-qps-k8s-1.21-below.sh
+++ b/test/cases/api-qps-k8s-1.21-below.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "--> Should use default API server QPS for K8s 1.21-"
+exit_code=0
+TEMP_DIR=$(mktemp -d)
+KUBELET_VERSION=v1.21.0-eks-ba74326
+run ${TEMP_DIR} /etc/eks/bootstrap.sh \
+    --b64-cluster-ca dGVzdA== \
+    --apiserver-endpoint http://my-api-endpoint \
+    test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+    echo "❌ Test Failed: expected a non-zero exit code but got '${exit_code}'"
+    exit 1
+fi
+
+# values should not be set
+expected_api_qps="null"
+expected_api_burst="null"
+
+actual_api_qps=$(jq -r '.kubeAPIQPS' < ${TEMP_DIR}/kubelet-config.json)
+actual_api_burst=$(jq -r '.kubeAPIBurst' < ${TEMP_DIR}/kubelet-config.json)
+if [[ ${actual_api_qps} != ${expected_api_qps} ]]; then
+    echo "❌ Test Failed: expected kubeAPIQPS = '${expected_api_qps}' but got '${actual_api_qps}'"
+    exit 1
+fi
+
+if [[ ${actual_api_burst} != ${expected_api_burst} ]]; then
+    echo "❌ Test Failed: expected kubeAPIBurst = '${expected_api_burst}' but got '${actual_api_burst}'"
+    exit 1
+fi

--- a/test/cases/api-qps-k8s-1.22-above.sh
+++ b/test/cases/api-qps-k8s-1.22-above.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "--> Should increase API server QPS for K8s 1.22+"
+exit_code=0
+TEMP_DIR=$(mktemp -d)
+KUBELET_VERSION=v1.22.0-eks-ba74326
+run ${TEMP_DIR} /etc/eks/bootstrap.sh \
+    --b64-cluster-ca dGVzdA== \
+    --apiserver-endpoint http://my-api-endpoint \
+    test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+    echo "❌ Test Failed: expected a non-zero exit code but got '${exit_code}'"
+    exit 1
+fi
+
+expected_api_qps="10"
+expected_api_burst="20"
+
+actual_api_qps=$(jq -r '.kubeAPIQPS' < ${TEMP_DIR}/kubelet-config.json)
+actual_api_burst=$(jq -r '.kubeAPIBurst' < ${TEMP_DIR}/kubelet-config.json)
+if [[ ${actual_api_qps} != ${expected_api_qps} ]]; then
+    echo "❌ Test Failed: expected kubeAPIQPS = '${expected_api_qps}' but got '${actual_api_qps}'"
+    exit 1
+fi
+
+if [[ ${actual_api_burst} != ${expected_api_burst} ]]; then
+    echo "❌ Test Failed: expected kubeAPIBurst = '${expected_api_burst}' but got '${actual_api_burst}'"
+    exit 1
+fi

--- a/test/cases/container-runtime-defaults.sh
+++ b/test/cases/container-runtime-defaults.sh
@@ -5,7 +5,7 @@ exit_code=0
 TEMP_DIR=$(mktemp -d)
 
 echo "--> Should allow dockerd as container runtime when below k8s version 1.24"
-KUBELET_VERSION="Kubernetes v1.20.15-eks-ba74326"
+KUBELET_VERSION="v1.20.15-eks-ba74326"
 run ${TEMP_DIR} /etc/eks/bootstrap.sh \
     --b64-cluster-ca dGVzdA== \
     --apiserver-endpoint http://my-api-endpoint \
@@ -18,7 +18,7 @@ if [[ ${exit_code} -ne 0 ]]; then
 fi
 
 echo "--> Should allow containerd as container runtime when below k8s version 1.24"
-KUBELET_VERSION="Kubernetes v1.20.15-eks-ba74326"
+KUBELET_VERSION="v1.20.15-eks-ba74326"
 run ${TEMP_DIR} /etc/eks/bootstrap.sh \
     --b64-cluster-ca dGVzdA== \
     --apiserver-endpoint http://my-api-endpoint \
@@ -31,7 +31,7 @@ if [[ ${exit_code} -ne 0 ]]; then
 fi
 
 echo "--> Should have default container runtime when below k8s version 1.24"
-KUBELET_VERSION="Kubernetes v1.20.15-eks-ba74326"
+KUBELET_VERSION="v1.20.15-eks-ba74326"
 run ${TEMP_DIR} /etc/eks/bootstrap.sh \
     --b64-cluster-ca dGVzdA== \
     --apiserver-endpoint http://my-api-endpoint \
@@ -43,7 +43,7 @@ if [[ ${exit_code} -ne 0 ]]; then
 fi
 
 echo "--> Should not allow dockerd as container runtime when at or above k8s version 1.24"
-export KUBELET_VERSION="Kubernetes v1.24.15-eks-ba74326"
+export KUBELET_VERSION="v1.24.15-eks-ba74326"
 run ${TEMP_DIR} /etc/eks/bootstrap.sh \
     --b64-cluster-ca dGVzdA== \
     --apiserver-endpoint http://my-api-endpoint \
@@ -58,7 +58,7 @@ fi
 exit_code=0
 
 echo "--> Should allow containerd as container runtime when at or above k8s version 1.24"
-KUBELET_VERSION="Kubernetes v1.24.15-eks-ba74326"
+KUBELET_VERSION="v1.24.15-eks-ba74326"
 run ${TEMP_DIR} /etc/eks/bootstrap.sh \
     --b64-cluster-ca dGVzdA== \
     --apiserver-endpoint http://my-api-endpoint \
@@ -71,7 +71,7 @@ if [[ ${exit_code} -ne 0 ]]; then
 fi
 
 echo "--> Should have default container runtime when at or above k8s version 1.24"
-KUBELET_VERSION="Kubernetes v1.24.15-eks-ba74326"
+KUBELET_VERSION="v1.24.15-eks-ba74326"
 run ${TEMP_DIR} /etc/eks/bootstrap.sh \
     --b64-cluster-ca dGVzdA== \
     --apiserver-endpoint http://my-api-endpoint \
@@ -83,7 +83,7 @@ if [[ ${exit_code} -ne 0 ]]; then
 fi
 
 echo "--> Should ignore docker-specific flags when at or above k8s version 1.24"
-KUBELET_VERSION="Kubernetes v1.24.15-eks-ba74326"
+KUBELET_VERSION="v1.24.15-eks-ba74326"
 run ${TEMP_DIR} /etc/eks/bootstrap.sh \
     --b64-cluster-ca dGVzdA== \
     --apiserver-endpoint http://my-api-endpoint \

--- a/test/mocks/kubelet
+++ b/test/mocks/kubelet
@@ -4,6 +4,8 @@ set -euo pipefail
 # The only use of kubelet directly is to get the Kubernetes version,
 # so we'll set a default here to avoid test failures, and you can
 # override by setting the KUBELET_VERSION environment variable.
-some_kubelet_version="Kubernetes v1.20.15-eks-ba74326"
-KUBELET_VERSION="${KUBELET_VERSION:-$some_kubelet_version}"
-echo "$KUBELET_VERSION"
+if [ $# == 1 ] && [ $1 == "--version" ]; then
+	echo "Kubernetes ${KUBELET_VERSION:-v1.23.9-eks-ba74326}"
+else
+	echo "mocking kubelet with params $@"
+fi


### PR DESCRIPTION
**Issue #, if available:**
Fixes #969

**Description of changes:**

This doubles the default API QPS values for EKS v1.22+ where API Priority & Fairness is available and there is a specific queue for kubelet health.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

- Created an AMI with this change and an EKS 1.23 cluster
- Launched nodes using this AMI
- Verified nodes came up ready and that pods went ready
- Verified that the change was applied to the config file on the node
```
sh-4.2$ cat /etc/kubernetes/kubelet/kubelet-config.json  | grep -i kubeAPI
  "kubeAPIQPS": 10,
  "kubeAPIBurst": 20,
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
