### PR TITLE
Install cri-tools

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -343,6 +343,9 @@ sudo systemctl daemon-reload
 # Disable the kubelet until the proper dropins have been configured
 sudo systemctl disable kubelet
 
+# install crictl, critest
+sudo yum install -y cri-tools
+
 ################################################################################
 ### EKS ########################################################################
 ################################################################################


### PR DESCRIPTION
**Issue #, if available:**

Closes https://github.com/awslabs/amazon-eks-ami/issues/797 .

**Description of changes:**

Adds cri-tools, which includes crictl and critest. The latest version of the package will be installed at build, and the package is not version-locked, because it's not in the critical path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**
```
> make
...
2023-03-28T11:50:21-07:00:     amazon-ebs: Downloading packages:
2023-03-28T11:50:22-07:00:     amazon-ebs: cri-tools-1.25.0-1.amzn2.0.1.x86_64.rpm                    |  17 MB   00:00
2023-03-28T11:50:22-07:00:     amazon-ebs: Running transaction check
2023-03-28T11:50:22-07:00:     amazon-ebs: Running transaction test
2023-03-28T11:50:22-07:00:     amazon-ebs: Transaction test succeeded
2023-03-28T11:50:22-07:00:     amazon-ebs: Running transaction
2023-03-28T11:50:24-07:00:     amazon-ebs:   Installing : cri-tools-1.25.0-1.amzn2.0.1.x86_64                          1/1
2023-03-28T11:50:24-07:00:     amazon-ebs:   Verifying  : cri-tools-1.25.0-1.amzn2.0.1.x86_64                          1/1
2023-03-28T11:50:24-07:00:     amazon-ebs:
2023-03-28T11:50:24-07:00:     amazon-ebs: Installed:
2023-03-28T11:50:24-07:00:     amazon-ebs:   cri-tools.x86_64 0:1.25.0-1.amzn2.0.1
2023-03-28T11:50:24-07:00:     amazon-ebs:
2023-03-28T11:50:24-07:00:     amazon-ebs: Complete!
```