### PR TITLE
configure containerd registry certificates by default

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -540,6 +540,8 @@ EOF
   sudo cp -v /etc/eks/containerd/kubelet-containerd.service /etc/systemd/system/kubelet.service
   sudo chown root:root /etc/systemd/system/kubelet.service
   sudo chown root:root /etc/systemd/system/sandbox-image.service
+  # Validate containerd config
+  sudo containerd config dump > /dev/null
   systemctl daemon-reload
   systemctl enable containerd
   systemctl restart containerd

--- a/files/containerd-config.toml
+++ b/files/containerd-config.toml
@@ -11,6 +11,9 @@ default_runtime_name = "runc"
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "SANDBOX_IMAGE"
 
+[plugins."io.containerd.grpc.v1.cri".registry]
+config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
+
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
 runtime_type = "io.containerd.runc.v2"
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,17 +1,19 @@
 FROM public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock:v1.11.2 as aemm
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
-RUN yum install -y jq && \
-    yum install -y wget && \
+RUN amazon-linux-extras enable docker && \
+    yum install -y jq containerd wget && \
     wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && \
     chmod a+x /usr/local/bin/yq
 
 ENV IMDS_ENDPOINT=127.0.0.1:1338
 COPY --from=aemm /ec2-metadata-mock /sbin/ec2-metadata-mock
+RUN mkdir -p /etc/eks/containerd
+COPY files/ /etc/eks/
+COPY files/containerd-config.toml files/kubelet-containerd.service files/pull-sandbox-image.sh files/sandbox-image.service /etc/eks/containerd/
 COPY files/kubelet-config.json /etc/kubernetes/kubelet/kubelet-config.json
 COPY files/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
 COPY files/ecr-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config
 COPY test/entrypoint.sh /entrypoint.sh
-COPY files /etc/eks
 COPY files/bin/* /usr/bin/
 COPY test/mocks/ /sbin/
 ENTRYPOINT ["/entrypoint.sh"]

--- a/test/cases/container-runtime-defaults.sh
+++ b/test/cases/container-runtime-defaults.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 exit_code=0
-TEMP_DIR=$(mktemp -d)
 
 echo "--> Should allow dockerd as container runtime when below k8s version 1.24"
 # This variable is used to override the default value in the kubelet mock

--- a/test/cases/containerd-config.sh
+++ b/test/cases/containerd-config.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exit_code=0
+
+echo "--> Default containerd config file should be valid"
+STDERR_FILE=$(mktemp)
+containerd -c /etc/eks/containerd/containerd-config.toml config dump > /dev/null 2> "$STDERR_FILE" || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: default containerd config file is invalid! $(cat "$STDERR_FILE")"
+  exit 1
+fi
+
+echo "--> Should fail when given an invalid containerd config"
+CONTAINERD_TOML=$(mktemp containerd-XXXXX.toml)
+cat > "$CONTAINERD_TOML" << EOF
+[cgroup]
+path = "foo"
+[cgroup]
+path = "bar"
+EOF
+
+export KUBELET_VERSION=v1.24.15-eks-ba74326
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  --container-runtime containerd \
+  --containerd-config-file "$CONTAINERD_TOML" \
+  test || exit_code=$?
+
+if [[ ${exit_code} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${exit_code}'"
+  exit 1
+fi

--- a/test/mocks/sudo
+++ b/test/mocks/sudo
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "mocking sudo with params $@"
+exec "$@"


### PR DESCRIPTION
**Issue #, if available:**

_N/A_

**Description of changes:**

By default, Docker used to allow placing registry certificates on the host filesystem under `/etc/docker/certs.d`. Containerd did not support this until 1.5 and as of 1.6, it is still not enabled by default. There are some discussions around enabling it in 1.7 (https://github.com/containerd/containerd/issues/6485), but it would be helpful to have this enabled in EKS AMIs as well.

**Testing Done**

Created an EKS 1.23 cluster with containerd as the runtime. Using a docker registry deployed within the cluster with a self-signed cert, dynamically placed a CA into /etc/docker/certs.d and confirmed that a pod referencing that registry worked.