### PR TITLE
Discontinue 1.21 AMI's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ T_GREEN := \e[0;32m
 T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
-.PHONY: all
-all: 1.21 1.22 1.23 1.24 1.25 ## Build all versions of EKS Optimized AL2 AMI
+.PHONY: latest
+latest: 1.25 ## Build EKS Optimized AL2 AMI with the latest supported version of Kubernetes
 
 # ensure that these flags are equivalent to the rules in the .editorconfig
 SHFMT_FLAGS := --list \

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,6 @@ k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 
 # Build dates and versions taken from https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 
-.PHONY: 1.21
-1.21: ## Build EKS Optimized AL2 AMI - K8s 1.21
-	$(MAKE) k8s kubernetes_version=1.21.14 kubernetes_build_date=2023-01-30 pull_cni_from_github=true
-
 .PHONY: 1.22
 1.22: ## Build EKS Optimized AL2 AMI - K8s 1.22
 	$(MAKE) k8s kubernetes_version=1.22.17 kubernetes_build_date=2023-01-30 pull_cni_from_github=true

--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ invoking Packer directly. You can initiate the build process by running the
 following command in the root of this repository:
 
 ```bash
+# build an AMI with the latest Kubernetes version
 make
+
+# build an AMI with a specific Kubernetes version
+make 1.25
 ```
-The Makefile chooses a particular kubelet binary to use per kubernetes version which you can [view here](Makefile).
-To build an Amazon EKS Worker AMI for a particular Kubernetes version run the following command
-```bash
-make 1.23 ## Build a Amazon EKS Worker AMI for k8s 1.23
-```
+
+The Makefile chooses a particular kubelet binary to use per Kubernetes version which you can [view here](Makefile).
 
 > **Note**
 > The default instance type to build this AMI does not qualify for the AWS free tier.


### PR DESCRIPTION
**Description of changes:**

Removes 1.21. Will include other associated logic related to the 1.21/1.22 divide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.