### PR TITLE
Move cleanup to separate provisioner, remove cleanup_image var

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -24,7 +24,6 @@
     "arch": null,
     "instance_type": null,
     "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image",
-    "cleanup_image": "true",
     "ssh_interface": "",
     "ssh_username": "ec2-user",
     "temporary_security_group_source_cidrs": "",
@@ -157,9 +156,13 @@
         "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
         "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
-        "CLEANUP_IMAGE={{user `cleanup_image`}}",
         "SONOBUOY_E2E_REGISTRY={{user `sonobuoy_e2e_registry`}}"
       ]
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "script": "{{template_dir}}/scripts/cleanup.sh"
     },
     {
       "type": "shell",

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Clean up yum caches to reduce the image size
+sudo yum clean all
+sudo rm -rf /var/cache/yum
+
+# Clean up build artifacts
+sudo rm -rf /tmp/worker
+
+# Clean up files to reduce confusion during debug
+sudo rm -rf \
+    /etc/hostname \
+    /etc/machine-id \
+    /etc/resolv.conf \
+    /etc/ssh/ssh_host* \
+    /home/ec2-user/.ssh/authorized_keys \
+    /root/.ssh/authorized_keys \
+    /var/lib/cloud/data \
+    /var/lib/cloud/instance \
+    /var/lib/cloud/instances \
+    /var/lib/cloud/sem \
+    /var/lib/dhclient/* \
+    /var/lib/dhcp/dhclient.* \
+    /var/lib/yum/history \
+    /var/log/cloud-init-output.log \
+    /var/log/cloud-init.log \
+    /var/log/secure \
+    /var/log/wtmp

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -373,37 +373,4 @@ echo vm.max_map_count=524288 | sudo tee -a /etc/sysctl.conf
 sudo mkdir -p /etc/eks/log-collector-script/
 sudo cp $TEMPLATE_DIR/log-collector-script/eks-log-collector.sh /etc/eks/log-collector-script/
 
-################################################################################
-### Cleanup ####################################################################
-################################################################################
-
-CLEANUP_IMAGE="${CLEANUP_IMAGE:-true}"
-if [[ "$CLEANUP_IMAGE" == "true" ]]; then
-    # Clean up yum caches to reduce the image size
-    sudo yum clean all
-    sudo rm -rf \
-        $TEMPLATE_DIR  \
-        /var/cache/yum
-
-    # Clean up files to reduce confusion during debug
-    sudo rm -rf \
-        /etc/hostname \
-        /etc/machine-id \
-        /etc/resolv.conf \
-        /etc/ssh/ssh_host* \
-        /home/ec2-user/.ssh/authorized_keys \
-        /root/.ssh/authorized_keys \
-        /var/lib/cloud/data \
-        /var/lib/cloud/instance \
-        /var/lib/cloud/instances \
-        /var/lib/cloud/sem \
-        /var/lib/dhclient/* \
-        /var/lib/dhcp/dhclient.* \
-        /var/lib/yum/history \
-        /var/log/cloud-init-output.log \
-        /var/log/cloud-init.log \
-        /var/log/secure \
-        /var/log/wtmp
-fi
-
 sudo touch /etc/machine-id


### PR DESCRIPTION
**Description of changes:**

Performing the cleanup steps within `install-worker.sh` is problematic, because they can only be skipped -- they can't be invoked separately from the rest of `install-worker.sh`. This is a pain for our GPU AMI template, for example.

The `cleanup_image` var was added to the packer template in #522. The value is passed to `install-worker.sh` as an environment variable, `CLEANUP_IMAGE`, which toggles the removal of various bits from the resulting AMI.

However, this variable doesn't actually work with our packer template; if you set its value to `false`, the build will fail. This is because `validate.sh` requires the cleanup steps to be run. This toggle would only make sense if you were using `install-worker.sh` in a custom packer template (which I assume is what folks are doing). However, I don't think it makes sense to allow cleanup to be disabled in the packer template that we publish, because `validate.sh` should never be optional in this template.

Removing the variable from our template won't break users who are using `install-worker.sh` in a custom template and setting `CLEANUP_IMAGE=false`. These users wouldn't include the new `cleanup.sh` provisioner; so there is no functional change.

This *could* break users who are directly modifying our packer template at build-time, such as setting `cleanup_image` to `false` and then deleting the `validate.sh` provisioner. This type of usage is inherently fragile and we can't always avoid breaking it. It shouldn't be difficult to resolve.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Before this change, this will fail:
```
# cleanup_image was never added to PACKER_VARIABLES in the Makefile, so just setting it here
> echo $(jq '.variables.cleanup_image = "false"' eks-worker-al2.json) > eks-worker-al2.json
> make 1.23
...
2022-09-28T14:57:52-07:00: ==> amazon-ebs: Provisioning with shell script: /var/folders/5t/c97ylshx62gb8ctzrmbtbv4h0000gs/T/tmp.AUBkWKrX/amazon-eks-ami/scripts/validate.sh
2022-09-28T14:57:52-07:00:     amazon-ebs: /etc/hostname shouldn't exists
...
```

After this change, this succeeds:
```
> make 1.23
```