### PR TITLE
Add Action to generate eni-max-pods.txt

### DIFF
--- a/sync-eni-max-pods.yaml
+++ b/sync-eni-max-pods.yaml
@@ -1,0 +1,40 @@
+name: '[Sync] Update eni-max-pods.txt'
+on:
+  workflow_dispatch:
+  schedule:
+    # once a day
+    - cron: '0 0 * * *'
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+jobs:
+  update-max-pods:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+      - uses: actions/checkout@v3
+        with:
+          repository: awslabs/amazon-eks-ami
+          ref: refs/heads/master
+          path: amazon-eks-ami/
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/amazon-vpc-cni-k8s
+          ref: refs/heads/master
+          path: amazon-vpc-cni-k8s/
+      - run: |
+          #!/usr/bin/env bash
+          set -o errexit
+          cd amazon-vpc-cni-k8s/
+          make generate-limits
+          cp misc/eni-max-pods.txt ../amazon-eks-ami/files/eni-max-pods.txt
+      - uses: peter-evans/create-pull-request@v4
+        with:
+            commit-message: "Update eni-max-pods.txt"
+            branch: update-eni-max-pods
+            path: amazon-eks-ami/
+            add-paths: files/eni-max-pods.txt


### PR DESCRIPTION
**Description of changes:**

This adds an Action that will generate `files/eni-max-pods.txt` once a day, and open a pull-request if the contents of the file change. This Action can also be triggered manually.