### PR TITLE
Use shfmt flags instead of editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
+# ensure that these rules are equivalent to the flags to shfmt in the Makefile.
+# we can't use this file with shfmt directly because there's no way to express
+# shebang matching on files without the `sh` extension.
 [*.sh]
 indent_style       = space
 indent_size        = 2

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,17 @@ all: 1.20 1.21 1.22 1.23 ## Build all versions of EKS Optimized AL2 AMI
 
 .PHONY: fmt
 fmt: ## Format the source files
-	shfmt --list $(MAKEFILE_DIR)
+	# ensure that these flags are equivalent to the rules in the .editorconfig
+	shfmt \
+	  --list \
+	  --write \
+	  --language-dialect auto \
+	  --indent 2 \
+	  --binary-next-line \
+	  --case-indent \
+	  --space-redirects \
+	  --keep-padding \
+	  $(MAKEFILE_DIR)
 
 .PHONY: test
 test: ## run the test-harness


### PR DESCRIPTION
**Description of changes:**

`shfmt` can find files based on their shebang (like `files/bin/imds`) while the matching rule `[*.sh]` in `.editorconfig` won't include them. The options are:
1. specifying every such file as an additional match pattern in the `.editorconfig`
2. keeping the style rules in sync between the `shfmt` flags and the `.editorconfig`.

Realistically, the style rules will change almost never, so I went with with the second option.

This PR also adds the `--write` flag, which will actually apply the formatting changes -- those are coming in a separate PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Testing Done**

```
make fmt
```