### PR TITLE
Version lock kernel

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -73,8 +73,6 @@ sudo yum install -y \
 # Remove any old kernel versions. `--count=1` here means "only leave 1 kernel version installed"
 sudo package-cleanup --oldkernels --count=1 -y
 
-sudo yum versionlock kernel
-
 # Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
 if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi
 

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -68,7 +68,6 @@ sudo yum install -y \
   socat \
   unzip \
   wget \
-  yum-plugin-versionlock \
   yum-utils
 
 # Remove any old kernel versions. `--count=1` here means "only leave 1 kernel version installed"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -74,6 +74,8 @@ sudo yum install -y \
 # Remove any old kernel versions. `--count=1` here means "only leave 1 kernel version installed"
 sudo package-cleanup --oldkernels --count=1 -y
 
+sudo yum versionlock kernel
+
 # Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
 if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi
 

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -24,4 +24,7 @@ sudo grubby \
   --update-kernel=ALL \
   --args="psi=1"
 
+sudo yum install -y yum-plugin-versionlock
+sudo yum versionlock kernel
+
 sudo reboot


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
As we introduced version lock for kernel header/devel for GPU AMI, to prevent compatibility issue from upgrading kernel, we also version locking the kernel

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

`make 1.25`

```
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs: AMIs were created:
us-west-2: ami-045b361401eb3adf1
```
