### PR TITLE
Updating install worker script to accept a user defined directory whe…

### DIFF
--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -34,5 +34,5 @@
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
     "volume_type": "gp2",
-    "awscli_dir": "/tmp/worker/aws_install"
+    "working_dir": "/tmp/worker/install"
 }

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -33,5 +33,6 @@
     "ssh_username": "ec2-user",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
-    "volume_type": "gp2"
+    "volume_type": "gp2",
+    "awscli_dir": "/tmp/worker/aws_install"
 }

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -40,7 +40,8 @@
     "ssh_username": null,
     "subnet_id": null,
     "temporary_security_group_source_cidrs": null,
-    "volume_type": null
+    "volume_type": null,
+    "awscli_dir": null
   },
   "builders": [
     {
@@ -174,13 +175,17 @@
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
         "SONOBUOY_E2E_REGISTRY={{user `sonobuoy_e2e_registry`}}",
         "PAUSE_CONTAINER_VERSION={{user `pause_container_version`}}",
-        "CACHE_CONTAINER_IMAGES={{user `cache_container_images`}}"
+        "CACHE_CONTAINER_IMAGES={{user `cache_container_images`}}",
+        "AWSCLI_DIR={{user `awscli_dir`}}"
       ]
     },
     {
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
-      "script": "{{template_dir}}/scripts/cleanup.sh"
+      "script": "{{template_dir}}/scripts/cleanup.sh",
+      "environment_vars": [
+        "AWSCLI_DIR={{user `awscli_dir`}}"
+      ]
     },
     {
       "type": "shell",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -41,7 +41,7 @@
     "subnet_id": null,
     "temporary_security_group_source_cidrs": null,
     "volume_type": null,
-    "awscli_dir": null
+    "working_dir": null
   },
   "builders": [
     {
@@ -176,7 +176,7 @@
         "SONOBUOY_E2E_REGISTRY={{user `sonobuoy_e2e_registry`}}",
         "PAUSE_CONTAINER_VERSION={{user `pause_container_version`}}",
         "CACHE_CONTAINER_IMAGES={{user `cache_container_images`}}",
-        "AWSCLI_DIR={{user `awscli_dir`}}"
+        "WORKING_DIR={{user `working_dir`}}"
       ]
     },
     {
@@ -184,7 +184,7 @@
       "remote_folder": "{{ user `remote_folder`}}",
       "script": "{{template_dir}}/scripts/cleanup.sh",
       "environment_vars": [
-        "AWSCLI_DIR={{user `awscli_dir`}}"
+        "WORKING_DIR={{user `working_dir`}}"
       ]
     },
     {

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -6,8 +6,8 @@ sudo rm -rf /var/cache/yum
 
 # Clean up build artifacts
 sudo rm -rf /tmp/worker
-if [[ $AWSCLI_DIR != /tmp* ]]; then
-  sudo rm -rf $AWSCLI_DIR
+if [[ $WORKING_DIR != /tmp* ]]; then
+  sudo rm -rf $WORKING_DIR
 fi
 
 # Clean up files to reduce confusion during debug

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -6,6 +6,9 @@ sudo rm -rf /var/cache/yum
 
 # Clean up build artifacts
 sudo rm -rf /tmp/worker
+if [[ $AWSCLI_DIR != /tmp* ]]; then
+    sudo rm -rf $AWSCLI_DIR
+fi
 
 # Clean up files to reduce confusion during debug
 sudo rm -rf \

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -7,7 +7,7 @@ sudo rm -rf /var/cache/yum
 # Clean up build artifacts
 sudo rm -rf /tmp/worker
 if [[ $AWSCLI_DIR != /tmp* ]]; then
-    sudo rm -rf $AWSCLI_DIR
+  sudo rm -rf $AWSCLI_DIR
 fi
 
 # Clean up files to reduce confusion during debug

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -122,15 +122,25 @@ sudo mv $TEMPLATE_DIR/iptables-restore.service /etc/eks/iptables-restore.service
 if [[ "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "us-isob-east-1" ]]; then
   # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
   echo "Installing awscli v2 bundle"
-  AWSCLI_DIR=$(mktemp -d)
-  curl \
-    --silent \
+  AWSCLI_DIR="${AWSCLI_DIR:-""}"
+  if [[ -n $AWSCLI_DIR ]]; then
+    AWSCLI_DIR=$AWSCLI_DIR
+    sudo mkdir -p $AWSCLI_DIR
+  else
+    AWSCLI_DIR=$(mktemp -d)
+  fi
+  sudo curl \
     --show-error \
     --retry 10 \
     --retry-delay 1 \
     -L "https://awscli.amazonaws.com/awscli-exe-linux-${MACHINE}.zip" -o "${AWSCLI_DIR}/awscliv2.zip"
-  unzip -q "${AWSCLI_DIR}/awscliv2.zip" -d ${AWSCLI_DIR}
-  sudo "${AWSCLI_DIR}/aws/install" --bin-dir /bin/
+  sudo unzip -q "${AWSCLI_DIR}/awscliv2.zip" -d ${AWSCLI_DIR}
+  sudo "${AWSCLI_DIR}/aws/install" --bin-dir /bin --update
+
+  if [[ -n $AWSCLI_DIR ]]; then
+    sudo rm -rf $AWSCLI_DIR
+  fi
+
 else
   echo "Installing awscli package"
   sudo yum install -y awscli

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -33,6 +33,7 @@ validate_env_set KUBERNETES_BUILD_DATE
 validate_env_set PULL_CNI_FROM_GITHUB
 validate_env_set PAUSE_CONTAINER_VERSION
 validate_env_set CACHE_CONTAINER_IMAGES
+validate_env_set AWSCLI_DIR
 
 ################################################################################
 ### Machine Architecture #######################################################
@@ -122,13 +123,7 @@ sudo mv $TEMPLATE_DIR/iptables-restore.service /etc/eks/iptables-restore.service
 if [[ "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "us-isob-east-1" ]]; then
   # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
   echo "Installing awscli v2 bundle"
-  AWSCLI_DIR="${AWSCLI_DIR:-""}"
-  if [[ -n $AWSCLI_DIR ]]; then
-    AWSCLI_DIR=$AWSCLI_DIR
-    sudo mkdir -p $AWSCLI_DIR
-  else
-    AWSCLI_DIR=$(mktemp -d)
-  fi
+  sudo mkdir -p $AWSCLI_DIR
   sudo curl \
     --show-error \
     --retry 10 \
@@ -136,11 +131,6 @@ if [[ "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "
     -L "https://awscli.amazonaws.com/awscli-exe-linux-${MACHINE}.zip" -o "${AWSCLI_DIR}/awscliv2.zip"
   sudo unzip -q "${AWSCLI_DIR}/awscliv2.zip" -d ${AWSCLI_DIR}
   sudo "${AWSCLI_DIR}/aws/install" --bin-dir /bin --update
-
-  if [[ -n $AWSCLI_DIR ]]; then
-    sudo rm -rf $AWSCLI_DIR
-  fi
-
 else
   echo "Installing awscli package"
   sudo yum install -y awscli

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -33,7 +33,13 @@ validate_env_set KUBERNETES_BUILD_DATE
 validate_env_set PULL_CNI_FROM_GITHUB
 validate_env_set PAUSE_CONTAINER_VERSION
 validate_env_set CACHE_CONTAINER_IMAGES
-validate_env_set AWSCLI_DIR
+validate_env_set WORKING_DIR
+
+################################################################################
+### Bootstrap actions ##########################################################
+################################################################################
+
+sudo mkdir -p $WORKING_DIR
 
 ################################################################################
 ### Machine Architecture #######################################################
@@ -123,14 +129,13 @@ sudo mv $TEMPLATE_DIR/iptables-restore.service /etc/eks/iptables-restore.service
 if [[ "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "us-isob-east-1" ]]; then
   # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
   echo "Installing awscli v2 bundle"
-  sudo mkdir -p $AWSCLI_DIR
   sudo curl \
     --show-error \
     --retry 10 \
     --retry-delay 1 \
-    -L "https://awscli.amazonaws.com/awscli-exe-linux-${MACHINE}.zip" -o "${AWSCLI_DIR}/awscliv2.zip"
-  sudo unzip -q "${AWSCLI_DIR}/awscliv2.zip" -d ${AWSCLI_DIR}
-  sudo "${AWSCLI_DIR}/aws/install" --bin-dir /bin --update
+    -L "https://awscli.amazonaws.com/awscli-exe-linux-${MACHINE}.zip" -o "${WORKING_DIR}/awscliv2.zip"
+  sudo unzip -q "${WORKING_DIR}/awscliv2.zip" -d ${WORKING_DIR}
+  sudo "${WORKING_DIR}/aws/install" --bin-dir /bin --update
 else
   echo "Installing awscli package"
   sudo yum install -y awscli


### PR DESCRIPTION
…re the aws install can take place.

**Issue #, if available:**
[#1164](https://github.com/awslabs/amazon-eks-ami/issues/1164)

**Description of changes:**

I've updated the install-worker script to enable users to specify where the aws install takes place. The default behavior has been left unaltered. This allows us to install aws v2 without using a tmp directory. Our base AMI is CIS hardened and doesn't allow executables with in tmpfs.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

I've verified that the AMI still builds and I've tested it in our dev environment.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
