### PR TITLE
Don't keep padding when formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,5 @@ indent_size        = 2
 binary_next_line   = true
 switch_case_indent = true
 space_redirects    = true
-keep_padding       = true
+keep_padding       = false
 function_next_line = false

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ fmt: ## Format the source files
 	  --binary-next-line \
 	  --case-indent \
 	  --space-redirects \
-	  --keep-padding \
 	  $(MAKEFILE_DIR)
 
 .PHONY: test


### PR DESCRIPTION
**Description of changes:**

When drafting a PR to apply the new `shfmt` rules, I noticed that the `--keep-padding` option often results in undesirable indentation/alignment (which is the opposite of what I'd expect). Removing this flag results in proper results.

For example, in `files/pull-sandbox-image.sh`, with `--keep-padding`, we get:
```
for attempt in $(seq 0 $API_RETRY_ATTEMPTS); do
  rc=0
    if [[ $attempt -gt 0 ]]; then
        echo "Attempt $attempt of $API_RETRY_ATTEMPTS"
  fi
done
```
and without it, we get the proper:
```
for attempt in $(seq 0 $API_RETRY_ATTEMPTS); do
  rc=0
  if [[ $attempt -gt 0 ]]; then
    echo "Attempt $attempt of $API_RETRY_ATTEMPTS"
  fi
done
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

`make fmt` succeeds without the flag, and the results are correct.