### PR TITLE
Update api version for client authentication in kubeconfig

### DIFF
--- a/files/kubelet-kubeconfig
+++ b/files/kubelet-kubeconfig
@@ -15,7 +15,7 @@ users:
 - name: kubelet
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: /usr/bin/aws-iam-authenticator
       args:
         - "token"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -241,6 +241,13 @@ for binary in ${BINARIES[*]} ; do
     sudo mv $binary /usr/bin/
 done
 
+#Updating the client-auth api version in cases where older iam-auth version is being used
+iam_auth_version=$(sudo /usr/bin/aws-iam-authenticator version | jq -r .Version)
+if [[ "$(printf '%s\n' $iam_auth_version "v0.5.8" | sort -V | tail -n 1)" = "v0.5.8" ]]; then
+    echo "AWS IAM authenticator version is lower than 0.5.8 so we should not update api version of kubeconfig"
+    sudo sed -i s,"client.authentication.k8s.io/v1beta1","client.authentication.k8s.io/v1alpha1", $TEMPLATE_DIR/kubelet-kubeconfig
+fi
+
 # Since CNI 0.7.0, all releases are done in the plugins repo.
 CNI_PLUGIN_FILENAME="cni-plugins-linux-${ARCH}-${CNI_PLUGIN_VERSION}"
 


### PR DESCRIPTION
**Issue #, if available:**
This commit updates the API Version from client.authentication.k8s.io/v1alpha1 to client.authentication.k8s.io/v1beta1 to address the issue #1020 . The corresponding binaries of aws-iam-authenticator have already been uploaded.

**Description of changes:**
Simple change to update the api version as the older version was deprecated beginning kubernetes version 1.24

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
I created 1.22 AMI locally with the latest uploaded binaries and was able test nodegroup creation.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
