### PR TITLE
Add vercmp helper

### DIFF
--- a/files/bin/vercmp
+++ b/files/bin/vercmp
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Comparison expressions for semantic versions.
+# only supports semver standard MAJOR.MINOR.PATCH syntax;
+# pre-release or build-metadata extensions have undefined behavior.
+
+set -o errexit
+set -o pipefail
+
+function usage() {
+  echo "Comparison expressions for semantic versions."
+  echo
+  echo "usage: vercmp VERSION_A OPERATOR VERSION_B"
+  echo
+  echo "OPERATORS"
+  echo
+  echo "  lt   - Less than"
+  echo "  lteq - Less than or equal to"
+  echo "  eq   - Equal to"
+  echo "  gteq - Grater than or equal to"
+  echo "  gt   - Greater than"
+  echo
+}
+
+if [ "$#" -ne 3 ]; then
+  usage
+  exit 1
+fi
+
+LEFT="$1"
+OPERATOR="$2"
+RIGHT="$3"
+
+if [ "$LEFT" = "$RIGHT" ]; then
+  COMPARISON=0
+else
+  SORTED=($(for VER in "$LEFT" "$RIGHT"; do echo "$VER"; done | sort -V))
+  if [ "${SORTED[0]}" = "$LEFT" ]; then
+    COMPARISON=-1
+  else
+    COMPARISON=1
+  fi
+fi
+
+OUTCOME=false
+
+case $OPERATOR in
+  lt)
+    if [ "$COMPARISON" -eq -1 ]; then
+      OUTCOME=true
+    fi
+    ;;
+
+  lteq)
+    if [ "$COMPARISON" -lt 1 ]; then
+      OUTCOME=true
+    fi
+    ;;
+
+  eq)
+    if [ "$COMPARISON" -eq 0 ]; then
+      OUTCOME=true
+    fi
+    ;;
+
+  gteq)
+    if [ "$COMPARISON" -gt -1 ]; then
+      OUTCOME=true
+    fi
+    ;;
+
+  gt)
+    if [ "$COMPARISON" -eq 1 ]; then
+      OUTCOME=true
+    fi
+    ;;
+
+  *)
+    usage
+    exit 1
+    ;;
+esac
+
+echo "$OUTCOME"
+
+if [ "$OUTCOME" = "true" ]; then
+  exit 0
+else
+  exit 1
+fi

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -138,18 +138,11 @@ set -u
 KUBELET_VERSION=$(kubelet --version | grep -Eo '[0-9]\.[0-9]+\.[0-9]+')
 echo "Using kubelet version $KUBELET_VERSION"
 
-function is_greater_than_or_equal_to_version() {
-  local actual_version="$1"
-  local compared_version="$2"
-
-  [ $actual_version = "$(echo -e "$actual_version\n$compared_version" | sort -V | tail -n1)" ]
-}
-
 # As of Kubernetes version 1.24, we will start defaulting the container runtime to containerd
 # and no longer support docker as a container runtime.
 IS_124_OR_GREATER=false
 DEFAULT_CONTAINER_RUNTIME=dockerd
-if is_greater_than_or_equal_to_version $KUBELET_VERSION "1.24.0"; then
+if vercmp "$KUBELET_VERSION" gteq "1.24.0"; then
   IS_124_OR_GREATER=true
   DEFAULT_CONTAINER_RUNTIME=containerd
 fi
@@ -467,7 +460,7 @@ else
 fi
 INSTANCE_TYPE=$(imds 'latest/meta-data/instance-type')
 
-if is_greater_than_or_equal_to_version $KUBELET_VERSION "1.22.0"; then
+if vercmp "$KUBELET_VERSION" gteq "1.22.0"; then
   # for K8s versions that suport API Priority & Fairness, increase our API server QPS
   echo $(jq ".kubeAPIQPS=( .kubeAPIQPS // 10)|.kubeAPIBurst=( .kubeAPIBurst // 20)" $KUBELET_CONFIG) > $KUBELET_CONFIG
 fi

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -166,7 +166,7 @@ else
   sudo mv $TEMPLATE_DIR/containerd-config.toml /etc/eks/containerd/containerd-config.toml
 fi
 
-if [[ ! $KUBERNETES_VERSION =~ "1.19"* && ! $KUBERNETES_VERSION =~ "1.20"* && ! $KUBERNETES_VERSION =~ "1.21"* ]]; then
+if vercmp "$KUBERNETES_VERSION" gteq "1.22.0"; then
   # enable CredentialProviders features in kubelet-containerd service file
   IMAGE_CREDENTIAL_PROVIDER_FLAGS='\\\n    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \\\n   --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider'
   sudo sed -i s,"aws","aws $IMAGE_CREDENTIAL_PROVIDER_FLAGS", $TEMPLATE_DIR/kubelet-containerd.service
@@ -278,7 +278,7 @@ if [[ $KUBERNETES_VERSION == "1.20"* ]]; then
   echo $KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED > $TEMPLATE_DIR/kubelet-config.json
 fi
 
-if [[ ! $KUBERNETES_VERSION =~ "1.19"* && ! $KUBERNETES_VERSION =~ "1.20"* && ! $KUBERNETES_VERSION =~ "1.21"* ]]; then
+if vercmp "$KUBERNETES_VERSION" gteq "1.22.0"; then
   # enable CredentialProviders feature flags in kubelet service file
   IMAGE_CREDENTIAL_PROVIDER_FLAGS='\\\n    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \\\n    --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider'
   sudo sed -i s,"aws","aws $IMAGE_CREDENTIAL_PROVIDER_FLAGS", $TEMPLATE_DIR/kubelet.service
@@ -316,7 +316,7 @@ fi
 ################################################################################
 ### ECR CREDENTIAL PROVIDER ####################################################
 ################################################################################
-if [[ ! $KUBERNETES_VERSION =~ "1.19"* && ! $KUBERNETES_VERSION =~ "1.20"* && ! $KUBERNETES_VERSION =~ "1.21"* ]]; then
+if vercmp "$KUBERNETES_VERSION" gteq "1.22.0"; then
   ECR_BINARY="ecr-credential-provider"
   if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
     echo "AWS cli present - using it to copy ecr-credential-provider binaries from s3."

--- a/test/cases/vercmp.sh
+++ b/test/cases/vercmp.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "--> Should compare strictly less-than"
+# should succeed
+EXIT_CODE=0
+vercmp "1.0.0" lt "2.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.0" lt "1.0.1" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.0" lt "1.1.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+# should fail
+EXIT_CODE=0
+vercmp "1.0.0" lt "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.1" lt "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.1.0" lt "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "2.0.0" lt "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+
+echo "--> Should compare less-than-or-equal-to"
+# should succeed
+EXIT_CODE=0
+vercmp "1.0.0" lteq "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.0" lteq "1.0.1" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.0" lteq "2.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+# should fail
+EXIT_CODE=0
+vercmp "1.0.1" lteq "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.1.0" lteq "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "2.0.0" lteq "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+
+echo "--> Should compare strictly equal-to"
+# should succeed
+EXIT_CODE=0
+vercmp "1.0.0" eq "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+# should fail
+EXIT_CODE=0
+vercmp "1.0.1" eq "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.0" eq "1.0.1" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+
+echo "--> Should compare greater-than-or-equal-to"
+# should succeed
+EXIT_CODE=0
+vercmp "1.0.0" gteq "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.1" gteq "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "2.0.0" gteq "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+# should fail
+EXIT_CODE=0
+vercmp "1.0.0" gteq "1.0.1" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.0" gteq "1.1.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.0" gteq "2.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+
+echo "--> Should compare strictly greater-than"
+# should succeed
+EXIT_CODE=0
+vercmp "2.0.0" gt "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.1" gt "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.1.0" gt "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+# should fail
+EXIT_CODE=0
+vercmp "1.0.0" gt "1.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.0" gt "1.0.1" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.0" gt "1.1.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi
+EXIT_CODE=0
+vercmp "1.0.0" gt "2.0.0" || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${EXIT_CODE}'"
+  exit 1
+fi


### PR DESCRIPTION
**Description of changes:**

This adds a utility to deal with semantic version comparisons, since we're adding more of these as times goes on (and will likely have more coming with 1.25).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Test cases added for each comparison operator

**Usage**
```
> vercmp

Comparison expressions for semantic versions.

usage: vercmp VERSION_A OPERATOR VERSION_B

OPERATORS

  lt   - Less than
  lteq - Less than or equal to
  eq   - Equal to
  gteq - Grater than or equal to
  gt   - Greater than
```
