### PR TITLE
Enable PSI

### DIFF
--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -21,4 +21,9 @@ else
   exit 1
 fi
 
+# enable pressure stall information
+sudo grubby \
+  --update-kernel=ALL \
+  --args="psi=1"
+
 sudo reboot


### PR DESCRIPTION
**Issue #, if available:**

Closes #660 

**Description of changes:**

Adds the `psi=1` flag to the kernel command line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Built a 1.24 AMI, and launched an instance. The pressure fs is mounted:
```
> cat /proc/pressure/cpu
some avg10=0.01 avg60=0.54 avg300=0.26 total=1072827

> cat /proc/pressure/memory
some avg10=0.00 avg60=0.00 avg300=0.00 total=0
full avg10=0.00 avg60=0.00 avg300=0.00 total=0

> cat /proc/pressure/io
some avg10=1.25 avg60=9.73 avg300=4.58 total=16250491
full avg10=1.24 avg60=9.20 avg300=4.26 total=15030917
```