### PR TITLE
Revert "Use external cloud provider for EKS Local deployments"

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -376,13 +376,8 @@ if [[ "${ENABLE_LOCAL_OUTPOST}" == "true" ]]; then
     mv /var/lib/kubelet/kubeconfig /var/lib/kubelet/bootstrap-kubeconfig
     KUBELET_EXTRA_ARGS="--bootstrap-kubeconfig /var/lib/kubelet/bootstrap-kubeconfig $KUBELET_EXTRA_ARGS"
   fi
-  ### For Local Outpost deployments, we will use the the external cloud provider
-  KUBELET_CLOUD_PROVIDER="external"
 else
   sed -i s,CLUSTER_NAME,$CLUSTER_NAME,g /var/lib/kubelet/kubeconfig
-
-  ### For any other type of deployment we will use the aws cloud provider for backwards compatibility
-  KUBELET_CLOUD_PROVIDER="aws"
 fi
 
 ### kubelet.service configuration
@@ -465,11 +460,6 @@ mkdir -p /etc/systemd/system/kubelet.service.d
 cat << EOF > /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf
 [Service]
 Environment='KUBELET_ARGS=--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER --v=2'
-EOF
-
-cat << EOF > /etc/systemd/system/kubelet.service.d/20-kubelet-cloud-provider.conf
-[Service]
-Environment='KUBELET_CLOUD_PROVIDER=$KUBELET_CLOUD_PROVIDER'
 EOF
 
 if [[ -n "$KUBELET_EXTRA_ARGS" ]]; then

--- a/files/kubelet-containerd.service
+++ b/files/kubelet-containerd.service
@@ -7,7 +7,7 @@ Requires=containerd.service sandbox-image.service
 [Service]
 Slice=runtime.slice
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
-ExecStart=/usr/bin/kubelet --cloud-provider $KUBELET_CLOUD_PROVIDER \
+ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime remote \

--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -6,7 +6,7 @@ Requires=docker.service
 
 [Service]
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
-ExecStart=/usr/bin/kubelet --cloud-provider $KUBELET_CLOUD_PROVIDER \
+ExecStart=/usr/bin/kubelet --cloud-provider aws \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime docker \


### PR DESCRIPTION
This reverts commit 2297119cee8466d0c4516e775cd030bcf01971bd.

**Issue #, if available:**
n/a

**Description of changes:**
This commit rolls-back support for external cloud provider for EKS Local due to issues on Local Cluster worker nodes. Nodes were able to join the cluster but commands such as `kubectl exec` and `kubectl logs` failed to execute.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

n/a

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
