### PR TITLE
cri: containerd for cluster required to be on kubelet<v1.24

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ kind: ClusterConfig
 
 metadata:
   name: basic-cluster
-  region: us-west-2
+  region: us-east-1
   version: '1.22'
 
 nodeGroups:

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "aws_region": "us-west-2",
+    "aws_region": "us-east-1",
     "ami_name": null,
     "creator": "{{env `USER`}}",
     "encrypted": "false",

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -27,7 +27,7 @@ function print_help {
     echo "--dns-cluster-ip Overrides the IP address to use for DNS queries within the cluster. Defaults to 10.100.0.10 or 172.20.0.10 based on the IP address of the primary interface"
     echo "--pause-container-account The AWS account (number) to pull the pause container from"
     echo "--pause-container-version The tag of the pause container"
-    echo "--container-runtime Specify a container runtime (default: dockerd)"
+    echo "--container-runtime Specify a container runtime (default: containerd)"
     echo "--ip-family Specify ip family of the cluster"
     echo "--service-ipv6-cidr ipv6 cidr range of the cluster"
     echo "--enable-local-outpost Enable support for worker nodes to communicate with the local control plane when running on a disconnected Outpost. (true or false)"
@@ -148,7 +148,7 @@ function is_greater_than_or_equal_to_version() {
 # As of Kubernetes version 1.24, we will start defaulting the container runtime to containerd
 # and no longer support docker as a container runtime.
 IS_124_OR_GREATER=false
-DEFAULT_CONTAINER_RUNTIME=dockerd
+DEFAULT_CONTAINER_RUNTIME=containerd
 if is_greater_than_or_equal_to_version $KUBELET_VERSION "1.24.0"; then
     IS_124_OR_GREATER=true
     DEFAULT_CONTAINER_RUNTIME=containerd

--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -1,15 +1,16 @@
 [Unit]
 Description=Kubernetes Kubelet
 Documentation=https://github.com/kubernetes/kubernetes
-After=docker.service iptables-restore.service
-Requires=docker.service
+After=containerd.service iptables-restore.service
+Requires=containerd.service
+Conflicts=docker.service
 
 [Service]
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
 ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
-    --container-runtime docker \
+    --container-runtime containerd \
     --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
 
 Restart=always

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -117,11 +117,11 @@ sudo mv $TEMPLATE_DIR/iptables-restore.service /etc/eks/iptables-restore.service
 
 sudo yum install -y device-mapper-persistent-data lvm2
 
-INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
-if [[ "$INSTALL_DOCKER" == "true" ]]; then
-    sudo amazon-linux-extras enable docker
-    sudo groupadd -og 1950 docker
-    sudo useradd --gid $(getent group docker | cut -d: -f3) docker
+INSTALL_CONTAINERD="${INSTALL_CONTAINERD:-true}"
+if [[ "$INSTALL_CONTAINERD" == "true" ]]; then
+#    sudo amazon-linux-extras enable docker
+#    sudo groupadd -og 1950 docker
+#    sudo useradd --gid $(getent group docker | cut -d: -f3) docker
 
     # install runc and lock version
     sudo yum install -y runc-${RUNC_VERSION}
@@ -132,18 +132,18 @@ if [[ "$INSTALL_DOCKER" == "true" ]]; then
     sudo yum versionlock containerd-*
 
     # install docker and lock version
-    sudo yum install -y docker-${DOCKER_VERSION}*
-    sudo yum versionlock docker-*
-    sudo usermod -aG docker $USER
+#    sudo yum install -y docker-${DOCKER_VERSION}*
+#    sudo yum versionlock docker-*
+#    sudo usermod -aG docker $USER
 
     # Remove all options from sysconfig docker.
-    sudo sed -i '/OPTIONS/d' /etc/sysconfig/docker
+#    sudo sed -i '/OPTIONS/d' /etc/sysconfig/docker
 
-    sudo mkdir -p /etc/docker
-    sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
-    sudo chown root:root /etc/docker/daemon.json
+#    sudo mkdir -p /etc/docker
+#    sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
+#    sudo chown root:root /etc/docker/daemon.json
 
-    # Enable docker daemon to start on boot.
+    # Enable docker|CRI daemon to start on boot.
     sudo systemctl daemon-reload
 fi
 

--- a/test/cases/container-runtime-defaults.sh
+++ b/test/cases/container-runtime-defaults.sh
@@ -9,7 +9,7 @@ KUBELET_VERSION="v1.20.15-eks-ba74326"
 run ${TEMP_DIR} /etc/eks/bootstrap.sh \
     --b64-cluster-ca dGVzdA== \
     --apiserver-endpoint http://my-api-endpoint \
-    --container-runtime dockerd \
+    --container-runtime containerd \
     test || exit_code=$?
 
 if [[ ${exit_code} -ne 0 ]]; then


### PR DESCRIPTION
**Issue #, if available:*NA*

**Description of changes:*Changes to AMI packer scripts to build image that uses containerd as cri by default and doesn't install docker by default*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done*Built AMI image; decoupling docker and using containerd as the default cri. On clusters that have to be on version < 1.24 for dependencies, CRs, etc.*

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->
- Tested built image creating new cluster with kubenertes v1.22
- Tested built image creating a managed nodegroup with cluster kubernetes v1.22

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
