### PR TITLE
Ignore shell formatting commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Applied code style rules to shell files
+6014c4e6872a23f82ca295afa93b033207042876
+


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This will ignore #1076 in the GitHub blame view, and can be used locally like:
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

More info here: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.