### PR TITLE
bootstrap: provide option to store image and container data on instance store

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -64,7 +64,9 @@ sudo yum install -y \
   ec2-instance-connect \
   ipvsadm \
   jq \
+  mdadm \
   nfs-utils \
+  nvme-cli \
   socat \
   unzip \
   wget \


### PR DESCRIPTION
**Description of changes:**

This PR adds an `--enable-instance-store` option to to the bootstrap script. 

If and only if it is set to `true` (`--enable-instance-store true`), before taking any other actions, the bootstrap script will create an ext4 filesystem on top of the available instance storage volumes. If more than one instance store volume exists, a RAID 0 volume will be created first before building the filesystem. The filesystem will be mounted at `/mnt/instance_store`. Then all data from `/var/lib/{docker,containerd,kubelet/`  will be relocated into the filesystem. Finally, a `bind` mount will be created to alias the original directories to the files on the instance store volume.

The benefit of this option is to significantly improve the latency and throughput of image unpacking and container volume access. Instance store volumes are backed by fast NVMe local storage and are orders of magnitude faster than EBS volumes.

This option can safely be used on EC2 instances that do not have instance storage, although it will not be effective and will report a notice to this effect.

This option currently only works on EC2 Nitro instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Testing was performed on both c6g.large and c6gd.large instance types, using a set of managed EKS nodegroups. The override-bootstrap command was set to:

```
#!/bin/bash
/etc/eks/bootstrap.sh mycluster --enable-instance-store true
```
