### PR TITLE
Add quotes to repository name in workflow definition

### DIFF
--- a/.github/workflows/sync-eni-max-pods.yaml
+++ b/.github/workflows/sync-eni-max-pods.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   update-max-pods:
     # this workflow will always fail in forks; bail if this isn't running in the upstream
-    if: github.repository == awslabs/amazon-eks-ami
+    if: github.repository == 'awslabs/amazon-eks-ami'
     runs-on: ubuntu-latest
     steps:
       - uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
**Description of changes:**

Fixes a silly syntax issue with the `sync-eni-max-pods.yaml` workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

The old version of `act` I had didn't seem to catch this; I updated to the latest and reproduced the syntax issue.

This now validates the workflow successfully:
```
act workflow_dispatch -W .github/workflows/sync-eni-max-pods.yaml --dryrun
```