### PR TITLE
Version lock kernel after removing old kernels

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -68,10 +68,13 @@ sudo yum install -y \
   socat \
   unzip \
   wget \
-  yum-utils
+  yum-utils \
+  yum-plugin-versionlock
 
 # Remove any old kernel versions. `--count=1` here means "only leave 1 kernel version installed"
 sudo package-cleanup --oldkernels --count=1 -y
+
+sudo yum versionlock kernel-$(uname -r)
 
 # Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
 if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -24,7 +24,4 @@ sudo grubby \
   --update-kernel=ALL \
   --args="psi=1"
 
-sudo yum install -y yum-plugin-versionlock
-sudo yum versionlock kernel
-
 sudo reboot


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This fixes an issue with multiple version locks on the `kernel` package, which may result in unexpected behavior when installing/updating this package.

This PR moves the version lock *after* old kernel packages have been removed, as well as explicitly locks the running kernel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Before this change, a version lock was present for both 4.14 and 5.4 versions of the kernel:
```
> yum versionlock list
Loaded plugins: priorities, update-motd, versionlock
0:kernel-4.14.301-224.520.amzn2.*
0:kernel-5.4.228-132.418.amzn2.*
0:runc-1.1.4-1.amzn2.*
0:containerd-1.6.6-1.amzn2.0.2.*
0:docker-20.10.17-1.amzn2.0.1.*
versionlock list done
```

The version lock on the 4.14 kernel is removed after this change.

```
> yum versionlock list
Loaded plugins: priorities, update-motd, versionlock
0:kernel-5.4.228-132.418.amzn2.*
0:runc-1.1.4-1.amzn2.*
0:containerd-1.6.6-1.amzn2.0.2.*
0:docker-20.10.17-1.amzn2.0.1.*
versionlock list done
```