### PR TITLE
Dynamically set GPU application clock speed using nvidia-smi output

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -585,6 +585,7 @@ if command -v nvidia-smi &> /dev/null; then
     sudo nvidia-smi -pm 1 # set persistence mode
     sudo nvidia-smi --auto-boost-default=0
 
+    # set application clock speeds for all gpus, based on the max clock speeds of the first device found
     MAX_CLOCKS_XML_NO_BREAKS=$(nvidia-smi -q --xml-format | sed -n '/<max_clocks>/, /<\/max_clocks>/p')
     MAX_MEMORY_CLOCK_MHZ=$(echo $MAX_CLOCKS_XML_NO_BREAKS | sed -e 's/.*<mem_clock>\([0-9]*\) MHz<\/mem_clock>.*/\1/' )
     MAX_GRAPHICS_CLOCK_MHZ=$(echo $MAX_CLOCKS_XML_NO_BREAKS | sed -e 's/.*<graphics_clock>\([0-9]*\) MHz<\/graphics_clock>.*/\1/' )


### PR DESCRIPTION
**Issue #, if available:**

Fixes #954 and supersedes #1097 if merged.

**Description of changes:**

Avoid maintaining a static mapping of GPU names to maximum clock speed values as suggested in https://github.com/awslabs/amazon-eks-ami/pull/1097#issuecomment-1311892158.

Pros:

* Automatically set application clock speeds when new GPU instance types are added, without having to maintain a static list of clock speeds (avoiding issues like #954).

Cons:

* Possibly fragile to changes in the `nvidia-smi --query --xml-format` output format


**Testing Done**

These changes have been tested manually on an EKS node with a recent AMI.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->
