### PR TITLE
do not cache images that rely on addons if no addons are returned

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -393,41 +393,54 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" && "$BINARY_BUCKET_REGION" != "us-iso-
   sudo systemctl enable containerd sandbox-image
 
   K8S_MINOR_VERSION=$(echo "${KUBERNETES_VERSION}" | cut -d'.' -f1-2)
+
+  #### Cache kube-proxy images starting with the addon default version and the latest version
   KUBE_PROXY_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name kube-proxy --kubernetes-version=${K8S_MINOR_VERSION})
+  KUBE_PROXY_IMGS=()
+  if [[ $(jq '.addons | length' <<< $KUBE_PROXY_ADDON_VERSIONS) -gt 0 ]]; then
+    DEFAULT_KUBE_PROXY_FULL_VERSION=$(echo "${KUBE_PROXY_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] | select(.compatibilities[] .defaultVersion==true).addonVersion')
+    DEFAULT_KUBE_PROXY_VERSION=$(echo "${DEFAULT_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f1)
+    DEFAULT_KUBE_PROXY_PLATFORM_VERSION=$(echo "${DEFAULT_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f2)
 
-  DEFAULT_KUBE_PROXY_FULL_VERSION=$(echo "${KUBE_PROXY_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] | select(.compatibilities[] .defaultVersion==true).addonVersion')
-  DEFAULT_KUBE_PROXY_VERSION=$(echo "${DEFAULT_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f1)
-  DEFAULT_KUBE_PROXY_PLATFORM_VERSION=$(echo "${DEFAULT_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f2)
+    LATEST_KUBE_PROXY_FULL_VERSION=$(echo "${KUBE_PROXY_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] .addonVersion' | sort -V | tail -n1)
+    LATEST_KUBE_PROXY_VERSION=$(echo "${LATEST_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f1)
+    LATEST_KUBE_PROXY_PLATFORM_VERSION=$(echo "${LATEST_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f2)
 
-  LATEST_KUBE_PROXY_FULL_VERSION=$(echo "${KUBE_PROXY_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] .addonVersion' | sort -V | tail -n1)
-  LATEST_KUBE_PROXY_VERSION=$(echo "${LATEST_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f1)
-  LATEST_KUBE_PROXY_PLATFORM_VERSION=$(echo "${LATEST_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f2)
+    KUBE_PROXY_IMGS=(
+      ## Default kube-proxy images
+      "${ECR_URI}/eks/kube-proxy:${DEFAULT_KUBE_PROXY_VERSION}-${DEFAULT_KUBE_PROXY_PLATFORM_VERSION}"
+      "${ECR_URI}/eks/kube-proxy:${DEFAULT_KUBE_PROXY_VERSION}-minimal-${DEFAULT_KUBE_PROXY_PLATFORM_VERSION}"
+
+      ## Latest kube-proxy images
+      "${ECR_URI}/eks/kube-proxy:${LATEST_KUBE_PROXY_VERSION}-${LATEST_KUBE_PROXY_PLATFORM_VERSION}"
+      "${ECR_URI}/eks/kube-proxy:${LATEST_KUBE_PROXY_VERSION}-minimal-${LATEST_KUBE_PROXY_PLATFORM_VERSION}"
+    )
+  fi
 
   #### Cache VPC CNI images starting with the addon default version and the latest version
   VPC_CNI_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name vpc-cni --kubernetes-version=${K8S_MINOR_VERSION})
-  DEFAULT_VPC_CNI_VERSION=$(echo "${VPC_CNI_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] | select(.compatibilities[] .defaultVersion==true).addonVersion')
-  LATEST_VPC_CNI_VERSION=$(echo "${VPC_CNI_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] .addonVersion' | sort -V | tail -n1)
-  CNI_IMG="${ECR_URI}/amazon-k8s-cni"
-  CNI_INIT_IMG="${CNI_IMG}-init"
+  VPC_CNI_IMGS=()
+  if [[ $(jq '.addons | length' <<< $VPC_CNI_ADDON_VERSIONS) -gt 0 ]]; then
+    DEFAULT_VPC_CNI_VERSION=$(echo "${VPC_CNI_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] | select(.compatibilities[] .defaultVersion==true).addonVersion')
+    LATEST_VPC_CNI_VERSION=$(echo "${VPC_CNI_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] .addonVersion' | sort -V | tail -n1)
+    CNI_IMG="${ECR_URI}/amazon-k8s-cni"
+    CNI_INIT_IMG="${CNI_IMG}-init"
+
+    VPC_CNI_IMGS=(
+      ## Default VPC CNI Images
+      "${CNI_IMG}:${DEFAULT_VPC_CNI_VERSION}"
+      "${CNI_INIT_IMG}:${DEFAULT_VPC_CNI_VERSION}"
+
+      ## Latest VPC CNI Images
+      "${CNI_IMG}:${LATEST_VPC_CNI_VERSION}"
+      "${CNI_INIT_IMG}:${LATEST_VPC_CNI_VERSION}"
+    )
+  fi
 
   CACHE_IMGS=(
     "${PAUSE_CONTAINER}"
-
-    ## Default kube-proxy images
-    "${ECR_URI}/eks/kube-proxy:${DEFAULT_KUBE_PROXY_VERSION}-${DEFAULT_KUBE_PROXY_PLATFORM_VERSION}"
-    "${ECR_URI}/eks/kube-proxy:${DEFAULT_KUBE_PROXY_VERSION}-minimal-${DEFAULT_KUBE_PROXY_PLATFORM_VERSION}"
-
-    ## Latest kube-proxy images
-    "${ECR_URI}/eks/kube-proxy:${LATEST_KUBE_PROXY_VERSION}-${LATEST_KUBE_PROXY_PLATFORM_VERSION}"
-    "${ECR_URI}/eks/kube-proxy:${LATEST_KUBE_PROXY_VERSION}-minimal-${LATEST_KUBE_PROXY_PLATFORM_VERSION}"
-
-    ## Default VPC CNI Images
-    "${CNI_IMG}:${DEFAULT_VPC_CNI_VERSION}"
-    "${CNI_INIT_IMG}:${DEFAULT_VPC_CNI_VERSION}"
-
-    ## Latest VPC CNI Images
-    "${CNI_IMG}:${LATEST_VPC_CNI_VERSION}"
-    "${CNI_INIT_IMG}:${LATEST_VPC_CNI_VERSION}"
+    ${KUBE_PROXY_IMGS[@]+"${KUBE_PROXY_IMGS[@]}"}
+    ${VPC_CNI_IMGS[@]+"${VPC_CNI_IMGS[@]}"}
   )
   PULLED_IMGS=()
 


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
 - If the DescribeAddonVersions API returns an empty list of add-ons, then don't try to find default and latest versions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Hardcoded K8s_MINOR_VERSION=1.25 

```
  K8S_MINOR_VERSION="1.25" #$(echo "${KUBERNETES_VERSION}" | cut -d'.' -f1-2)
  KUBE_PROXY_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name kube-proxy --kubernetes-version=${K8S_MINOR_VERSION})
```
which results in 
```
> aws eks describe-addon-versions --addon-name kube-proxy --kubernetes-version=1.25
{
    "addons": []
}
```
observed only the pause container being cached but no errors:
```
2022-12-16T20:26:34-06:00:     amazon-ebs: ‘/etc/eks/containerd/containerd-cached-pause-config.toml’ -> ‘/etc/containerd/config.toml’
2022-12-16T20:26:34-06:00:     amazon-ebs: ‘/etc/eks/containerd/sandbox-image.service’ -> ‘/etc/systemd/system/sandbox-image.service’
2022-12-16T20:26:34-06:00:     amazon-ebs: Created symlink from /etc/systemd/system/multi-user.target.wants/containerd.service to /usr/lib/systemd/system/containerd.service.
2022-12-16T20:26:34-06:00:     amazon-ebs: Created symlink from /etc/systemd/system/multi-user.target.wants/sandbox-image.service to /etc/systemd/system/sandbox-image.service.
2022-12-16T20:26:37-06:00:     amazon-ebs: 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/pause:3.5:                    resolved       |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: index-sha256:529cf6b1b6e5b76e901abc43aee825badbd93f9c5ee5f1e316d46a83abbce5a2: downloading    |--------------------------------------|    0.0 B/741.0 B
2022-12-16T20:26:37-06:00:     amazon-ebs: elapsed: 0.1 s                                                                 total:   0.0 B (0.0 B/s)
2022-12-16T20:26:37-06:00:     amazon-ebs: 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/pause:3.5:                       resolved       |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: index-sha256:529cf6b1b6e5b76e901abc43aee825badbd93f9c5ee5f1e316d46a83abbce5a2:    done           |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: manifest-sha256:666eebd093e91212426aeba3b89002911d2c981fefd8806b1a0ccb4f1b639a60: downloading    |--------------------------------------|    0.0 B/526.0 B
2022-12-16T20:26:37-06:00:     amazon-ebs: elapsed: 0.2 s                                                                    total:  741.0  (3.6 KiB/s)
2022-12-16T20:26:37-06:00:     amazon-ebs: 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/pause:3.5:                       resolved       |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: index-sha256:529cf6b1b6e5b76e901abc43aee825badbd93f9c5ee5f1e316d46a83abbce5a2:    done           |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: manifest-sha256:666eebd093e91212426aeba3b89002911d2c981fefd8806b1a0ccb4f1b639a60: done           |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: layer-sha256:0692f38991d53a0c28679148f99de26a44d630fda984b41f63c5e19f839d15a6:    downloading    |++++++++++++++++++++++++++++++++++++++| 289.6 Ki/289.6 KiB
2022-12-16T20:26:37-06:00:     amazon-ebs: config-sha256:6996f8da07bd405c6f82a549ef041deda57d1d658ec20a78584f9f436c9a3bb7:   done           |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: elapsed: 0.3 s                                                                    total:  291.7  (964.1 KiB/s)
2022-12-16T20:26:37-06:00:     amazon-ebs: 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/pause:3.5:                       resolved       |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: index-sha256:529cf6b1b6e5b76e901abc43aee825badbd93f9c5ee5f1e316d46a83abbce5a2:    done           |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: manifest-sha256:666eebd093e91212426aeba3b89002911d2c981fefd8806b1a0ccb4f1b639a60: done           |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: layer-sha256:0692f38991d53a0c28679148f99de26a44d630fda984b41f63c5e19f839d15a6:    done           |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: config-sha256:6996f8da07bd405c6f82a549ef041deda57d1d658ec20a78584f9f436c9a3bb7:   done           |++++++++++++++++++++++++++++++++++++++|
2022-12-16T20:26:37-06:00:     amazon-ebs: elapsed: 0.4 s                                                                    total:  291.7  (727.1 KiB/s)
2022-12-16T20:26:37-06:00:     amazon-ebs: unpacking linux/amd64 sha256:529cf6b1b6e5b76e901abc43aee825badbd93f9c5ee5f1e316d46a83abbce5a2...
2022-12-16T20:26:38-06:00:     amazon-ebs: done: 51.179399ms
```
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
