### PR TITLE
Use --cloud-provider=external on 1.26+

### DIFF
--- a/files/bin/imds
+++ b/files/bin/imds
@@ -41,7 +41,7 @@ function imdscurl() {
     "$@" || echo "1")
   # CODE will be either the HTTP status code, or 1 if the exit code of `curl` is non-zero
   if [[ ${CODE} -lt 200 || ${CODE} -gt 299 ]]; then
-    >&2 cat $OUTPUT_FILE
+    cat >&2 $OUTPUT_FILE
     return $CODE
   fi
   printf "$(cat $OUTPUT_FILE)\n"

--- a/files/bin/imds
+++ b/files/bin/imds
@@ -4,13 +4,6 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-IMDS_DEBUG="${IMDS_DEBUG:-false}"
-function log() {
-  if [ "$IMDS_DEBUG" = "true" ]; then
-    echo >&2 "$1"
-  fi
-}
-
 if [ "$#" -ne 1 ]; then
   echo >&2 "usage: imds API_PATH"
   exit 1
@@ -21,57 +14,79 @@ API_PATH="${1#/}"
 
 CURRENT_TIME=$(date '+%s')
 
+IMDS_DEBUG="${IMDS_DEBUG:-false}"
+# default ttl is 15 minutes
+IMDS_TOKEN_TTL_SECONDS=${IMDS_TOKEN_TTL_SECONDS:-900}
+# max ttl is 6 hours, see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
+IMDS_MAX_TOKEN_TTL_SECONDS=${IMDS_MAX_TOKEN_TTL_SECONDS:-21600}
+IMDS_RETRIES=${IMDS_RETRIES:-10}
+IMDS_RETRY_DELAY_SECONDS=${IMDS_RETRY_DELAY_SECONDS:-1}
 IMDS_ENDPOINT=${IMDS_ENDPOINT:-169.254.169.254}
+
+function log() {
+  if [ "$IMDS_DEBUG" = "true" ]; then
+    echo >&2 "$1"
+  fi
+}
+
+function imdscurl() {
+  local OUTPUT_FILE=$(mktemp)
+  local CODE=$(curl \
+    --silent \
+    --show-error \
+    --output $OUTPUT_FILE \
+    --write-out "%{http_code}" \
+    --retry $IMDS_RETRIES \
+    --retry-delay $IMDS_RETRY_DELAY_SECONDS \
+    "$@" || echo "1")
+  # CODE will be either the HTTP status code, or 1 if the exit code of `curl` is non-zero
+  if [[ ${CODE} -lt 200 || ${CODE} -gt 299 ]]; then
+    >&2 cat $OUTPUT_FILE
+    return $CODE
+  fi
+  printf "$(cat $OUTPUT_FILE)\n"
+  rm $OUTPUT_FILE
+}
+
+function get-token() {
+  local TOKEN_DIR=/tmp/imds-tokens
+  mkdir -p $TOKEN_DIR
+
+  # cleanup expired tokens
+  local DELETED_TOKENS=0
+  for TOKEN_FILE in $(ls $TOKEN_DIR | awk '$0 < '$(($CURRENT_TIME - $IMDS_MAX_TOKEN_TTL_SECONDS))); do
+    rm $TOKEN_DIR/$TOKEN_FILE
+    DELETED_TOKENS=$(($DELETED_TOKENS + 1))
+  done
+  if [ "$DELETED_TOKENS" -gt 0 ]; then
+    log "🗑️ Deleted $DELETED_TOKENS expired IMDS token(s)."
+  fi
+
+  local TOKEN_FILE=$(ls $TOKEN_DIR | awk '$0 > '$CURRENT_TIME | sort -n -r | head -n 1)
+
+  if [ "$TOKEN_FILE" = "" ]; then
+    TOKEN_FILE=$(($CURRENT_TIME + $IMDS_TOKEN_TTL_SECONDS))
+    local TOKEN=$(imdscurl \
+      -H "X-aws-ec2-metadata-token-ttl-seconds: $IMDS_TOKEN_TTL_SECONDS" \
+      -X PUT \
+      "http://$IMDS_ENDPOINT/latest/api/token")
+    echo "$TOKEN" > "$TOKEN_DIR/$TOKEN_FILE"
+    # make sure any user can utilize (and clean up) these tokens
+    chmod a+rwx $TOKEN_DIR/$TOKEN_FILE
+    log "🔑 Retrieved a fresh IMDS token that will expire in $IMDS_TOKEN_TTL_SECONDS seconds."
+  else
+    log "ℹ️ Using cached IMDS token that expires in $(($TOKEN_FILE - $CURRENT_TIME)) seconds."
+  fi
+  cat "$TOKEN_DIR/$TOKEN_FILE"
+}
+
+function get-with-token() {
+  local API_PATH="$1"
+  imdscurl \
+    -H "X-aws-ec2-metadata-token: $(get-token)" \
+    "http://$IMDS_ENDPOINT/$API_PATH"
+}
 
 log "ℹ️ Talking to IMDS at $IMDS_ENDPOINT"
 
-TOKEN_DIR=/tmp/imds-tokens
-mkdir -p $TOKEN_DIR
-
-IMDS_RETRIES=${IMDS_RETRIES:-10}
-IMDS_RETRY_DELAY_SECONDS=${IMDS_RETRY_DELAY_SECONDS:-1}
-
-# default ttl is 15 minutes
-IMDS_TOKEN_TTL_SECONDS=${IMDS_TOKEN_TTL_SECONDS:-900}
-
-# max ttl is 6 hours, see: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
-IMDS_MAX_TOKEN_TTL_SECONDS=${IMDS_MAX_TOKEN_TTL_SECONDS:-21600}
-
-# cleanup expired tokens
-DELETED_TOKENS=0
-for TOKEN_FILE in $(ls $TOKEN_DIR | awk '$0 < '$(($CURRENT_TIME - $IMDS_MAX_TOKEN_TTL_SECONDS))); do
-  rm $TOKEN_DIR/$TOKEN_FILE
-  DELETED_TOKENS=$(($DELETED_TOKENS + 1))
-done
-if [ "$DELETED_TOKENS" -gt 0 ]; then
-  log "🗑️ Deleted $DELETED_TOKENS expired IMDS token(s)."
-fi
-
-TOKEN_FILE=$(ls $TOKEN_DIR | awk '$0 > '$CURRENT_TIME | sort -n -r | head -n 1)
-
-if [ "$TOKEN_FILE" = "" ]; then
-  TOKEN_FILE=$(($CURRENT_TIME + $IMDS_TOKEN_TTL_SECONDS))
-  curl \
-    --silent \
-    --show-error \
-    --retry $IMDS_RETRIES \
-    --retry-delay $IMDS_RETRY_DELAY_SECONDS \
-    -o $TOKEN_DIR/$TOKEN_FILE \
-    -H "X-aws-ec2-metadata-token-ttl-seconds: $IMDS_TOKEN_TTL_SECONDS" \
-    -X PUT \
-    "http://$IMDS_ENDPOINT/latest/api/token"
-  # make sure any user can utilize (and clean up) these tokens
-  chmod a+rwx $TOKEN_DIR/$TOKEN_FILE
-  log "🔑 Retrieved a fresh IMDS token that will expire in $IMDS_TOKEN_TTL_SECONDS seconds."
-else
-  log "ℹ️ Using cached IMDS token that expires in $(($TOKEN_FILE - $CURRENT_TIME)) seconds."
-fi
-
-curl \
-  --silent \
-  --show-error \
-  --retry $IMDS_RETRIES \
-  --retry-delay $IMDS_RETRY_DELAY_SECONDS \
-  --write-out '\n' \
-  -H "X-aws-ec2-metadata-token: $(cat $TOKEN_DIR/$TOKEN_FILE)" \
-  "http://$IMDS_ENDPOINT/$API_PATH"
+get-with-token "$API_PATH"

--- a/files/bin/provider-id
+++ b/files/bin/provider-id
@@ -6,4 +6,4 @@ set -o nounset
 AVAILABILITY_ZONE=$(imds '/latest/meta-data/placement/availability-zone')
 INSTANCE_ID=$(imds '/latest/meta-data/instance-id')
 
-echo "aws://$AVAILABILITY_ZONE/$INSTANCE_ID"
+echo "aws:///$AVAILABILITY_ZONE/$INSTANCE_ID"

--- a/files/bin/provider-id
+++ b/files/bin/provider-id
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+AVAILABILITY_ZONE=$(imds '/latest/meta-data/placement/availability-zone')
+INSTANCE_ID=$(imds '/latest/meta-data/instance-id')
+
+echo "aws://$AVAILABILITY_ZONE/$INSTANCE_ID"

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -462,7 +462,7 @@ if vercmp "$KUBELET_VERSION" lt "1.26.0"; then
   KUBELET_CLOUD_PROVIDER="aws"
 else
   KUBELET_CLOUD_PROVIDER="external"
-  KUBELET_ARGS="$KUBELET_ARGS --provider-id=$(provider-id)"
+  echo "$(jq ".providerID=\"$(provider-id)\"" $KUBELET_CONFIG)" > $KUBELET_CONFIG
 fi
 
 KUBELET_ARGS="$KUBELET_ARGS --cloud-provider=$KUBELET_CLOUD_PROVIDER"

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -455,11 +455,23 @@ if [[ "$USE_MAX_PODS" = "true" ]]; then
   echo "$(jq ".maxPods=$MAX_PODS" $KUBELET_CONFIG)" > $KUBELET_CONFIG
 fi
 
+KUBELET_ARGS="--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER --v=2"
+
+if vercmp "$KUBELET_VERSION" lt "1.26.0"; then
+  # TODO: remove this when 1.25 is EOL
+  KUBELET_CLOUD_PROVIDER="aws"
+else
+  KUBELET_CLOUD_PROVIDER="external"
+  KUBELET_ARGS="$KUBELET_ARGS --provider-id=$(provider-id)"
+fi
+
+KUBELET_ARGS="$KUBELET_ARGS --cloud-provider=$KUBELET_CLOUD_PROVIDER"
+
 mkdir -p /etc/systemd/system/kubelet.service.d
 
 cat << EOF > /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf
 [Service]
-Environment='KUBELET_ARGS=--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER --v=2'
+Environment='KUBELET_ARGS=$KUBELET_ARGS'
 EOF
 
 if [[ -n "$KUBELET_EXTRA_ARGS" ]]; then

--- a/files/kubelet-containerd.service
+++ b/files/kubelet-containerd.service
@@ -7,12 +7,13 @@ Requires=containerd.service sandbox-image.service
 [Service]
 Slice=runtime.slice
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
-ExecStart=/usr/bin/kubelet --cloud-provider aws \
+ExecStart=/usr/bin/kubelet \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime remote \
     --container-runtime-endpoint unix:///run/containerd/containerd.sock \
-    $KUBELET_ARGS $KUBELET_EXTRA_ARGS
+    $KUBELET_ARGS \
+    $KUBELET_EXTRA_ARGS
 
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -6,11 +6,13 @@ Requires=docker.service
 
 [Service]
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
-ExecStart=/usr/bin/kubelet --cloud-provider aws \
+ExecStart=/usr/bin/kubelet \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime docker \
-    --network-plugin cni $KUBELET_ARGS $KUBELET_EXTRA_ARGS
+    --network-plugin cni \
+    $KUBELET_ARGS \
+    $KUBELET_EXTRA_ARGS
 
 Restart=always
 RestartSec=5

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock:v1.11.2 as aemm
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN amazon-linux-extras enable docker && \
-    yum install -y jq containerd wget && \
+    yum install -y jq containerd wget which && \
     wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && \
     chmod a+x /usr/local/bin/yq
 

--- a/test/cases/cloud-provider-config.sh
+++ b/test/cases/cloud-provider-config.sh
@@ -5,14 +5,20 @@ set -o pipefail
 set -o nounset
 
 KUBELET_UNIT_DIR="/etc/systemd/system/kubelet.service.d"
+KUBELET_CONFIG_FILE="/etc/kubernetes/kubelet/kubelet-config.json"
 
 function fail() {
   echo "❌ Test Failed:" "$@"
+  echo "Kubelet systemd units:"
   find $KUBELET_UNIT_DIR -type f | xargs cat
+  echo "Kubelet config file:"
+  cat $KUBELET_CONFIG_FILE | jq '.'
   exit 1
 }
 
-echo "--> Should use in-tree cloud provider when below k8s version 1.26"
+EXPECTED_PROVIDER_ID=$(provider-id)
+
+echo "--> Should use in-tree cloud provider below k8s version 1.26"
 # This variable is used to override the default value in the kubelet mock
 export KUBELET_VERSION=v1.25.5-eks-ba74326
 EXIT_CODE=0
@@ -28,13 +34,12 @@ grep -RFq -e "--cloud-provider=aws" $KUBELET_UNIT_DIR || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   fail "expected --cloud-provider=aws to be present in kubelet's systemd units"
 fi
-EXIT_CODE=0
-grep -RFq -e "--provider-id=$(provider-id)" $KUBELET_UNIT_DIR || EXIT_CODE=$?
-if [[ ${EXIT_CODE} -eq 0 ]]; then
-  fail "expected --provider-id=$(provider-id) to be absent in kubelet's systemd units"
+ACTUAL_PROVIDER_ID=$(jq -r '.providerID' $KUBELET_CONFIG_FILE)
+if [ ! "$ACTUAL_PROVIDER_ID" = "null" ]; then
+  fail "expected .providerID to be absent in kubelet's config file but was '$ACTUAL_PROVIDER_ID'"
 fi
 
-echo "--> Should use external cloud provider when at or above k8s version 1.26"
+echo "--> Should use external cloud provider at k8s version 1.26"
 # at 1.26
 export KUBELET_VERSION=v1.26.5-eks-ba74326
 EXIT_CODE=0
@@ -50,11 +55,12 @@ grep -RFq -e "--cloud-provider=external" $KUBELET_UNIT_DIR || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   fail "expected --cloud-provider=external to be present in kubelet's systemd units"
 fi
-EXIT_CODE=0
-grep -RFq -e "--provider-id=$(provider-id)" $KUBELET_UNIT_DIR || EXIT_CODE=$?
-if [[ ${EXIT_CODE} -ne 0 ]]; then
-  fail "expected --provider-id=$(provider-id) to be present in kubelet's systemd units"
+ACTUAL_PROVIDER_ID=$(jq -r '.providerID' $KUBELET_CONFIG_FILE)
+if [ ! "$ACTUAL_PROVIDER_ID" = "$EXPECTED_PROVIDER_ID" ]; then
+  fail "expected .providerID=$EXPECTED_PROVIDER_ID to be present in kubelet's config file but was '$ACTUAL_PROVIDER_ID'"
 fi
+
+echo "--> Should use external cloud provider above k8s version 1.26"
 # above 1.26
 export KUBELET_VERSION=v1.27.0-eks-ba74326
 EXIT_CODE=0
@@ -70,8 +76,7 @@ grep -RFq -e "--cloud-provider=external" $KUBELET_UNIT_DIR || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   fail "expected --cloud-provider=external to be present in kubelet's systemd units"
 fi
-EXIT_CODE=0
-grep -RFq -e "--provider-id=$(provider-id)" $KUBELET_UNIT_DIR || EXIT_CODE=$?
-if [[ ${EXIT_CODE} -ne 0 ]]; then
-  fail "expected --provider-id=$(provider-id) to be present in kubelet's systemd units"
+ACTUAL_PROVIDER_ID=$(jq -r '.providerID' $KUBELET_CONFIG_FILE)
+if [ ! "$ACTUAL_PROVIDER_ID" = "$EXPECTED_PROVIDER_ID" ]; then
+  fail "expected .providerID=$EXPECTED_PROVIDER_ID to be present in kubelet's config file but was '$ACTUAL_PROVIDER_ID"
 fi

--- a/test/cases/cloud-provider-config.sh
+++ b/test/cases/cloud-provider-config.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+KUBELET_UNIT_DIR="/etc/systemd/system/kubelet.service.d"
+
+function fail() {
+  echo "❌ Test Failed:" "$@"
+  find $KUBELET_UNIT_DIR -type f | xargs cat
+  exit 1
+}
+
+echo "--> Should use in-tree cloud provider when below k8s version 1.26"
+# This variable is used to override the default value in the kubelet mock
+export KUBELET_VERSION=v1.25.5-eks-ba74326
+EXIT_CODE=0
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  test || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  fail "expected a zero exit code but got '${EXIT_CODE}'"
+fi
+EXIT_CODE=0
+grep -RFq -e "--cloud-provider=aws" $KUBELET_UNIT_DIR || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  fail "expected --cloud-provider=aws to be present in kubelet's systemd units"
+fi
+EXIT_CODE=0
+grep -RFq -e "--provider-id=$(provider-id)" $KUBELET_UNIT_DIR || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  fail "expected --provider-id=$(provider-id) to be absent in kubelet's systemd units"
+fi
+
+echo "--> Should use external cloud provider when at or above k8s version 1.26"
+# at 1.26
+export KUBELET_VERSION=v1.26.5-eks-ba74326
+EXIT_CODE=0
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  test || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  fail "expected a zero exit code but got '${EXIT_CODE}'"
+fi
+EXIT_CODE=0
+grep -RFq -e "--cloud-provider=external" $KUBELET_UNIT_DIR || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  fail "expected --cloud-provider=external to be present in kubelet's systemd units"
+fi
+EXIT_CODE=0
+grep -RFq -e "--provider-id=$(provider-id)" $KUBELET_UNIT_DIR || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  fail "expected --provider-id=$(provider-id) to be present in kubelet's systemd units"
+fi
+# above 1.26
+export KUBELET_VERSION=v1.27.0-eks-ba74326
+EXIT_CODE=0
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  test || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  fail "expected a zero exit code but got '${EXIT_CODE}'"
+fi
+EXIT_CODE=0
+grep -RFq -e "--cloud-provider=external" $KUBELET_UNIT_DIR || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  fail "expected --cloud-provider=external to be present in kubelet's systemd units"
+fi
+EXIT_CODE=0
+grep -RFq -e "--provider-id=$(provider-id)" $KUBELET_UNIT_DIR || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  fail "expected --provider-id=$(provider-id) to be present in kubelet's systemd units"
+fi

--- a/test/cases/imds-errors.sh
+++ b/test/cases/imds-errors.sh
@@ -4,6 +4,15 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+echo "--> Should succeed for known API"
+EXIT_CODE=0
+export IMDS_DEBUG=true
+imds /latest/meta-data/instance-id || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got: $EXIT_CODE"
+  exit 1
+fi
+
 echo "--> Should fail for unknown API"
 EXIT_CODE=0
 export IMDS_DEBUG=true

--- a/test/cases/imds-errors.sh
+++ b/test/cases/imds-errors.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "--> Should fail for unknown API"
+EXIT_CODE=0
+export IMDS_DEBUG=true
+imds /foo || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code"
+  exit 1
+fi
+
+echo "--> Should fail for invalid endpoint"
+EXIT_CODE=0
+export IMDS_ENDPOINT="127.0.0.0:1234"
+export IMDS_DEBUG=true
+imds /latest/meta-data/instance-id || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code"
+  exit 1
+fi

--- a/test/cases/imds-errors.sh
+++ b/test/cases/imds-errors.sh
@@ -4,9 +4,10 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+export IMDS_DEBUG=true
+
 echo "--> Should succeed for known API"
 EXIT_CODE=0
-export IMDS_DEBUG=true
 imds /latest/meta-data/instance-id || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   echo "❌ Test Failed: expected a zero exit code but got: $EXIT_CODE"
@@ -15,7 +16,6 @@ fi
 
 echo "--> Should fail for unknown API"
 EXIT_CODE=0
-export IMDS_DEBUG=true
 imds /foo || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -eq 0 ]]; then
   echo "❌ Test Failed: expected a non-zero exit code"
@@ -25,7 +25,6 @@ fi
 echo "--> Should fail for invalid endpoint"
 EXIT_CODE=0
 export IMDS_ENDPOINT="127.0.0.0:1234"
-export IMDS_DEBUG=true
 imds /latest/meta-data/instance-id || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -eq 0 ]]; then
   echo "❌ Test Failed: expected a non-zero exit code"

--- a/test/cases/provider-id.sh
+++ b/test/cases/provider-id.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "--> Should fetch imds details correctly"
+EXPECTED_INSTANCE_ID="i-1234567890abcdef0"
+EXPECTED_AVAILABILITY_ZONE="us-east-1a"
+EXPECTED_PROVIDER_ID="aws://$EXPECTED_AVAILABILITY_ZONE/$EXPECTED_INSTANCE_ID"
+PROVIDER_ID=$(provider-id)
+if [ ! "$PROVIDER_ID" = "$EXPECTED_PROVIDER_ID" ]; then
+  echo "❌ Test Failed: expected provider-id=$EXPECTED_PROVIDER_ID but got '${PROVIDER_ID}'"
+  exit 1
+fi
+
+echo "--> Should fail when imds is unreachable"
+echo '#!/usr/bin/sh
+exit 1' > $(which imds)
+EXIT_CODE=0
+provider-id || EXIT_CODE=$?
+if [[ ${EXIT_CODE} -eq 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code"
+  exit 1
+fi

--- a/test/cases/provider-id.sh
+++ b/test/cases/provider-id.sh
@@ -7,7 +7,7 @@ set -o pipefail
 echo "--> Should fetch imds details correctly"
 EXPECTED_INSTANCE_ID="i-1234567890abcdef0"
 EXPECTED_AVAILABILITY_ZONE="us-east-1a"
-EXPECTED_PROVIDER_ID="aws://$EXPECTED_AVAILABILITY_ZONE/$EXPECTED_INSTANCE_ID"
+EXPECTED_PROVIDER_ID="aws:///$EXPECTED_AVAILABILITY_ZONE/$EXPECTED_INSTANCE_ID"
 PROVIDER_ID=$(provider-id)
 if [ ! "$PROVIDER_ID" = "$EXPECTED_PROVIDER_ID" ]; then
   echo "❌ Test Failed: expected provider-id=$EXPECTED_PROVIDER_ID but got '${PROVIDER_ID}'"


### PR DESCRIPTION
**Issue #, if available:**

Closes #1096.

**Description of changes:**

This will move 1.26+ AMI's away from kubelet's in-tree cloud provider. This requires specifying a `--provider-id`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Unit tests added.

@camrakin has run 1.26 sonobuoy conformance against this branch, and it passed.