### PR TITLE
Update credential provider API to beta for 1.24+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,21 @@ Delete the cluster:
 eksctl delete cluster -f cluster.yaml
 ```
 
+## Troubleshooting
+
+**Tests fail with `realpath: command not found`**
+
+When running `make test`, you may see a message like below:
+
+```
+test/test-harness.sh: line 41: realpath: command not found
+/entrypoint.sh: line 13: /test.sh: No such file or directory
+```
+
+The issue is discussed in [this StackExchange post](https://unix.stackexchange.com/questions/101080/realpath-command-not-found).
+
+On OSX, running `brew install coreutils` resolves the issue.
+
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels ((enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/aws-samples/amazon-eks-ami/labels/help%20wanted) issues is a great place to start. 
 

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -145,6 +145,14 @@ DEFAULT_CONTAINER_RUNTIME=dockerd
 if vercmp "$KUBELET_VERSION" gteq "1.24.0"; then
   IS_124_OR_GREATER=true
   DEFAULT_CONTAINER_RUNTIME=containerd
+elif vercmp "$KUBELET_VERSION" gteq "1.22.0"; then
+  # Ensure that these exist for testing purposes
+  mkdir -p /etc/eks/ecr-credential-provider
+  touch /etc/eks/ecr-credential-provider/ecr-credential-provider-config
+  # These APIs are only available in alpha pre-1.24.
+  # This can be removed when version 1.23 is no longer supported.
+  sed -i s,kubelet.config.k8s.io/v1beta1,kubelet.config.k8s.io/v1alpha1,g /etc/eks/ecr-credential-provider/ecr-credential-provider-config
+  sed -i s,credentialprovider.kubelet.k8s.io/v1beta1,credentialprovider.kubelet.k8s.io/v1alpha1,g /etc/eks/ecr-credential-provider/ecr-credential-provider-config
 fi
 
 # Set container runtime related variables

--- a/files/ecr-credential-provider-config
+++ b/files/ecr-credential-provider-config
@@ -1,4 +1,4 @@
-apiVersion: kubelet.config.k8s.io/v1alpha1
+apiVersion: kubelet.config.k8s.io/v1beta1
 kind: CredentialProviderConfig
 providers:
   - name: ecr-credential-provider
@@ -9,6 +9,6 @@ providers:
       - "*.dkr.ecr.us-iso-east-1.c2s.ic.gov"
       - "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
     defaultCacheDuration: "12h"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1alpha1
+    apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
     args:
       - get-credentials

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,9 @@
 FROM public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock:v1.11.2 as aemm
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN yum install -y jq
+RUN yum install -y wget
+RUN wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+RUN chmod a+x /usr/local/bin/yq
 
 ENV IMDS_ENDPOINT=127.0.0.1:1338
 COPY --from=aemm /ec2-metadata-mock /sbin/ec2-metadata-mock

--- a/test/cases/ecr-credential-provider-config.sh
+++ b/test/cases/ecr-credential-provider-config.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exit_code=0
+TEMP_DIR=$(mktemp -d)
+
+# Setup test cases
+mkdir -p /etc/eks/ecr-credential-provider
+export CRED_PROVIDER_FILE="/etc/eks/ecr-credential-provider/ecr-credential-provider-config"
+
+echo "--> Should default to credentialprovider.kubelet.k8s.io/v1alpha1 and kubelet.config.k8s.io/v1alpha1 when below k8s version 1.24"
+
+# Ensure the credential provider config is present and fresh
+cp /etc/eks/ecr-credential-provider-config $CRED_PROVIDER_FILE
+# This variable is used to override the default value in the kubelet mock
+export KUBELET_VERSION=v1.22.15-eks-ba74326
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1alpha1"
+actual=$(yq e '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
+if [[ "$expected_cred_provider_api" != "$actual" ]]; then
+  echo "❌ Test Failed: expected 1.22 credential provider file to contain $expected_cred_provider_api"
+  exit 1
+fi
+
+expected_kubelet_config_api="kubelet.config.k8s.io/v1alpha1"
+actual=$(yq e '.apiVersion' $CRED_PROVIDER_FILE)
+if [[ "$expected_kubelet_config_api" != "$actual" ]]; then
+  echo "❌ Test Failed: expected 1.22 credential provider file to contain $expected_kubelet_config_api"
+  exit 1
+fi
+
+echo "--> Should default to credentialprovider.kubelet.k8s.io/v1beta1 and kubelet.config.k8s.io/v1beta1 when at or above k8s version 1.24"
+
+# Ensure the credential provider config is present and fresh
+cp /etc/eks/ecr-credential-provider-config $CRED_PROVIDER_FILE
+export KUBELET_VERSION=v1.24.15-eks-ba74326
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1beta1"
+actual=$(yq e '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
+if [[ "$expected_cred_provider_api" != "$actual" ]]; then
+  echo "❌ Test Failed: expected 1.24 credential provider file to contain $expected_cred_provider_api"
+  exit 1
+fi
+
+expected_kubelet_config_api="kubelet.config.k8s.io/v1beta1"
+actual=$(yq e '.apiVersion' $CRED_PROVIDER_FILE)
+if [[ "$expected_kubelet_config_api" != "$actual" ]]; then
+  echo "❌ Test Failed: expected 1.24 credential provider file to contain $expected_kubelet_config_api"
+  exit 1
+fi
+
+exit_code=0

--- a/test/cases/vercmp.sh
+++ b/test/cases/vercmp.sh
@@ -24,6 +24,12 @@ if [[ ${EXIT_CODE} -ne 0 ]]; then
   echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
   exit 1
 fi
+EXIT_CODE=0
+vercmp "v1.0.0" lt "v1.1.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
 # should fail
 EXIT_CODE=0
 vercmp "1.0.0" lt "1.0.0" || EXIT_CODE=$?
@@ -49,6 +55,12 @@ if [[ ${EXIT_CODE} -eq 0 ]]; then
   echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
   exit 1
 fi
+EXIT_CODE=0
+vercmp "v2.0.0" lt "v1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
 
 echo "--> Should compare less-than-or-equal-to"
 # should succeed
@@ -66,6 +78,12 @@ if [[ ${EXIT_CODE} -ne 0 ]]; then
 fi
 EXIT_CODE=0
 vercmp "1.0.0" lteq "2.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "v1.0.0" lteq "v2.0.0" || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
   exit 1
@@ -89,11 +107,23 @@ if [[ ${EXIT_CODE} -eq 0 ]]; then
   echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
   exit 1
 fi
+EXIT_CODE=0
+vercmp "v2.0.0" lteq "v1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
 
 echo "--> Should compare strictly equal-to"
 # should succeed
 EXIT_CODE=0
 vercmp "1.0.0" eq "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "v1.0.0" eq "v1.0.0" || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
   exit 1
@@ -107,6 +137,12 @@ if [[ ${EXIT_CODE} -eq 0 ]]; then
 fi
 EXIT_CODE=0
 vercmp "1.0.0" eq "1.0.1" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "v1.0.0" eq "v1.0.1" || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -eq 0 ]]; then
   echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
   exit 1
@@ -132,6 +168,12 @@ if [[ ${EXIT_CODE} -ne 0 ]]; then
   echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
   exit 1
 fi
+EXIT_CODE=0
+vercmp "v2.0.0" gteq "v1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
 # should fail
 EXIT_CODE=0
 vercmp "1.0.0" gteq "1.0.1" || EXIT_CODE=$?
@@ -147,6 +189,12 @@ if [[ ${EXIT_CODE} -eq 0 ]]; then
 fi
 EXIT_CODE=0
 vercmp "1.0.0" gteq "2.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "v1.0.0" gteq "v2.0.0" || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -eq 0 ]]; then
   echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
   exit 1
@@ -172,6 +220,12 @@ if [[ ${EXIT_CODE} -ne 0 ]]; then
   echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
   exit 1
 fi
+EXIT_CODE=0
+vercmp "v1.1.0" gt "v1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
 # should fail
 EXIT_CODE=0
 vercmp "1.0.0" gt "1.0.0" || EXIT_CODE=$?
@@ -193,6 +247,12 @@ if [[ ${EXIT_CODE} -eq 0 ]]; then
 fi
 EXIT_CODE=0
 vercmp "1.0.0" gt "2.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "v1.0.0" gt "v2.0.0" || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -eq 0 ]]; then
   echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
   exit 1

--- a/test/test-harness.sh
+++ b/test/test-harness.sh
@@ -38,8 +38,7 @@ docker build -t eks-optimized-ami -f "${SCRIPTPATH}/Dockerfile" "${SCRIPTPATH}/.
 overall_status=0
 
 function run() {
-  docker run -v ${SCRIPTPATH}/../files/:/etc/eks/ \
-    -v "$(realpath $1):/test.sh" \
+  docker run -v "$(realpath $1):/test.sh" \
     --attach STDOUT \
     --attach STDERR \
     --rm \


### PR DESCRIPTION
**Description of changes:**
As of 1.22, we [added ECR credential provider support](https://github.com/awslabs/amazon-eks-ami/commit/da570d5d2474f847d1f24bbf36fedbf437c1de65), which was an alpha feature. The feature was enabled [here](https://github.com/awslabs/amazon-eks-ami/blob/master/scripts/install-worker.sh#L286), but in my testing, those branches didn't actually catch correctly, so the changes were never applied. As of 1.24, the feature have graduated to beta, so this PR updates the API version for 1.24+.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Created 1.24 and 1.23 AMIs, verified that they joined a cluster and confirmed that `--image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider` flags were set correctly and that 1.23 set alpha APIs and 1.24 set beta APIs.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
