### PR TITLE
add cached images to version-info

### DIFF
--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -18,3 +18,6 @@ sudo rpm --query --all --queryformat '\{"%{NAME}": "%{VERSION}-%{RELEASE}"\}\n' 
 # binaries
 echo $(jq ".binaries.kubelet = \"$(kubelet --version | awk '{print $2}')\"" $OUTPUT_FILE) > $OUTPUT_FILE
 echo $(jq ".binaries.awscli = \"$(aws --version | awk '{print $1}' | cut -d '/' -f 2)\"" $OUTPUT_FILE) > $OUTPUT_FILE
+
+# cached images
+echo $(jq ".images = [ $(sudo ctr -n k8s.io image ls -q | cut -d'/' -f2- | sort | uniq | grep -v 'sha256' | xargs -r printf "\"%s\"," | sed 's/,$//') ]" $OUTPUT_FILE) > $OUTPUT_FILE


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
 - Adds cachedImages to the version-info.json file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**


```
> cache_container_images=true ami_name=version-info-test make 1.24
...
cat version-info-test-version-info.json | jq .
...
  },
  "binaries": {
    "kubelet": "v1.24.7-eks-fb459a0",
    "awscli": "2.9.6"
  },
  "images": [
    "amazon-k8s-cni-init:v1.11.4",
    "amazon-k8s-cni-init:v1.11.4-eksbuild.1",
    "amazon-k8s-cni-init:v1.12.0",
    "amazon-k8s-cni-init:v1.12.0-eksbuild.1",
    "amazon-k8s-cni:v1.11.4",
    "amazon-k8s-cni:v1.11.4-eksbuild.1",
    "amazon-k8s-cni:v1.12.0",
    "amazon-k8s-cni:v1.12.0-eksbuild.1",
    "eks/kube-proxy:v1.24.7-minimal-eksbuild.2",
    "eks/pause:3.5"
  ]
}
```

```
> cache_container_images=false ami_name=version-info-test-2 make 1.24
...
cat version-info-test-2-version-info.json | jq .
...
  },
  "binaries": {
    "kubelet": "v1.24.7-eks-fb459a0",
    "awscli": "2.9.6"
  },
  "images": []
}
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
