### PR TITLE
Decrease launch_block_device_mappings_volume_size to 4

### DIFF
--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -18,7 +18,7 @@
     "encrypted": "false",
     "kernel_version": "",
     "kms_key_id": "",
-    "launch_block_device_mappings_volume_size": "8",
+    "launch_block_device_mappings_volume_size": "4",
     "pause_container_version": "3.5",    
     "pull_cni_from_github": "true",
     "remote_folder": "",


### PR DESCRIPTION
**Issue #, if available:**

#1142 

**Description of changes:**

Changes the `launch_block_device_mappings_volume_size `to `4`, from `8`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.