### PR TITLE
Disable eni-max-pods.txt workflow in forks

### DIFF
--- a/.github/workflows/sync-eni-max-pods.yaml
+++ b/.github/workflows/sync-eni-max-pods.yaml
@@ -10,6 +10,8 @@ permissions:
   pull-requests: write
 jobs:
   update-max-pods:
+    # this workflow will always fail in forks; bail if this isn't running in the upstream
+    if: github.repository == awslabs/amazon-eks-ami
     runs-on: ubuntu-latest
     steps:
       - uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
**Description of changes:**

The `sync-eni-max-pods.yaml` workflow will always fail in forks; this adds a condition to the `job` that terminates early if the context isn't the upstream repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.