### PR TITLE
Upgrades runc to 1.1.3-1.amzn2.0.2

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -26,7 +26,7 @@
     "launch_block_device_mappings_volume_size": "4",
     "pull_cni_from_github": "true",
     "remote_folder": "",
-    "runc_version": "1.1.3-1.amzn2",
+    "runc_version": "1.1.3-1.amzn2.0.2",
     "security_group_id": "",
     "sonobuoy_e2e_registry": "",
     "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",


### PR DESCRIPTION
**Description of changes:**
Upgrades runc to mitigate [ALASDOCKER-2022-020](https://alas.aws.amazon.com/AL2/ALASDOCKER-2022-020.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

Built a 1.23 AMI and verified runc version was as expected.

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
