### PR TITLE
rewrite k8s.gcr.io registry to registry.k8s.io

### DIFF
--- a/files/containerd-config.toml
+++ b/files/containerd-config.toml
@@ -23,3 +23,8 @@ SystemdCgroup = true
 [plugins."io.containerd.grpc.v1.cri".cni]
 bin_dir = "/opt/cni/bin"
 conf_dir = "/etc/cni/net.d"
+
+# Enable registry.k8s.io as the primary mirror for k8s.gcr.io
+# See: https://github.com/kubernetes/k8s.io/issues/3411
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."k8s.gcr.io"]
+  endpoint = ["https://registry.k8s.io", "https://k8s.gcr.io",]


### PR DESCRIPTION
**Description of changes:**
Sets a default config for containerd to redirect k8s.gcr.io registry pulls to the new registry.k8s.io. This is needed to avoid breaking users if the old registry deletes images (a current option being discussed). This has potential to break some users if they rely on network rules for external connections.

More context https://github.com/kubernetes/registry.k8s.io#stability
https://github.com/kubernetes/k8s.io/issues/4214#issuecomment-1247446149

More discussions about options are happening in #sig-infra in Kubernetes slack. We would want to clearly communicate this change to users and allow them to check if their accounts will be affected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
