### PR TITLE
Disable colorized packer output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ validate: ## Validate packer config
 .PHONY: k8s
 k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 	@echo "$(T_GREEN)Building AMI for version $(T_YELLOW)$(kubernetes_version)$(T_GREEN) on $(T_YELLOW)$(arch)$(T_RESET)"
-	$(PACKER_BINARY) build -timestamp-ui $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
+	$(PACKER_BINARY) build -timestamp-ui -color=false $(foreach packerVar,$(PACKER_VARIABLES), $(if $($(packerVar)),--var $(packerVar)='$($(packerVar))',)) eks-worker-al2.json
 
 # Build dates and versions taken from https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 


### PR DESCRIPTION
**Description of changes:**

Disables color output; format chars are making our logs hard to look at.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

```
> packer --version
1.8.0
> packer build --help | grep "color"
  -color=false                  Disable color output. (Default: color)
```