### PR TITLE
Use IMDSv2 when getting instanceId in Windows log collector script

### DIFF
--- a/log-collector-script/windows/eks-log-collector.ps1
+++ b/log-collector-script/windows/eks-log-collector.ps1
@@ -26,7 +26,8 @@ param(
 
 # Common options
 $basedir="C:\log-collector"
-$instanceid = Invoke-RestMethod -uri http://169.254.169.254/latest/meta-data/instance-id
+$token = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "5"} -Method PUT -Uri http://169.254.169.254/latest/api/token
+$instanceId = Invoke-RestMethod -Headers @{"X-aws-ec2-metadata-token" = $token} -Method GET -Uri http://169.254.169.254/latest/meta-data/instance-id
 $curtime = Get-Date -Format FileDateTimeUniversal
 $outfilename = "eks_" + $instanceid + "_" + $curtime + ".zip"
 $infodir="$basedir\collect"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This change enables the `eks-log-collector.ps` script to retrieve the `instanceId` if IMDSv2 is enabled, It tries using IMDSv1 and if that fails with "Unauthorized" it tries to use IMDSv2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Tested the script on an EC2 with IMDSv1 and IMDSv2 enabled

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
