### PR TITLE
Add stale issue workflow

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,21 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    # once a day at noon
+    - cron: '0 12 * * *'
+permissions:
+  issues: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          days-before-stale: 90
+          days-before-close: 14
+          stale-issue-message: 'Please update this issue if it applies to the latest AMI release; otherwise it will be closed soon.'
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'never-stale'   
+          # empty message will prevent PR's from being staled          
+          stale-pr-message: ''
+          debug-only: true


### PR DESCRIPTION
**Description of changes:**

In an effort to compact our backlog, this adds a daily job to mark issues as stale if they've had no activity in the last 90 days. Issues with the `never-stale` label will be excluded. PR's will be excluded.

This is initially in debug-only mode in order to pro-actively apply `never-stale` to long-standing issues that remain relevant.

More information available here: https://github.com/actions/stale

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.