### PR TITLE
Added checks for AWS CLI

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -119,21 +119,26 @@ sudo mv $TEMPLATE_DIR/iptables-restore.service /etc/eks/iptables-restore.service
 ### awscli #####################################################
 ################################################################################
 
-if [[ "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "us-isob-east-1" ]]; then
-  # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
-  echo "Installing awscli v2 bundle"
-  AWSCLI_DIR=$(mktemp -d)
-  curl \
-    --silent \
-    --show-error \
-    --retry 10 \
-    --retry-delay 1 \
-    -L "https://awscli.amazonaws.com/awscli-exe-linux-${MACHINE}.zip" -o "${AWSCLI_DIR}/awscliv2.zip"
-  unzip -q "${AWSCLI_DIR}/awscliv2.zip" -d ${AWSCLI_DIR}
-  sudo "${AWSCLI_DIR}/aws/install" --bin-dir /bin/
+if command -v aws &> /dev/null
+then
+    echo "AWS CLI is already installed."
 else
-  echo "Installing awscli package"
-  sudo yum install -y awscli
+  if [[ "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "us-isob-east-1" ]]; then
+    # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+    echo "Installing awscli v2 bundle"
+    AWSCLI_DIR=$(mktemp -d)
+    curl \
+      --silent \
+      --show-error \
+      --retry 10 \
+      --retry-delay 1 \
+      -L "https://awscli.amazonaws.com/awscli-exe-linux-${MACHINE}.zip" -o "${AWSCLI_DIR}/awscliv2.zip"
+    unzip -q "${AWSCLI_DIR}/awscliv2.zip" -d ${AWSCLI_DIR}
+    sudo "${AWSCLI_DIR}/aws/install" --bin-dir /bin/ --update
+  else
+    echo "Installing awscli package"
+    sudo yum install -y awscli
+  fi
 fi
 
 ################################################################################


### PR DESCRIPTION
Added condition that checks if AWS CLI is pre-installed. If yes, it skips installation step.

**Issue #, if available:**
Script is interrupted when it finds AWS CLI is already pre-installed.

**Description of changes:**
Added condition that checks if AWS CLI is pre-installed. If yes, it skips installation step.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
Run the script again, and its now skipping the installation steps when it sees AWS CLI is already installed.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
