### PR TITLE
always add empty machine-id file

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -26,3 +26,5 @@ sudo rm -rf \
     /var/log/cloud-init.log \
     /var/log/secure \
     /var/log/wtmp
+
+sudo touch /etc/machine-id

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -372,5 +372,3 @@ echo vm.max_map_count=524288 | sudo tee -a /etc/sysctl.conf
 ################################################################################
 sudo mkdir -p /etc/eks/log-collector-script/
 sudo cp $TEMPLATE_DIR/log-collector-script/eks-log-collector.sh /etc/eks/log-collector-script/
-
-sudo touch /etc/machine-id


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**

https://github.com/awslabs/amazon-eks-ami/pull/1036
When moving the clean-up after the install-worker, the machine-id touch was left in the install-worker.sh script. This results in the `/etc/machine-id` file to be deleted when clean-up is executed and not recreated as an empty file. The system will come online, but the journal stops. This file is necessary on the first boot of the AMI per (https://www.freedesktop.org/software/systemd/man/machine-id.html). 

This change deletes and adds the empty machine-id file with or without clean-up. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Built an image at current head and noticed that the journal was not functional. Added the empty machine-id file back and rebuilt the image, journal started working again.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
