### PR TITLE
Fixes arch reference in README per #1057

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ PLATFORM=linux # Chose a platform and set the variable
 
 #List of all architectures for the selected Kubernetes Version, build date and platform
 aws s3 ls s3://amazon-eks/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/
-ARCH=amd64 #Chose an architecture and set the variable
+ARCH=x86_64 #Chose an architecture and set the variable
 ```
 Run the following command to build an Amazon EKS Worker AMI based on the chosen parameters in the previous step
 ```bash


### PR DESCRIPTION
**Issue #, if available:**
#1057

**Description of changes:**
`amd64` is not a valid architecture. Should be `x86_64` or `arm64`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

None

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
