### PR TITLE
Reflecting actual available ephemeral-storage for nodes

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -449,7 +449,7 @@ cpu_millicores_to_reserve=$(get_cpu_millicores_to_reserve)
 # writes kubeReserved and evictionHard to the kubelet-config using the amount of CPU and memory to be reserved
 echo "$(jq '. += {"evictionHard": {"memory.available": "100Mi", "nodefs.available": "10%", "nodefs.inodesFree": "5%"}}' $KUBELET_CONFIG)" > $KUBELET_CONFIG
 echo "$(jq --arg mebibytes_to_reserve "${mebibytes_to_reserve}Mi" --arg cpu_millicores_to_reserve "${cpu_millicores_to_reserve}m" \
-  '. += {kubeReserved: {"cpu": $cpu_millicores_to_reserve, "ephemeral-storage": "1Gi", "memory": $mebibytes_to_reserve}}' $KUBELET_CONFIG)" > $KUBELET_CONFIG
+  '. += {kubeReserved: {"cpu": $cpu_millicores_to_reserve, "ephemeral-storage": "3Gi", "memory": $mebibytes_to_reserve}}' $KUBELET_CONFIG)" > $KUBELET_CONFIG
 
 if [[ "$USE_MAX_PODS" = "true" ]]; then
   echo "$(jq ".maxPods=$MAX_PODS" $KUBELET_CONFIG)" > $KUBELET_CONFIG


### PR DESCRIPTION
**Description of changes:**
By default the OS+k8s components consumes at-least 2+Gi on any empty node. Having the default values of KubeReserved:ephemeral-storage set to **1Gi**, leads to disk-pressure for pods heavily relying on ephemeral storage while the allocatable presented by kubelet is not exactly same as the OS free-available disk. 

**Impact** Adjusting KubeReserved:ephemeral-storage to **3Gi**, not only provides the actual usable blocks to k8s but also helps to skip the user-data script modification out of box use case eg managed node group.  

Example: An empty worker node with 20 GB disk
```
df -hk /
Filesystem              1K-blocks     Used          Available    Use%   Mounted on
/dev/nvme0n1p1          20959212      4297520       16661692     21%    / 
```

**Testing Done** 

**Case 1 (current)**: ephemeral-storage with 1Gi  
``` 
kubectl describe ip-172-31-x-x.ec2.internal  
...
Allocatable:
...
  ephemeral-storage:            18242267924
...
```

**Case 2 (Requesting with this pull)**: ephemeral-storage with 3Gi  
``` 
kubectl describe ip-172-31-x-x.ec2.internal  
...
Allocatable:
...
  ephemeral-storage:             16094784276
...
```

**Issue #, if available:**
https://github.com/aws/containers-roadmap/issues/1847

