### PR TITLE
Add clean target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ endif
 arch ?= x86_64
 ifeq ($(arch), arm64)
 instance_type ?= m6g.large
-ami_name = amazon-eks-arm64-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
+ami_name ?= amazon-eks-arm64-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 else
 instance_type ?= m4.large
-ami_name = amazon-eks-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
+ami_name ?= amazon-eks-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 endif
 
 ifeq ($(aws_region), cn-northwest-1)

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,11 @@ endif
 arch ?= x86_64
 ifeq ($(arch), arm64)
 instance_type ?= m6g.large
-AMI_NAME_PREFIX = amazon-eks-arm64-node
+ami_name = amazon-eks-arm64-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 else
 instance_type ?= m4.large
-AMI_NAME_PREFIX = amazon-eks-node
+ami_name = amazon-eks-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 endif
-
-ami_name ?= $(AMI_NAME_PREFIX)-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 
 ifeq ($(aws_region), cn-northwest-1)
 source_ami_owners ?= 141808717104
@@ -108,8 +106,8 @@ k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 
 .PHONY: clean
 clean:
-	rm $(AMI_NAME_PREFIX)-*-manifest.json
-	rm $(AMI_NAME_PREFIX)-*-version-info.json
+	rm *-manifest.json
+	rm *-version-info.json
 
 .PHONY: help
 help: ## Display help

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,13 @@ endif
 arch ?= x86_64
 ifeq ($(arch), arm64)
 instance_type ?= m6g.large
-ami_name ?= amazon-eks-arm64-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
+AMI_NAME_PREFIX = amazon-eks-arm64-node
 else
 instance_type ?= m4.large
-ami_name ?= amazon-eks-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
+AMI_NAME_PREFIX = amazon-eks-node
 endif
+
+ami_name ?= $(AMI_NAME_PREFIX)-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 
 ifeq ($(aws_region), cn-northwest-1)
 source_ami_owners ?= 141808717104
@@ -103,6 +105,11 @@ k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 .PHONY: 1.25
 1.25: ## Build EKS Optimized AL2 AMI - K8s 1.25
 	$(MAKE) k8s kubernetes_version=1.25.7 kubernetes_build_date=2023-03-17 pull_cni_from_github=true
+
+.PHONY: clean
+clean:
+	rm $(AMI_NAME_PREFIX)-*-manifest.json
+	rm $(AMI_NAME_PREFIX)-*-version-info.json
 
 .PHONY: help
 help: ## Display help


### PR DESCRIPTION
**Description of changes:**

This adds a `clean` target to the Makefile that will remove runtime artifacts (`*-manifest.json` and `*-version-info.json`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

I had lots of these hanging out in my checkout:
```
> ls *-version-info.json
amazon-eks-node-1.20-v20221103-version-info.json	amazon-eks-node-1.23-v20221214-version-info.json	amazon-eks-node-1.24-v20230221-version-info.json
amazon-eks-node-1.21-v20221103-version-info.json	amazon-eks-node-1.23-v20230104-version-info.json	amazon-eks-node-1.24-v20230321-version-info.json
amazon-eks-node-1.21-v20230328-version-info.json	amazon-eks-node-1.23-v20230221-version-info.json	amazon-eks-node-1.24-v20230324-version-info.json
amazon-eks-node-1.22-v20220928-version-info.json	amazon-eks-node-1.23-v20230324-version-info.json	amazon-eks-node-1.24-v20230328-version-info.json
amazon-eks-node-1.22-v20221011-version-info.json	amazon-eks-node-1.23-v20230328-version-info.json	amazon-eks-node-1.25-v20230130-version-info.json
amazon-eks-node-1.22-v20221028-version-info.json	amazon-eks-node-1.24-v20221115-version-info.json	amazon-eks-node-1.25-v20230206-version-info.json
amazon-eks-node-1.22-v20221102-version-info.json	amazon-eks-node-1.24-v20221129-version-info.json	amazon-eks-node-1.25-v20230207-version-info.json
amazon-eks-node-1.22-v20230104-version-info.json	amazon-eks-node-1.24-v20221206-version-info.json	amazon-eks-node-1.25-v20230220-version-info.json
amazon-eks-node-1.22-v20230217-version-info.json	amazon-eks-node-1.24-v20221207-version-info.json	amazon-eks-node-1.25-v20230221-version-info.json
amazon-eks-node-1.22-v20230328-version-info.json	amazon-eks-node-1.24-v20221208-version-info.json	amazon-eks-node-1.25-v20230306-version-info.json
amazon-eks-node-1.23-v20221007-version-info.json	amazon-eks-node-1.24-v20221213-version-info.json	amazon-eks-node-1.25-v20230309-version-info.json
amazon-eks-node-1.23-v20221011-version-info.json	amazon-eks-node-1.24-v20221214-version-info.json	amazon-eks-node-1.25-v20230317-version-info.json
amazon-eks-node-1.23-v20221012-version-info.json	amazon-eks-node-1.24-v20221215-version-info.json	amazon-eks-node-1.25-v20230321-version-info.json
amazon-eks-node-1.23-v20221028-version-info.json	amazon-eks-node-1.24-v20230104-version-info.json	amazon-eks-node-1.25-v20230324-version-info.json
amazon-eks-node-1.23-v20221103-version-info.json	amazon-eks-node-1.24-v20230130-version-info.json	amazon-eks-node-1.25-v20230328-version-info.json
amazon-eks-node-1.23-v20221115-version-info.json	amazon-eks-node-1.24-v20230131-version-info.json	amazon-eks-node-1.26-v20230306-version-info.json
amazon-eks-node-1.23-v20221207-version-info.json	amazon-eks-node-1.24-v20230206-version-info.json
```

This got rid of them 🥳: 
```
> make clean
rm *-manifest.json
rm *-version-info.json
> ls *-manifest.json
> ls *-version-info.json