### PR TITLE
Install cri-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,14 @@ vercmp = $(shell $(MAKEFILE_DIR)/files/bin/vercmp "$1" "$2" "$3")
 # gp2 volumes are used by default prior to 1.26
 # TODO: remove this when 1.25 reaches EOL
 ifeq ($(call packer_variable_file_contains,volume_type), false)
-	ifeq ($(call vercmp, $(kubernetes_version), lt, 1.26.0), true)
+	ifeq ($(call vercmp,$(kubernetes_version),lt,1.26.0), true)
 		volume_type ?= gp2
 	endif
 endif
 
 # Docker is not present on 1.25+ AMI's
 # TODO: remove this when 1.24 reaches EOL
-ifeq ($(call vercmp, $(kubernetes_version), gteq, 1.25.0), true)
+ifeq ($(call vercmp,$(kubernetes_version),gteq,1.25.0), true)
 	# do not tag the AMI with the Docker version
 	docker_version ?= none
 	# do not include the Docker version in the AMI description

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ packer_variable_file_contains = $(if $(PACKER_VARIABLE_FILE),$(shell grep -Fq $1
 
 vercmp = $(shell $(MAKEFILE_DIR)/files/bin/vercmp "$1" "$2" "$3")
 
-# gp2 volumes are used by default prior to 1.26
+# gp3 volumes are used by default for 1.26+
 # TODO: remove this when 1.25 reaches EOL
 ifeq ($(call packer_variable_file_contains,volume_type), false)
-	ifeq ($(call vercmp,$(kubernetes_version),lt,1.26.0), true)
-		volume_type ?= gp2
+	ifeq ($(call vercmp,$(kubernetes_version),gteq,1.26.0), true)
+		volume_type ?= gp3
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,15 @@ packer_variable_file_contains = $(if $(PACKER_VARIABLE_FILE),$(shell grep -Fq $1
 
 vercmp = $(shell $(MAKEFILE_DIR)/files/bin/vercmp "$1" "$2" "$3")
 
+in_iso_region = $(if $(findstring us-iso,$(aws_region)),true,false)
+
 # gp3 volumes are used by default for 1.26+
 # TODO: remove this when 1.25 reaches EOL
 ifeq ($(call packer_variable_file_contains,volume_type), false)
 	ifeq ($(call vercmp,$(kubernetes_version),gteq,1.26.0), true)
-		volume_type ?= gp3
+		ifeq ($(call in_iso_region),false)
+			volume_type ?= gp3
+		endif
 	endif
 endif
 

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -33,5 +33,5 @@
     "ssh_username": "ec2-user",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
-    "volume_type": "gp3"
+    "volume_type": "gp2"
 }

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -33,5 +33,5 @@
     "ssh_username": "ec2-user",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
-    "volume_type": "gp2"
+    "volume_type": "gp3"
 }

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -154,6 +154,9 @@ sudo yum versionlock runc-*
 sudo yum install -y containerd-${CONTAINERD_VERSION}
 sudo yum versionlock containerd-*
 
+# install cri-tools
+sudo yum install -y cri-tools
+
 sudo mkdir -p /etc/eks/containerd
 if [ -f "/etc/eks/containerd/containerd-config.toml" ]; then
   ## this means we are building a gpu ami and have already placed a containerd configuration file in /etc/eks


### PR DESCRIPTION
**Issue #, if available:**

Closes #797 .

**Description of changes:**

Adds `cri-tools`, which includes `crictl` and `critest`. The latest version of the package will be installed at build, and the package is not version-locked, because it's not in the critical path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

```
> make
...
2023-03-28T11:50:21-07:00:     amazon-ebs: Downloading packages:
2023-03-28T11:50:22-07:00:     amazon-ebs: cri-tools-1.25.0-1.amzn2.0.1.x86_64.rpm                    |  17 MB   00:00
2023-03-28T11:50:22-07:00:     amazon-ebs: Running transaction check
2023-03-28T11:50:22-07:00:     amazon-ebs: Running transaction test
2023-03-28T11:50:22-07:00:     amazon-ebs: Transaction test succeeded
2023-03-28T11:50:22-07:00:     amazon-ebs: Running transaction
2023-03-28T11:50:24-07:00:     amazon-ebs:   Installing : cri-tools-1.25.0-1.amzn2.0.1.x86_64                          1/1
2023-03-28T11:50:24-07:00:     amazon-ebs:   Verifying  : cri-tools-1.25.0-1.amzn2.0.1.x86_64                          1/1
2023-03-28T11:50:24-07:00:     amazon-ebs:
2023-03-28T11:50:24-07:00:     amazon-ebs: Installed:
2023-03-28T11:50:24-07:00:     amazon-ebs:   cri-tools.x86_64 0:1.25.0-1.amzn2.0.1
2023-03-28T11:50:24-07:00:     amazon-ebs:
2023-03-28T11:50:24-07:00:     amazon-ebs: Complete!
```
