### PR TITLE
sym-link aws to bin

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -132,7 +132,7 @@ if [[ "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "
     --retry-delay 1 \
     -L "https://awscli.amazonaws.com/awscli-exe-linux-${MACHINE}.zip" -o "${AWSCLI_DIR}/awscliv2.zip"
   unzip -q "${AWSCLI_DIR}/awscliv2.zip" -d ${AWSCLI_DIR}
-  sudo "${AWSCLI_DIR}/aws/install"
+  sudo "${AWSCLI_DIR}/aws/install" --bin-dir /bin/
 else
   echo "Installing awscli package"
   sudo yum install -y awscli


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
 - sym link aws cli v2 to /bin/aws so that root has the aws binary in the path by default. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

```
sh-4.2$ which aws
/usr/bin/aws
sh-4.2$ aws --version
aws-cli/2.8.13 Python/3.9.11 Linux/5.4.219-126.411.amzn2.x86_64 exe/x86_64.amzn.2 prompt/off
sh-4.2$ sudo su
[root@i-02cffc64b04e0690b bin]# which aws
/bin/aws
[root@i-02cffc64b04e0690b bin]# aws --version
aws-cli/2.8.13 Python/3.9.11 Linux/5.4.219-126.411.amzn2.x86_64 exe/x86_64.amzn.2 prompt/off
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/master/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
