### PR TITLE
Validate versionlocks

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -46,7 +46,7 @@ else
 fi
 
 echo "Verifying that the package versionlocks are correct..."
-  
+
 function versionlock-entries() {
   # the format of this output is EPOCH:NAME-VERSION-RELEASE.ARCH
   # more info in yum-versionlock(1)
@@ -55,7 +55,7 @@ function versionlock-entries() {
 }
 
 function versionlock-packages() {
-  versionlock-entries | xargs -I '{}' rpm --query  '{}' --queryformat '%{NAME}\n'
+  versionlock-entries | xargs -I '{}' rpm --query '{}' --queryformat '%{NAME}\n'
 }
 
 for ENTRY in $(versionlock-entries); do

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -36,11 +36,30 @@ validate_file_nonexists '/var/log/secure'
 validate_file_nonexists '/var/log/wtmp'
 
 actual_kernel=$(uname -r)
-echo "Verifying that kernel version $actual_kernel matches $KERNEL_VERSION"
+echo "Verifying that kernel version $actual_kernel matches $KERNEL_VERSION..."
 
 if [[ $actual_kernel == $KERNEL_VERSION* ]]; then
-  echo "Kernel matches expected version"
+  echo "Kernel matches expected version!"
 else
-  echo "Kernel does not match expected version."
+  echo "Kernel does not match expected version!"
   exit 1
 fi
+
+echo "Verifying that the kernel has the correct versionlock..."
+
+# only one version of the kernel should be version locked
+if [ $(yum versionlock list --quiet | grep -c "kernel") -ne 1 ]; then
+  echo "More than one version of the kernel has a versionlock!"
+  yum versionlock list
+  exit 1
+fi
+
+# the current version of the kernel should be version locked
+if [ $(yum versionlock list --quiet | grep -c "kernel-$KERNEL_VERSION") -ne 1 ]; then
+  echo "The current version of the kernel does not have a versionlock!"
+  yum versionlock list
+  exit 1
+fi
+
+echo "Kernel has the correct versionlock!"
+

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -45,20 +45,29 @@ else
   exit 1
 fi
 
-echo "Verifying that the kernel has the correct versionlock..."
+echo "Verifying that the package versionlocks are correct..."
+  
+function versionlock-entries() {
+  # the format of this output is EPOCH:NAME-VERSION-RELEASE.ARCH
+  # more info in yum-versionlock(1)
+  # rpm doesn't accept EPOCH when querying the db, so remove it
+  yum versionlock list --quiet | cut -d ':' -f2
+}
 
-# only one version of the kernel should be version locked
-if [ $(yum versionlock list --quiet | grep -c "kernel") -ne 1 ]; then
-  echo "More than one version of the kernel has a versionlock!"
-  yum versionlock list
-  exit 1
+function versionlock-packages() {
+  versionlock-entries | xargs -I '{}' rpm --query  '{}' --queryformat '%{NAME}\n'
+}
+
+for ENTRY in $(versionlock-entries); do
+  if ! rpm --query "$ENTRY" &> /dev/null; then
+    echo "There is no package matching the versionlock entry: '$ENTRY'"
+    exit 1
+  fi
+done
+
+LOCKED_PACKAGES=$(versionlock-packages | wc -l)
+UNIQUE_LOCKED_PACKAGES=$(versionlock-packages | sort -u | wc -l)
+if [ $LOCKED_PACKAGES -ne $UNIQUE_LOCKED_PACKAGES ]; then
+  echo "Package(s) have multiple version locks!"
+  versionlock-entries
 fi
-
-# the current version of the kernel should be version locked
-if [ $(yum versionlock list --quiet | grep -c "kernel-$KERNEL_VERSION") -ne 1 ]; then
-  echo "The current version of the kernel does not have a versionlock!"
-  yum versionlock list
-  exit 1
-fi
-
-echo "Kernel has the correct versionlock!"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -71,3 +71,5 @@ if [ $LOCKED_PACKAGES -ne $UNIQUE_LOCKED_PACKAGES ]; then
   echo "Package(s) have multiple version locks!"
   versionlock-entries
 fi
+
+echo "Package versionlocks are correct!"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -62,4 +62,3 @@ if [ $(yum versionlock list --quiet | grep -c "kernel-$KERNEL_VERSION") -ne 1 ];
 fi
 
 echo "Kernel has the correct versionlock!"
-


### PR DESCRIPTION
**Issue #, if available:**

#1193 

**Description of changes:**

Adds some validation on kernel versionlocks, since multiple locks can lead to unexpected behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Succeeds:
```
> make 1.25
...
2023-03-06T13:02:56-08:00: ==> amazon-ebs: Provisioning with shell script: awslabs/amazon-eks-ami/scripts/validate.sh
2023-03-06T13:02:57-08:00:     amazon-ebs: Verifying that kernel version 5.10.167-147.601.amzn2.x86_64 matches ...
2023-03-06T13:02:57-08:00:     amazon-ebs: Kernel matches expected version!
2023-03-06T13:02:57-08:00:     amazon-ebs: Verifying that the package versionlocks are correct...
2023-03-06T13:02:57-08:00:     amazon-ebs: Package versionlocks are correct!
```

Fails (as expected):
```
> git checkout 8b10a76977278e7afec85b51c326d17392565fd6
> curl -L https://github.com/awslabs/amazon-eks-ami/pull/1195.patch | git apply
> make 1.24
...
2023-03-06T13:28:35-08:00: ==> amazon-ebs: Provisioning with shell script: awslabs/amazon-eks-ami/scripts/validate.sh
2023-03-06T13:28:35-08:00:     amazon-ebs: Verifying that kernel version 5.10.167-147.601.amzn2.x86_64 matches ...
2023-03-06T13:28:35-08:00:     amazon-ebs: Kernel matches expected version!
2023-03-06T13:28:35-08:00:     amazon-ebs: Verifying that the package versionlocks are correct...
2023-03-06T13:28:36-08:00:     amazon-ebs: There is no package matching the versionlock entry: 'kernel-4.14.305-227.531.amzn2.*'
2023-03-06T13:28:36-08:00: ==> amazon-ebs: Provisioning step had errors: Running the cleanup provisioner, if present...

```