### PR TITLE
Move file copy after kernel upgrade

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -123,6 +123,17 @@
     {
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
+      "expect_disconnect": true,
+      "pause_after": "90s",
+      "script": "{{template_dir}}/scripts/upgrade_kernel.sh",
+      "environment_vars": [
+        "KUBERNETES_VERSION={{user `kubernetes_version`}}",
+        "KERNEL_VERSION={{user `kernel_version`}}"
+      ]
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
       "inline": [
         "mkdir -p /tmp/worker/log-collector-script/"
       ]
@@ -142,17 +153,6 @@
       "inline": [
         "sudo chmod -R a+x /tmp/worker/bin/",
         "sudo mv /tmp/worker/bin/* /usr/bin/"
-      ]
-    },
-    {
-      "type": "shell",
-      "remote_folder": "{{ user `remote_folder`}}",
-      "expect_disconnect": true,
-      "pause_after": "90s",
-      "script": "{{template_dir}}/scripts/upgrade_kernel.sh",
-      "environment_vars": [
-        "KUBERNETES_VERSION={{user `kubernetes_version`}}",
-        "KERNEL_VERSION={{user `kernel_version`}}"
       ]
     },
     {


### PR DESCRIPTION
**Description of changes:**

We ran into this issue with AL2 today where we had an error using the latest tag [v20230304](https://github.com/awslabs/amazon-eks-ami/releases/tag/v20230304) during the `install-worker.sh` step:
```
2023-03-23T20:50:09Z:     amazon-ebs: mv: cannot stat ‘/tmp/worker/iptables-restore.service’: No such file or directory
```

In some distros the `/tmp` directory is cleared upon reboot, which removes the `/tmp/worker` files needed to successfully build the AMI. Since the `kernel_upgrade.sh` script has a reboot step, the file transfer needs to happen after the reboot.

In our testing the change in order of steps fixes the above issue.

Looks like this change was previously accepted (https://github.com/awslabs/amazon-eks-ami/pull/474) and then reverted in recent changes.

Closes #1229

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
