### PR TITLE
Garbage collection for imds tokens

### DIFF
--- a/files/bin/imds
+++ b/files/bin/imds
@@ -30,22 +30,41 @@ log "ℹ️ Talking to IMDS at $IMDS_ENDPOINT"
 TOKEN_DIR=/tmp/imds-tokens
 mkdir -p $TOKEN_DIR
 
+IMDS_RETRIES=${IMDS_RETRIES:-10}
+IMDS_RETRY_DELAY_SECONDS=${IMDS_RETRY_DELAY_SECONDS:-1}
+
+# default ttl is 15 minutes
+IMDS_TOKEN_TTL_SECONDS=${IMDS_TOKEN_TTL_SECONDS:-900}
+
+# max ttl is 6 hours, see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+IMDS_MAX_TOKEN_TTL_SECONDS=${IMDS_MAX_TOKEN_TTL_SECONDS:-21600}
+
+# cleanup expired tokens
+DELETED_TOKENS=0
+for TOKEN_FILE in $(ls $TOKEN_DIR | awk '$0 < '$(($CURRENT_TIME - $IMDS_MAX_TOKEN_TTL_SECONDS))); do
+  rm $TOKEN_DIR/$TOKEN_FILE
+  DELETED_TOKENS=$(($DELETED_TOKENS + 1))
+done
+if [ "$DELETED_TOKENS" -gt 0 ]; then
+  log "🗑️ Deleted $DELETED_TOKENS expired IMDS token(s)."
+fi
+
 TOKEN_FILE=$(ls $TOKEN_DIR | awk '$0 > '$CURRENT_TIME | sort -n -r | head -n 1)
 
 if [ "$TOKEN_FILE" = "" ]
 then
-  # default ttl is 15 minutes
-  IMDS_TOKEN_TTL_SECONDS=${IMDS_TOKEN_TTL_SECONDS:-900}
   TOKEN_FILE=$(($CURRENT_TIME + $IMDS_TOKEN_TTL_SECONDS))
   curl \
     --silent \
     --show-error \
-    --retry 10 \
-    --retry-delay 1 \
+    --retry $IMDS_RETRIES \
+    --retry-delay $IMDS_RETRY_DELAY_SECONDS \
     -o $TOKEN_DIR/$TOKEN_FILE \
     -H "X-aws-ec2-metadata-token-ttl-seconds: $IMDS_TOKEN_TTL_SECONDS" \
     -X PUT \
     "http://$IMDS_ENDPOINT/latest/api/token"
+  # make sure any user can utilize (and clean up) these tokens
+  chmod a+rwx $TOKEN_DIR/$TOKEN_FILE
   log "🔑 Retrieved a fresh IMDS token that will expire in $IMDS_TOKEN_TTL_SECONDS seconds."
 else
   log "ℹ️ Using cached IMDS token that expires in $(($TOKEN_FILE - $CURRENT_TIME)) seconds."
@@ -54,8 +73,8 @@ fi
 curl \
   --silent \
   --show-error \
-  --retry 10 \
-  --retry-delay 1 \
+  --retry $IMDS_RETRIES \
+  --retry-delay $IMDS_RETRY_DELAY_SECONDS \
   --write-out '\n' \
   -H "X-aws-ec2-metadata-token: $(cat $TOKEN_DIR/$TOKEN_FILE)" \
   "http://$IMDS_ENDPOINT/$API_PATH"

--- a/test/cases/imds-token-refresh.sh
+++ b/test/cases/imds-token-refresh.sh
@@ -47,3 +47,33 @@ then
     echo "❌ Test Failed: expected two tokens to be present after third IMDS call but got '$(ls $TOKEN_DIR)'"
     exit 1
 fi
+
+sleep $(($TTL + 1))
+
+# both tokens are now expired, but only one should be garbage-collected with a window of $TTL
+
+IMDS_MAX_TOKEN_TTL_SECONDS=$TTL imds /latest/meta-data/instance-id || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]
+then
+    echo "❌ Test Failed: expected a non-zero exit code but got '${exit_code}'"
+    exit 1
+elif [[ $(ls $TOKEN_DIR | wc -l) -ne 2 ]]
+then
+    echo "❌ Test Failed: expected two tokens to be present after first garbage-collection but got '$(ls $TOKEN_DIR)'"
+    exit 1
+fi
+
+# the other expired token should be removed with a window of 0
+
+IMDS_MAX_TOKEN_TTL_SECONDS=0 imds /latest/meta-data/instance-id || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]
+then
+    echo "❌ Test Failed: expected a non-zero exit code but got '${exit_code}'"
+    exit 1
+elif [[ $(ls $TOKEN_DIR | wc -l) -ne 1 ]]
+then
+    echo "❌ Test Failed: expected one token to be present after second garbage-collection but got '$(ls $TOKEN_DIR)'"
+    exit 1
+fi


### PR DESCRIPTION
**Description of changes:**

This will delete IMDS tokens older than 6 hours, the current maximum token TTL. The `imds` program isn't likely to be used much after bootstrap, but you never know. 😄 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Added test cases for garbage collection.