### PR TITLE
Don't pass URL to --content

### DIFF
--- a/log-collector-script/linux/README.md
+++ b/log-collector-script/linux/README.md
@@ -102,10 +102,11 @@ Trying to archive gathered information...
 1. Create the SSM document named "EKSLogCollector" using the following commands:
 
 ```
+curl -O https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/log-collector-script/linux/eks-ssm-content.json
 aws ssm create-document \
   --name "EKSLogCollectorLinux" \
   --document-type "Command" \
-  --content https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/log-collector-script/linux/eks-ssm-content.json
+  --content file://eks-ssm-content.json
 ```
 
 2. To execute the bash script in the SSM document and to collect the logs from worker, run the following command:


### PR DESCRIPTION
**Description of changes:**

The `--content` flag on `aws ssm create-document` no longer supports URLs on recent CLI versions.

All AWS CLI parameters support the `file://` scheme, so this switches to that: https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-parameters-file.html#cli-usage-parameters-file-how

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

CLI version:
```
> aws --version
aws-cli/2.9.23 Python/3.9.11 Darwin/22.3.0 exe/x86_64 prompt/off
```

Doesn't work:
```
> aws ssm create-document \
>   --name "EKSLogCollectorLinux" \
>   --document-type "Command" \
>   --content https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/log-collector-script/linux/eks-ssm-content.json


An error occurred (InvalidDocumentContent) when calling the CreateDocument operation: JSON not well-formed. at Line: 1, Column: 6
```

Works:
```
> curl -O https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/log-collector-script/linux/eks-ssm-content.json
> aws ssm create-document \
>   --name "EKSLogCollectorLinux" \
>   --document-type "Command" \
>   --content file://eks-ssm-content.json
```

