### PR TITLE
Short-circut sandbox image fetching

### DIFF
--- a/files/pull-sandbox-image.sh
+++ b/files/pull-sandbox-image.sh
@@ -2,4 +2,10 @@
 set -euo pipefail
 
 sandbox_image="$(awk -F'[ ="]+' '$1 == "sandbox_image" { print $2 }' /etc/containerd/config.toml)"
+
+### Short-circuit fetching sandbox image if its already present
+if [[ "$(sudo ctr --namespace k8s.io image ls | grep $sandbox_image)" != "" ]]; then
+  exit 0
+fi
+
 /etc/eks/containerd/pull-image.sh "${sandbox_image}"


### PR DESCRIPTION
**Issue #, if available:**
N/A
**Description of changes:**
The commit short-circuits fetching the sandbox image from ECR whenever its present locally. This is needed to support edge device stability during disconnection. 

In order to bring the kubelet back online, systemd will create a sandbox in which the kubelet will run. If connection to the AWS region is down, we won't be able to reach ECR and pulling will fail. 

We don't need to call ECR to pull the image if its available locally. So this commit adds that short-circuiting.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

- Built the AMI
- Tested locally with a worker node when it is disconnect and connected using a cluster running k8s 1.21.
- Ran conformance tests
