### PR TITLE
Auth api update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,19 +78,23 @@ k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 
 .PHONY: 1.20
 1.20: ## Build EKS Optimized AL2 AMI - K8s 1.20
-	$(MAKE) k8s kubernetes_version=1.20.15 kubernetes_build_date=2022-07-27 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.20.15 kubernetes_build_date=2022-10-31 pull_cni_from_github=true
 
 .PHONY: 1.21
 1.21: ## Build EKS Optimized AL2 AMI - K8s 1.21
-	$(MAKE) k8s kubernetes_version=1.21.14 kubernetes_build_date=2022-07-27 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.21.14 kubernetes_build_date=2022-10-31 pull_cni_from_github=true
 
 .PHONY: 1.22
 1.22: ## Build EKS Optimized AL2 AMI - K8s 1.22
-	$(MAKE) k8s kubernetes_version=1.22.12 kubernetes_build_date=2022-07-27 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.22.15 kubernetes_build_date=2022-10-31 pull_cni_from_github=true
 
 .PHONY: 1.23
 1.23: ## Build EKS Optimized AL2 AMI - K8s 1.23
-	$(MAKE) k8s kubernetes_version=1.23.9 kubernetes_build_date=2022-07-27 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.23.13 kubernetes_build_date=2022-10-31 pull_cni_from_github=true
+
+.PHONY: 1.24
+1.24: ## Build EKS Optimized AL2 AMI - K8s 1.24
+	$(MAKE) k8s kubernetes_version=1.24.7 kubernetes_build_date=2022-10-31 pull_cni_from_github=true
 
 .PHONY: help
 help: ## Display help

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -146,9 +146,6 @@ if vercmp "$KUBELET_VERSION" gteq "1.24.0"; then
   IS_124_OR_GREATER=true
   DEFAULT_CONTAINER_RUNTIME=containerd
 elif vercmp "$KUBELET_VERSION" gteq "1.22.0"; then
-  # Ensure that these exist for testing purposes
-  mkdir -p /etc/eks/ecr-credential-provider
-  touch /etc/eks/ecr-credential-provider/ecr-credential-provider-config
   # These APIs are only available in alpha pre-1.24.
   # This can be removed when version 1.23 is no longer supported.
   sed -i s,kubelet.config.k8s.io/v1beta1,kubelet.config.k8s.io/v1alpha1,g /etc/eks/ecr-credential-provider/ecr-credential-provider-config

--- a/files/kubelet-kubeconfig
+++ b/files/kubelet-kubeconfig
@@ -15,7 +15,7 @@ users:
 - name: kubelet
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: /usr/bin/aws-iam-authenticator
       args:
         - "token"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -260,6 +260,16 @@ for binary in ${BINARIES[*]}; do
   sudo mv $binary /usr/bin/
 done
 
+# Verify that the aws-iam-authenticator is at last v0.5.9 or greater. Otherwise, nodes will be
+# unable to join clusters due to upgrading to client.authentication.k8s.io/v1beta1
+iam_auth_version=$(sudo /usr/bin/aws-iam-authenticator version | jq -r .Version)
+if vercmp "$iam_auth_version" lt "v0.5.9"; then
+  # To resolve this issue, you need to update the aws-iam-authenticator binary. Using binaries distributed by EKS
+  # with kubernetes_build_date 2022-10-31 or later include v0.5.10 or greater.
+  echo "❌ The aws-iam-authenticator should be on version v0.5.9 or later. Found $iam_auth_version"
+  exit 1
+fi
+
 # Since CNI 0.7.0, all releases are done in the plugins repo.
 CNI_PLUGIN_FILENAME="cni-plugins-linux-${ARCH}-${CNI_PLUGIN_VERSION}"
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,14 +1,15 @@
 FROM public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock:v1.11.2 as aemm
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
-RUN yum install -y jq
-RUN yum install -y wget
-RUN wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-RUN chmod a+x /usr/local/bin/yq
+RUN yum install -y jq && \
+    yum install -y wget && \
+    wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && \
+    chmod a+x /usr/local/bin/yq
 
 ENV IMDS_ENDPOINT=127.0.0.1:1338
 COPY --from=aemm /ec2-metadata-mock /sbin/ec2-metadata-mock
 COPY files/kubelet-config.json /etc/kubernetes/kubelet/kubelet-config.json
 COPY files/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
+COPY files/ecr-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config
 COPY test/entrypoint.sh /entrypoint.sh
 COPY files /etc/eks
 COPY files/bin/* /usr/bin/


### PR DESCRIPTION
**Issue #, if available:**
#1020
**Description of changes:**
As detailed in #1020, the `client.authentication.k8s.io/v1alpha1` API has been removed and we need to start using `client.authentication.k8s.io/v1beta1`. As of `aws-iam-authenticator` `0.5.9`, the beta API version is supported. On earlier versions, nodes will fail to join the cluster due to a mismatch in our config and expectations from the authenticator. To handle that we did a few things:

1. Released binaries with `kubernetes_build_date` of `2022-10-31` that include authenticator version `0.5.10`.
2. Added a check, in this PR, to fail the AMI build if the authenticator version does not support the beta API version.
3. Update the Makefile to use the latest binary versions, which also include `kubelet` version upgrades for Kubernetes versions 1.22+.

**NOTE: We have not yet released AMIs with these binaries and run our full suite of tests on these AMIs, though we have run a portion of them, so I recommend that customers wait for an official AMI release with all of these changes before building your own AMIs with them and running production traffic.** We intend to release AMIs soon, and those AMIs will go through our usual validation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
Built 1.20-1.24 AMIs and verified that 1.20, 1.23 and 1.24 AMIs successfully joined clusters.

Also, I verified that if we don't update the binaries, we get a build failure as expected.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
