### PR TITLE
Increase polling timeout to 45 minutes

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -74,6 +74,10 @@
           "delete_on_termination": true
         }
       ],
+      "aws_polling": {
+        "delay_seconds": 30,
+        "max_attempts": 90
+      },
       "ami_regions": "{{user `ami_regions`}}",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_interface": "{{user `ssh_interface`}}",


### PR DESCRIPTION
**Description of changes:**

We occasionally see timeouts waiting for the AMI to become available with packer's current values (30 minutes): https://github.com/hashicorp/packer-plugin-amazon/blob/5f715bd700e1f932632113443943c648dc1b9f22/builder/common/state.go#L81

I've also increased the polling interval to 30 seconds because we build many AMI's in parallel, and lower values don't meaningfully reduce build time.

More info here: https://www.packer.io/plugins/builders/amazon/ebs#polling-configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Build succeeded:
```
make 1.23
```