### PR TITLE
Remove aws_region and binary_bucket_region overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS
 
 MAKEFILE_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-aws_region ?= $(AWS_DEFAULT_REGION)
-binary_bucket_region ?= $(AWS_DEFAULT_REGION)
 arch ?= x86_64
 ifeq ($(arch), arm64)
 instance_type ?= m6g.large


### PR DESCRIPTION
**Issue #, if available:**

Closes #1112 

**Description of changes:**

Removing the environment variable override for `aws_region` and `binary_bucket_region`. These overrides offer a slight convenience, but prevent users from defining these variables in their `PACKER_VARIABLE_FILE`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.