### PR TITLE
Update kubelet version and build date 2023-01-11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,19 +82,19 @@ k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 
 .PHONY: 1.21
 1.21: ## Build EKS Optimized AL2 AMI - K8s 1.21
-	$(MAKE) k8s kubernetes_version=1.21.14 kubernetes_build_date=2022-10-31 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.21.14 kubernetes_build_date=2023-01-11 pull_cni_from_github=true
 
 .PHONY: 1.22
 1.22: ## Build EKS Optimized AL2 AMI - K8s 1.22
-	$(MAKE) k8s kubernetes_version=1.22.15 kubernetes_build_date=2022-10-31 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.22.17 kubernetes_build_date=2023-01-11 pull_cni_from_github=true
 
 .PHONY: 1.23
 1.23: ## Build EKS Optimized AL2 AMI - K8s 1.23
-	$(MAKE) k8s kubernetes_version=1.23.13 kubernetes_build_date=2022-10-31 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.23.15 kubernetes_build_date=2023-01-11 pull_cni_from_github=true
 
 .PHONY: 1.24
 1.24: ## Build EKS Optimized AL2 AMI - K8s 1.24
-	$(MAKE) k8s kubernetes_version=1.24.7 kubernetes_build_date=2022-10-31 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.24.9 kubernetes_build_date=2023-01-11 pull_cni_from_github=true
 
 .PHONY: help
 help: ## Display help


### PR DESCRIPTION
update kubelet version and build date 2023-01-11 for new AMI release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
```shell
> aws s3 ls s3://amazon-eks/1.21.14/
                           PRE 2022-07-27/
                           PRE 2022-10-05/
                           PRE 2022-10-31/
                           PRE 2023-01-11/
> aws s3 ls s3://amazon-eks/1.22.17/
                           PRE 2023-01-11/
> aws s3 ls s3://amazon-eks/1.23.15/
                           PRE 2023-01-11/
> aws s3 ls s3://amazon-eks/1.24.9/
                           PRE 2023-01-11/
```
