### PR TITLE
Pause after kernel upgrade

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -121,7 +121,6 @@
     },
     {
       "type": "shell",
-      "pause_before": "90s",
       "remote_folder": "{{ user `remote_folder`}}",
       "inline": [
         "mkdir -p /tmp/worker/log-collector-script/"
@@ -148,6 +147,7 @@
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
       "expect_disconnect": true,
+      "pause_after": "90s",
       "script": "{{template_dir}}/scripts/upgrade_kernel.sh",
       "environment_vars": [
         "KUBERNETES_VERSION={{user `kubernetes_version`}}",


### PR DESCRIPTION
**Description of changes:**

Fixes a race condition introduced by #1118; the `upgrade-kernel.sh` provisioner was moved *after* the `install-additional-yum-repos.sh` provisioner, which had a `pause_before` directive that gave the instance time to reboot after the kernel was upgraded. The pause was no longer having the intended effect, leading to intermittent issues in which the instance would reboot during the `install-worker.sh` provisioner.

This moves the directive to the `upgrade-kernel.sh` provisioner as a more explicit `pause_after`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

`make 1.24` succeeds consistently.