### PR TITLE
Exclude docker from 1.25+ AMI metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@ K8S_VERSION_MINOR := $(word 1,${K8S_VERSION_PARTS}).$(word 2,${K8S_VERSION_PARTS
 
 MAKEFILE_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+# Docker is not present on 1.25+ AMI's
+ifeq ($(shell $(MAKEFILE_DIR)/files/bin/vercmp "$(kubernetes_version)" gteq "1.25.0"), true)
+# do not tag the AMI with the Docker version
+docker_version ?= none
+# do not include the Docker version in the AMI description
+ami_component_description ?= (k8s: {{ user `kubernetes_version` }}, containerd: {{ user `containerd_version` }})
+endif
+
 arch ?= x86_64
 ifeq ($(arch), arm64)
 instance_type ?= m6g.large

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -1,5 +1,6 @@
 {
     "additional_yum_repos": "",
+    "ami_component_description": "(k8s: {{ user `kubernetes_version` }}, docker: {{ user `docker_version` }}, containerd: {{ user `containerd_version` }})",
     "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image",
     "ami_regions": "",
     "ami_users": "",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -2,6 +2,7 @@
   "_comment": "All template variables are enumerated here; and most variables have a default value defined in eks-worker-al2-variables.json",
   "variables": {
     "additional_yum_repos": null,
+    "ami_component_description": null,    
     "ami_description": null,
     "ami_name": null,
     "ami_regions": null,
@@ -107,7 +108,7 @@
         "cni_plugin_version": "{{ user `cni_plugin_version`}}"
       },
       "ami_name": "{{user `ami_name`}}",
-      "ami_description": "{{ user `ami_description` }}, (k8s: {{ user `kubernetes_version` }}, docker: {{ user `docker_version` }}, containerd: {{ user `containerd_version` }})"
+      "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}"
     }
   ],
   "provisioners": [


### PR DESCRIPTION
**Description of changes:**

Docker isn't installed for 1.25+; this removes the Docker version from the AMI description and sets the `docker_version` AMI tag to `none` (I couldn't find a reasonable way to conditionally exclude this tag).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

With #1173 , `make 1.25` succeeds and the description does not include the `docker` bit, and the `docker_version` tag is set to `none`.