### PR TITLE
Skip docker installation for Kubernetes 1.25+

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -3,6 +3,7 @@
 set -o pipefail
 set -o nounset
 set -o errexit
+set -o xtrace
 IFS=$'\n\t'
 export AWS_DEFAULT_OUTPUT="json"
 
@@ -203,11 +204,12 @@ EOF
 
 sudo yum install -y device-mapper-persistent-data lvm2
 
-if [[ -z "$INSTALL_DOCKER" ]]; then
-  INSTALL_DOCKER=$(vercmp "$KUBERNETES_VERSION" lt "1.25.0")
+if [[ ! -v "INSTALL_DOCKER" ]]; then
+  INSTALL_DOCKER=$(vercmp "$KUBERNETES_VERSION" lt "1.25.0" || true)
 else
   echo "WARNING: using override INSTALL_DOCKER=${INSTALL_DOCKER}. This option is deprecated and will be removed in a future release."
 fi
+
 if [[ "$INSTALL_DOCKER" == "true" ]]; then
   sudo amazon-linux-extras enable docker
   sudo groupadd -og 1950 docker

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -203,7 +203,11 @@ EOF
 
 sudo yum install -y device-mapper-persistent-data lvm2
 
-INSTALL_DOCKER="${INSTALL_DOCKER:-true}"
+if [[ -z "$INSTALL_DOCKER" ]]; then
+  INSTALL_DOCKER=$(vercmp "$KUBERNETES_VERSION" lt "1.25.0")
+else
+  echo "WARNING: using override INSTALL_DOCKER=${INSTALL_DOCKER}. This option is deprecated and will be removed in a future release."
+fi
 if [[ "$INSTALL_DOCKER" == "true" ]]; then
   sudo amazon-linux-extras enable docker
   sudo groupadd -og 1950 docker

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -3,7 +3,6 @@
 set -o pipefail
 set -o nounset
 set -o errexit
-set -o xtrace
 IFS=$'\n\t'
 export AWS_DEFAULT_OUTPUT="json"
 


### PR DESCRIPTION
**Description of changes:**

This skips the installation of Docker by default for Kubernetes 1.25+.

If a user has set `INSTALL_DOCKER`, that value will be used regardless of the Kubernetes version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.