### PR TITLE
Cache container image content without unpacking/snapshotting

### DIFF
--- a/files/pull-image.sh
+++ b/files/pull-image.sh
@@ -24,4 +24,4 @@ if [[ -z ${ecr_password} ]]; then
   echo >&2 "Unable to retrieve the ECR password."
   exit 1
 fi
-retry sudo ctr --namespace k8s.io image pull "${img}" --user AWS:${ecr_password}
+retry sudo ctr --namespace k8s.io content fetch "${img}" --user AWS:${ecr_password}


### PR DESCRIPTION
**Issue #, if available:**

Related to #1142.

**Description of changes:**

Decreases the disk space used by cached container images by avoiding the unpacking/snapshotting phase of `ctr image pull`. Relevant discussion: https://github.com/containerd/containerd/pull/7922

More info on `containerd`'s content flow: https://github.com/containerd/containerd/blob/main/docs/content-flow.md#content-areas

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

I built a 1.24 AMI with this change, launched an instance from it, and did `df -H`.
- Without image caching enabled, `2.4G` is used (for `amazon-eks-node-1.24-v20221112`).
- With this change `2.7G` was used.
- Without this change `3.7G` was used (for `amazon-eks-node-1.24-v20221222`).

This change achieves a 76.9% reduction (`1 - (2.7 - 2.4) / (3.7 - 2.4)`) in the space consumed by cached images, and should alleviate any concerns with using a 4GiB launch block device as discussed in #1142.