### PR TITLE
Allow any KERNEL_VERSION

### DIFF
--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -15,13 +15,8 @@ fi
 
 if [[ $KERNEL_VERSION == "4.14" ]]; then
   sudo yum update -y kernel
-elif [[ $KERNEL_VERSION == "5.4" ]]; then
-  sudo amazon-linux-extras install -y kernel-5.4
-elif [[ $KERNEL_VERSION == "5.10" ]]; then
-  sudo amazon-linux-extras install -y kernel-5.10
 else
-  echo "$KERNEL_VERSION is not a valid kernel version"
-  exit 1
+  sudo amazon-linux-extras install -y "kernel-${KERNEL_VERSION}"
 fi
 
 # enable pressure stall information


### PR DESCRIPTION
**Description of changes:**

This removes our validation on the `kernel_version` template variable, which will allow custom AMI builders to use the 5.15 kernel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Succeeds:
```
make 1.25 kernel_version=5.15
```