### PR TITLE
cleanup messages and imds-tokens

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -25,6 +25,8 @@ sudo rm -rf \
     /var/log/cloud-init-output.log \
     /var/log/cloud-init.log \
     /var/log/secure \
-    /var/log/wtmp
+    /var/log/wtmp \
+    /var/log/messages \
+    /tmp/imds-tokens
 
 sudo touch /etc/machine-id


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
 - Fixes a bug where the imds-token generated during AMI creation time sticks around when the AMI is launched. If the token is still valid, the IMDS call will fail since the token is not associated with the instance id that built the AMI. This is a small annoyance since it only affects instances that are launched within 15 minutes of AMI creation since the default IMDS Token TTL in the imds script is 900s. This is fixed by deleting `/tmp/imds-tokens` in the cleanup script. 
 -  I've also deleted `/var/log/messages` in the cleanup script to make debugging launch failures easier. Right now you have to find the start of the actual launch rather than the build logs. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
 - Reproduced IMDS issue by increasing the token ttl to 6 hours and observing nodes launched w/ that test AMI not going to ready. Cleared the /tmp/imds-tokens and observed nodes launching correctly afterwards. 
 - Built x86 AMI, launched in a cluster and observed nodes going to ready.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
