### PR TITLE
Add fmt to make targets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*.sh]
+indent_style       = space
+indent_size        = 2
+binary_next_line   = true
+switch_case_indent = true
+space_redirects    = true
+keep_padding       = true
+function_next_line = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,11 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+3. Ensure your changes match our style guide (`make fmt`).
+4. Ensure local tests pass (`make test`).
+5. Commit to your fork using clear commit messages.
+6. Send us a pull request, answering any default questions in the pull request interface.
+7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and 
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PACKER_VARIABLES := aws_region ami_name binary_bucket_name binary_bucket_region 
 K8S_VERSION_PARTS := $(subst ., ,$(kubernetes_version))
 K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS})
 
+MAKEFILE_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
 aws_region ?= $(AWS_DEFAULT_REGION)
 binary_bucket_region ?= $(AWS_DEFAULT_REGION)
 arch ?= x86_64
@@ -30,6 +32,10 @@ T_RESET := \e[0m
 
 .PHONY: all
 all: 1.20 1.21 1.22 1.23 ## Build all versions of EKS Optimized AL2 AMI
+
+.PHONY: fmt
+fmt: ## Format the source files
+	shfmt --list $(MAKEFILE_DIR)
 
 .PHONY: test
 test: ## run the test-harness


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This adds a `fmt` target to the Makefile. This PR does not include any actual formatting changes. Once this is merged, I will open a PR that applies any formatting changes as a result of this standardization.

**Testing Done**

```
> make fmt

shfmt --list /local/home/mckdev/github/amazon-eks-ami
/local/home/mckdev/github/amazon-eks-ami/files/bin/imds:8:13: a command can only contain words and redirects; encountered (
/local/home/mckdev/github/amazon-eks-ami/files/bootstrap.sh
/local/home/mckdev/github/amazon-eks-ami/files/max-pods-calculator.sh
/local/home/mckdev/github/amazon-eks-ami/files/pull-sandbox-image.sh
/local/home/mckdev/github/amazon-eks-ami/log-collector-script/linux/eks-log-collector.sh
/local/home/mckdev/github/amazon-eks-ami/scripts/cleanup_additional_repos.sh
/local/home/mckdev/github/amazon-eks-ami/scripts/generate-version-info.sh
/local/home/mckdev/github/amazon-eks-ami/scripts/install-worker.sh
/local/home/mckdev/github/amazon-eks-ami/scripts/install_additional_repos.sh
/local/home/mckdev/github/amazon-eks-ami/scripts/validate.sh
/local/home/mckdev/github/amazon-eks-ami/test/cases/imds-token-refresh.sh:21:97: not a valid parameter expansion operator: $
/local/home/mckdev/github/amazon-eks-ami/test/cases/ipv4-cluster-dns-ip.sh
/local/home/mckdev/github/amazon-eks-ami/test/cases/ipv6-cluster-dns-ip.sh
/local/home/mckdev/github/amazon-eks-ami/test/cases/ipv6-dns-cluster-ip-given-service-ipv6-cidr.sh
/local/home/mckdev/github/amazon-eks-ami/test/cases/ipv6-ip-family-and-service-ipv6-cidr.sh
/local/home/mckdev/github/amazon-eks-ami/test/cases/max-pods-cni-1-7-5.sh
/local/home/mckdev/github/amazon-eks-ami/test/entrypoint.sh
/local/home/mckdev/github/amazon-eks-ami/test/mocks/aws
/local/home/mckdev/github/amazon-eks-ami/test/mocks/iptables-save
/local/home/mckdev/github/amazon-eks-ami/test/mocks/sudo
/local/home/mckdev/github/amazon-eks-ami/test/mocks/systemctl
/local/home/mckdev/github/amazon-eks-ami/test/test-harness.sh
make: *** [fmt] Error 1
```

The two syntax issues identified in the output are addressed in #1062 .