### PR TITLE
Handle indentation when parsing `sandbox_image`

### DIFF
--- a/files/pull-sandbox-image.sh
+++ b/files/pull-sandbox-image.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sandbox_image="$(awk -F'[ ="]+' '$1 == "sandbox_image" { print $2 }' /etc/containerd/config.toml)"
+source <(grep "sandbox_image" /etc/containerd/config.toml | tr -d ' ')
 
 ### Short-circuit fetching sandbox image if its already present
 if [[ "$(sudo ctr --namespace k8s.io image ls | grep $sandbox_image)" != "" ]]; then


### PR DESCRIPTION
**Issue #, if available:**

Resolves #767 

**Description of changes:**

Handles indentation on the `sandbox_image` key of the `containerd` config file. Works by just converting this line to valid bash and `source`-ing it. TOML comments are ignored because they're valid bash comments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Executed:
```
#!/usr/bin/env bash

INDENTED=$(mktemp)

echo '[plugins]
  [plugins."io.containerd.grpc.v1.cri"]
    # sandbox_image comment about the sandbox_image
    sandbox_image = "one"' >> $INDENTED

FLAT=$(mktemp)

echo '[plugins]
[plugins."io.containerd.grpc.v1.cri"]
# sandbox_image comment about the sandbox_image
sandbox_image = "two"' >> $FLAT

source <(grep "sandbox_image" $INDENTED | tr -d ' ')
echo "$sandbox_image"

source <(grep "sandbox_image" $FLAT | tr -d ' ')
echo "$sandbox_image"
```

Output:
```
one
two
```