### PR TITLE
Set application clock speeds for p4de instances in bootstrap.sh

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -589,8 +589,10 @@ if command -v nvidia-smi &> /dev/null; then
     echo $GPUNAME
 
     # set application clock to maximum
-    if [[ $GPUNAME == *"A100"* ]]; then
+    if [[ $GPUNAME == *"A100-SXM-40GB"* ]]; then
       nvidia-smi -ac 1215,1410
+    elif [[ $GPUNAME == *"A100-SXM-80GB"* ]]; then
+      nvidia-smi -ac 1593,1410
     elif [[ $GPUNAME == *"V100"* ]]; then
       nvidia-smi -ac 877,1530
     elif [[ $GPUNAME == *"K80"* ]]; then

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -588,7 +588,8 @@ if command -v nvidia-smi &> /dev/null; then
     GPUNAME=$(nvidia-smi -L | head -n1)
     echo $GPUNAME
 
-    # set application clock to maximum
+    # set gpu application clocks to their respective maximum values:
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize_gpu.html
     if [[ $GPUNAME == *"A100-SXM-40GB"* ]]; then
       nvidia-smi -ac 1215,1410
     elif [[ $GPUNAME == *"A100-SXM-80GB"* ]]; then


### PR DESCRIPTION
**Issue #, if available:**

Fixes https://github.com/awslabs/amazon-eks-ami/issues/954, as suggested by [hassanbabaie](https://github.com/hassanbabaie).


**Description of changes:**

Sets GPU application clocks to their maximum value for p4de.*, instances according to [this recommended value](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/optimize_gpu.html) (which is also the maximum `-ac` value for this GPU type).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

This value has been tested on p4de.24xlarge instances in EKS. They have not been tested on p4d.* instances.

Without this change, the following errors are present in `/var/log/cloud-init-output.log` for EKS nodes using p4de.24xlarge instance types.

```
...
Treating as warning and moving on.
Enabling/disabling default auto boosted clocks is not supported for GPU: 00000000:A0:1C.0.
Treating as warning and moving on.
Enabling/disabling default auto boosted clocks is not supported for GPU: 00000000:A0:1D.0.
Treating as warning and moving on.
All done.
GPU 0: NVIDIA A100-SXM-80GB (UUID: GPU-70ba6113-4249-9a27-3c17-ffd2fb5612ac)
Specified clock combination "(MEM 1215, SM 1410)" is not supported for GPU 00000000:10:1C.0. Run 'nvidia-smi -q -d SUPPORTED_CLOCKS' to see list of supported clock combinations
Treating as warning and moving on.
Specified clock combination "(MEM 1215, SM 1410)" is not supported for GPU 00000000:10:1D.0. Run 'nvidia-smi -q -d SUPPORTED_CLOCKS' to see list of supported clock combinations
Treating as warning and moving on.
Specified clock combination "(MEM 1215, SM 1410)" is not supported for GPU 00000000:20:1C.0. Run 'nvidia-smi -q -d SUPPORTED_CLOCKS' to see list of supported clock combinations
Treating as warning and moving on.
Specified clock combination "(MEM 1215, SM 1410)" is not supported for GPU 00000000:20:1D.0. Run 'nvidia-smi -q -d SUPPORTED_CLOCKS' to see list of supported clock combinations
Treating as warning and moving on.
Specified clock combination "(MEM 1215, SM 1410)" is not supported for GPU 00000000:90:1C.0. Run 'nvidia-smi -q -d SUPPORTED_CLOCKS' to see list of supported clock combinations
Treating as warning and moving on.
Specified clock combination "(MEM 1215, SM 1410)" is not supported for GPU 00000000:90:1D.0. Run 'nvidia-smi -q -d SUPPORTED_CLOCKS' to see list of supported clock combinations
Treating as warning and moving on.
Specified clock combination "(MEM 1215, SM 1410)" is not supported for GPU 00000000:A0:1C.0. Run 'nvidia-smi -q -d SUPPORTED_CLOCKS' to see list of supported clock combinations
Treating as warning and moving on.
Specified clock combination "(MEM 1215, SM 1410)" is not supported for GPU 00000000:A0:1D.0. Run 'nvidia-smi -q -d SUPPORTED_CLOCKS' to see list of supported clock combinations
Treating as warning and moving on.
All done.
...
```

When setting application clock speeds with `nvidia-smi -ac 1593,1410` on p4de.24xlarge instances, application clock speeds are correctly set to their maximum supported value... 

```
...
Applications clocks set to "(MEM 1593, SM 1410)" for GPU 00000000:10:1C.0
Applications clocks set to "(MEM 1593, SM 1410)" for GPU 00000000:10:1D.0
Applications clocks set to "(MEM 1593, SM 1410)" for GPU 00000000:20:1C.0
Applications clocks set to "(MEM 1593, SM 1410)" for GPU 00000000:20:1D.0
Applications clocks set to "(MEM 1593, SM 1410)" for GPU 00000000:90:1C.0
Applications clocks set to "(MEM 1593, SM 1410)" for GPU 00000000:90:1D.0
Applications clocks set to "(MEM 1593, SM 1410)" for GPU 00000000:A0:1C.0
Applications clocks set to "(MEM 1593, SM 1410)" for GPU 00000000:A0:1D.0
...
```