### PR TITLE
Remove NetworkManager-cloud-setup RPM if present

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -81,8 +81,11 @@ sudo yum install -y \
 # Remove any old kernel versions. `--count=1` here means "only leave 1 kernel version installed"
 sudo package-cleanup --oldkernels --count=1 -y
 
-# Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
+# Remove the ec2-net-utils package if it is installed. This package interferes with the route setup on the instance.
 if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi
+
+# Remove the NetworkManager-cloud-setup package if it is installed. This package interferes with ip rules installed by AWS VPC CNI.
+if yum list installed | grep NetworkManager-cloud-setup; then sudo yum remove NetworkManager-cloud-setup -y -q; fi
 
 ################################################################################
 ### Time #######################################################################


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This is very similar to https://github.com/awslabs/amazon-eks-ami/pull/368 , which removed the `ec2-net-utils` package. A customer using this repo with a RHEL8 base image ran into pod networking issues caused by the presence of `NetworkManager-cloud-setup` RPM. There is a RedHat support article on this here: https://access.redhat.com/solutions/6319811

Though this only affected custom RHEL AMIs, this change is desired as we want to make sure this package never gets into EKS AMIs. Also, customers not using AL2 still depend on this repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**
Verified that yum command will not cause any issues. Customer also verified change in their environment.
