### PR TITLE
Added check if group "docker" exists.

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -206,7 +206,18 @@ fi
 
 if [[ "$INSTALL_DOCKER" == "true" ]]; then
   sudo amazon-linux-extras enable docker
-  sudo groupadd -og 1950 docker
+
+  if grep -q "^docker:" /etc/group
+  then
+      echo "The 'docker' group already exists. Changing the GID of the group to '1950'."
+      sudo groupmod -og 1950 docker
+      echo "Group: docker"
+      echo "Group ID: $(getent group docker | cut -d: -f3)"
+  else
+      echo "Creating the group 'docker'."    
+      sudo groupadd -fog 1950 docker
+  fi
+  
   sudo useradd --gid $(getent group docker | cut -d: -f3) docker
 
   # install docker and lock version


### PR DESCRIPTION
Added condition that checks if the group "docker" is already created.  
If yes, it changes the GID to "1950".
If no, it creates the group with GID "1950".

**Issue #, if available:**
Script stops if the group "docker" exists.

**Description of changes:**
Added condition that check if group "docker" exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
