### PR TITLE
Use gp3 volume_type for 1.27+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,14 @@ vercmp = $(shell $(MAKEFILE_DIR)/files/bin/vercmp "$1" "$2" "$3")
 # gp2 volumes are used by default prior to 1.26
 # TODO: remove this when 1.25 reaches EOL
 ifeq ($(call packer_variable_file_contains,volume_type), false)
-	ifeq ($(call vercmp, $(kubernetes_version), lt, 1.26.0), true)
+	ifeq ($(call vercmp,$(kubernetes_version),lt,1.26.0), true)
 		volume_type ?= gp2
 	endif
 endif
 
 # Docker is not present on 1.25+ AMI's
 # TODO: remove this when 1.24 reaches EOL
-ifeq ($(call vercmp, $(kubernetes_version), gteq, 1.25.0), true)
+ifeq ($(call vercmp,$(kubernetes_version),gteq,1.25.0), true)
 	# do not tag the AMI with the Docker version
 	docker_version ?= none
 	# do not include the Docker version in the AMI description

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ packer_variable_file_contains = $(if $(PACKER_VARIABLE_FILE),$(shell grep -Fq $1
 
 vercmp = $(shell $(MAKEFILE_DIR)/files/bin/vercmp "$1" "$2" "$3")
 
-# gp2 volumes are used by default prior to 1.26
+# gp3 volumes are used by default for 1.26+
 # TODO: remove this when 1.25 reaches EOL
 ifeq ($(call packer_variable_file_contains,volume_type), false)
-	ifeq ($(call vercmp,$(kubernetes_version),lt,1.26.0), true)
-		volume_type ?= gp2
+	ifeq ($(call vercmp,$(kubernetes_version),gteq,1.26.0), true)
+		volume_type ?= gp3
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,22 @@ MAKEFILE_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 # otherwise, expands to 'false'
 packer_variable_file_contains = $(if $(PACKER_VARIABLE_FILE),$(shell grep -Fq $1 $(PACKER_VARIABLE_FILE) && echo true || echo false),false)
 
+# expands to 'true' if the version comparison is affirmative
+# otherwise expands to 'false'
 vercmp = $(shell $(MAKEFILE_DIR)/files/bin/vercmp "$1" "$2" "$3")
 
+# expands to 'true' if the 'aws_region' contains 'us-iso' (an isolated region)
+# otherwise, expands to 'false'
 in_iso_region = $(if $(findstring us-iso,$(aws_region)),true,false)
 
-# gp3 volumes are used by default for 1.26+
-# TODO: remove this when 1.25 reaches EOL
-ifeq ($(call packer_variable_file_contains,volume_type), false)
-	ifeq ($(call vercmp,$(kubernetes_version),gteq,1.26.0), true)
-		ifeq ($(call in_iso_region),false)
-			volume_type ?= gp3
-		endif
+# gp3 volumes are used by default for 1.27+
+# TODO: remove when 1.26 reaches EOL
+# TODO: remove when gp3 is supported in isolated regions
+ifneq ($(call packer_variable_file_contains,volume_type), true)
+	ifeq ($(call in_iso_region), true)
+		volume_type ?= gp2
+	else ifeq ($(call vercmp,$(kubernetes_version),lt,1.27.0), true)
+		volume_type ?= gp2
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,15 @@ packer_variable_file_contains = $(if $(PACKER_VARIABLE_FILE),$(shell grep -Fq $1
 
 vercmp = $(shell $(MAKEFILE_DIR)/files/bin/vercmp "$1" "$2" "$3")
 
+in_iso_region = $(if $(findstring us-iso,$(aws_region)),true,false)
+
 # gp3 volumes are used by default for 1.26+
 # TODO: remove this when 1.25 reaches EOL
 ifeq ($(call packer_variable_file_contains,volume_type), false)
 	ifeq ($(call vercmp,$(kubernetes_version),gteq,1.26.0), true)
-		volume_type ?= gp3
+		ifeq ($(call in_iso_region),false)
+			volume_type ?= gp3
+		endif
 	endif
 endif
 

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -33,5 +33,5 @@
     "ssh_username": "ec2-user",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
-    "volume_type": "gp3"
+    "volume_type": "gp2"
 }

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -33,5 +33,5 @@
     "ssh_username": "ec2-user",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
-    "volume_type": "gp2"
+    "volume_type": "gp3"
 }


### PR DESCRIPTION
**Issue #, if available:**

Closes #626.

**Description of changes:**

Changes the `volume_type` to `gp3` for Kubernetes 1.27+, if the user has not specified a `volume_type` either in their `PACKER_VARIABLE_FILE` or as an argument to `make`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Succeeds and the resulting AMI is `gp2`:
```
make 1.25
```

TODO:
```
make 1.27
```