### PR TITLE
Makes volume_type configurable with make arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKER_BINARY ?= packer
-PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version runc_version cni_plugin_version source_ami_id source_ami_owners source_ami_filter_name arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry ami_regions
+PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region kubernetes_version kubernetes_build_date kernel_version docker_version containerd_version runc_version cni_plugin_version source_ami_id source_ami_owners source_ami_filter_name arch instance_type security_group_id additional_yum_repos pull_cni_from_github sonobuoy_e2e_registry ami_regions volume_type
 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -1,41 +1,42 @@
 {
   "variables": {
-    "aws_region": "us-west-2",
+    "additional_yum_repos": "",
+    "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image",
     "ami_name": null,
-    "creator": "{{env `USER`}}",
-    "encrypted": "false",
-    "kms_key_id": "",
+    "ami_regions": "",
+    "ami_users": "",
+    "arch": null,
+    "associate_public_ip_address": "",
     "aws_access_key_id": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_region": "us-west-2",
     "aws_secret_access_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
-    "kubernetes_version": null,
-    "kubernetes_build_date": null,
-    "kernel_version": "",
-    "docker_version": "20.10.17-1.amzn2",
-    "containerd_version": "1.6.6-1.amzn2",
-    "runc_version": "1.1.3-1.amzn2",
     "cni_plugin_version": "v0.8.6",
+    "containerd_version": "1.6.6-1.amzn2",
+    "creator": "{{env `USER`}}",
+    "docker_version": "20.10.17-1.amzn2",
+    "encrypted": "false",
+    "instance_type": null,
+    "kernel_version": "",
+    "kms_key_id": "",
+    "kubernetes_build_date": null,
+    "kubernetes_version": null,
+    "launch_block_device_mappings_volume_size": "4",
     "pull_cni_from_github": "true",
+    "remote_folder": "",
+    "runc_version": "1.1.3-1.amzn2",
+    "security_group_id": "",
+    "sonobuoy_e2e_registry": "",
+    "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
-    "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
-    "arch": null,
-    "instance_type": null,
-    "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image",
     "ssh_interface": "",
     "ssh_username": "ec2-user",
-    "temporary_security_group_source_cidrs": "",
-    "security_group_id": "",
-    "associate_public_ip_address": "",
     "subnet_id": "",
-    "remote_folder": "",
-    "launch_block_device_mappings_volume_size": "4",
-    "ami_users": "",
-    "additional_yum_repos": "",
-    "sonobuoy_e2e_registry": "",
-    "ami_regions": ""
+    "temporary_security_group_source_cidrs": "",
+    "volume_type": "gp2"
   },
   "builders": [
     {
@@ -61,7 +62,7 @@
       "launch_block_device_mappings": [
         {
           "device_name": "/dev/xvda",
-          "volume_type": "gp2",
+          "volume_type": "{{user `volume_type`}}",
           "volume_size": "{{user `launch_block_device_mappings_volume_size`}}",
           "delete_on_termination": true
         }
@@ -69,7 +70,7 @@
       "ami_block_device_mappings": [
         {
           "device_name": "/dev/xvda",
-          "volume_type": "gp2",
+          "volume_type": "{{user `volume_type`}}",
           "volume_size": 20,
           "delete_on_termination": true
         }


### PR DESCRIPTION
**Issue #, if available:**

Precursor for:
1. #626 
2. #695 

**Description of changes:**
Makes volume_type configurable with make arguments. Prior to making gp3 volumes the default volume type, we need to make it configurable to allow it to be overridden in cases where it's not desired or not supported. We're tracking making gp3 volumes the default at some point, and this is the first step in unblocking that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Built two AMIs: one with no `volume_type` override and one with `volume_type=gp3` passed in to the make command. I verified in the EC2 console that the block devices were `gp2` in the default case and `gp3` in the override case.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
