### PR TITLE
Add ALAS issue workflow

### DIFF
--- a/.github/workflows/alas-issues.yaml
+++ b/.github/workflows/alas-issues.yaml
@@ -9,7 +9,7 @@ on:
         required: true  
   schedule:
     # once an hour, at the top of hour
-    - cron: "0 0 * * *"
+    - cron: "0 * * * *"
 permissions:
   issues: write
 jobs:
@@ -20,7 +20,7 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           feed: "https://alas.aws.amazon.com/AL2/alas.rss"
-          dry-run: "false"
+          dry-run: "true"
           lastTime: "${{ github.event.inputs.window || '24h' }}"
           labels: "alas,alas/al2"
           titleFilter: "(medium|low)"

--- a/.github/workflows/alas-issues.yaml
+++ b/.github/workflows/alas-issues.yaml
@@ -21,6 +21,6 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           feed: "https://alas.aws.amazon.com/AL2/alas.rss"
           dry-run: "false"
-          lastTime: "${{ github.event.inputs.window }}"
+          lastTime: "${{ github.event.inputs.window || '24h' }}"
           labels: "alas,alas/al2"
           titleFilter: "(medium|low)"

--- a/.github/workflows/alas-issues.yaml
+++ b/.github/workflows/alas-issues.yaml
@@ -1,0 +1,26 @@
+---
+name: "[ALAS] Open issues for new bulletins"
+on:
+  workflow_dispatch:
+    inputs:
+      window:
+        description: "Only consider bulletins published within this relative time window (golang Duration)"
+        default: "24h"
+        required: true  
+  schedule:
+    # once an hour, at the top of hour
+    - cron: "0 * * * *"
+permissions:
+  issues: write
+jobs:
+  alas-al2-bulletins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: guilhem/rss-issues-action@0.5.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          feed: "https://alas.aws.amazon.com/AL2/alas.rss"
+          dry-run: "false"
+          lastTime: "${{ github.event.inputs.window }}"
+          labels: "alas,alas/al2"
+          titleFilter: "(medium|low)"

--- a/.github/workflows/alas-issues.yaml
+++ b/.github/workflows/alas-issues.yaml
@@ -9,7 +9,7 @@ on:
         required: true  
   schedule:
     # once an hour, at the top of hour
-    - cron: "0 * * * *"
+    - cron: "0 0 * * *"
 permissions:
   issues: write
 jobs:


### PR DESCRIPTION
**Description of changes:**

This adds a scheduled workflow to create an issue for every `Important` or `Critical` ALAS bulletin published for AL2.

This will:
1. Notify the maintainers of new bulletins via the standard GH flow.
2. Give users a consistent place to track fixes.

The Action being used currently only supports excluding a feed item based on the title or description matching a regex. I think it'd be ideal if we could only include items that are particularly relevant to our use case, like for bulletins concerning the kernel or container stack.

On the other hand, it'll be quick to close issues if they aren't relevant, and then we have a searchable history of those decisions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.