### PR TITLE
Address shellcheck finding

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -265,7 +265,7 @@ get_cpu_millicores_to_reserve() {
   local cpu_ranges=(0 1000 2000 4000 $total_cpu_on_instance)
   local cpu_percentage_reserved_for_ranges=(600 100 50 25)
   cpu_to_reserve="0"
-  for i in ${!cpu_percentage_reserved_for_ranges[@]}; do
+  for i in "${!cpu_percentage_reserved_for_ranges[@]}"; do
     local start_range=${cpu_ranges[$i]}
     local end_range=${cpu_ranges[(($i+1))]}
     local percentage_to_reserve_for_range=${cpu_percentage_reserved_for_ranges[$i]}


### PR DESCRIPTION
**Description of changes:**

In preparation for #1068, addressing the single `error`-level finding from `shellcheck`:
```
> shellcheck --severity error --format gcc **/*.sh
files/bootstrap.sh:268:12: error: Double quote array expansions to avoid re-splitting elements. [SC2068]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Testing Done**

After this change, no such error is found:
```
> shellcheck --severity error --format gcc **/*.sh
> echo $?
0
```
