### PR TITLE
Pin Kernel 5.4 to 5.4.209-116.367 to prevent nodes from going into Unready

### DIFF
--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -13,7 +13,12 @@ fi
 if [[ $KERNEL_VERSION == "4.14" ]]; then
     sudo yum update -y kernel
 elif [[ $KERNEL_VERSION == "5.4" ]]; then
-    sudo amazon-linux-extras install -y kernel-5.4
+    # Pinning Kernel to 5.4.209-116.367 since we're investigating issues with later Kernel versions which cause nodes to become Unready.
+    # sudo amazon-linux-extras install -y kernel-5.4
+    sudo amazon-linux-extras enable kernel-5.4=latest
+    sudo yum -y install kernel-5.4.209-116.367.amzn2
+    sudo yum install -y yum-plugin-versionlock
+    sudo yum versionlock kernel-5.4*
 elif [[ $KERNEL_VERSION == "5.10" ]]; then
     sudo amazon-linux-extras install -y kernel-5.10
 else


### PR DESCRIPTION
**Issue #, if available:** https://github.com/awslabs/amazon-eks-ami/issues/1071

**Description of changes:**

Pin Kernel 5.4 to 5.4.209-116.367 to prevent nodes from going into Unready

We're investigating issues with later Kernel versions which cause nodes to become Unready. Till those issues are resolved, pinning the Kernel to the last known good version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

I was able to build a new AMI with these changes and confirm that the Kernel version on an instance launched with that AMI matched the pinned version.

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
