### PR TITLE
Pass ecr-credential-provider flags to kubelet correctly

### DIFF
--- a/files/kubelet-config.json
+++ b/files/kubelet-config.json
@@ -27,7 +27,8 @@
   "cgroupDriver": "cgroupfs",
   "cgroupRoot": "/",
   "featureGates": {
-    "RotateKubeletServerCertificate": true
+    "RotateKubeletServerCertificate": true,
+    "KubeletCredentialProviders": true
   },
   "protectKernelDefaults": true,
   "serializeImagePulls": false,

--- a/files/kubelet-containerd.service
+++ b/files/kubelet-containerd.service
@@ -12,6 +12,8 @@ ExecStart=/usr/bin/kubelet \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime remote \
     --container-runtime-endpoint unix:///run/containerd/containerd.sock \
+    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \
+    --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider \
     $KUBELET_ARGS \
     $KUBELET_EXTRA_ARGS
 

--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -11,6 +11,8 @@ ExecStart=/usr/bin/kubelet \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime docker \
     --network-plugin cni \
+    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \
+    --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider \    
     $KUBELET_ARGS \
     $KUBELET_EXTRA_ARGS
 

--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -12,7 +12,7 @@ ExecStart=/usr/bin/kubelet \
     --container-runtime docker \
     --network-plugin cni \
     --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \
-    --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider \    
+    --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider \
     $KUBELET_ARGS \
     $KUBELET_EXTRA_ARGS
 

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -162,12 +162,6 @@ else
   sudo mv $TEMPLATE_DIR/containerd-config.toml /etc/eks/containerd/containerd-config.toml
 fi
 
-if vercmp "$KUBERNETES_VERSION" gteq "1.22.0"; then
-  # enable CredentialProviders features in kubelet-containerd service file
-  IMAGE_CREDENTIAL_PROVIDER_FLAGS='\\\n    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \\\n   --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider'
-  sudo sed -i s,"aws","aws $IMAGE_CREDENTIAL_PROVIDER_FLAGS", $TEMPLATE_DIR/kubelet-containerd.service
-fi
-
 sudo mv $TEMPLATE_DIR/kubelet-containerd.service /etc/eks/containerd/kubelet-containerd.service
 sudo mv $TEMPLATE_DIR/sandbox-image.service /etc/eks/containerd/sandbox-image.service
 sudo mv $TEMPLATE_DIR/pull-sandbox-image.sh /etc/eks/containerd/pull-sandbox-image.sh
@@ -323,15 +317,6 @@ sudo chown root:root /var/lib/kubelet/kubeconfig
 if [[ $KUBERNETES_VERSION == "1.20"* ]]; then
   KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED=$(cat $TEMPLATE_DIR/kubelet-config.json | jq '.featureGates += {CSIServiceAccountToken: true}')
   echo $KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED > $TEMPLATE_DIR/kubelet-config.json
-fi
-
-if vercmp "$KUBERNETES_VERSION" gteq "1.22.0"; then
-  # enable CredentialProviders feature flags in kubelet service file
-  IMAGE_CREDENTIAL_PROVIDER_FLAGS='\\\n    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \\\n    --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider'
-  sudo sed -i s,"aws","aws $IMAGE_CREDENTIAL_PROVIDER_FLAGS", $TEMPLATE_DIR/kubelet.service
-  # enable KubeletCredentialProviders features in kubelet configuration
-  KUBELET_CREDENTIAL_PROVIDERS_FEATURES=$(cat $TEMPLATE_DIR/kubelet-config.json | jq '.featureGates += {KubeletCredentialProviders: true}')
-  printf "%s" "$KUBELET_CREDENTIAL_PROVIDERS_FEATURES" > "$TEMPLATE_DIR/kubelet-config.json"
 fi
 
 sudo mv $TEMPLATE_DIR/kubelet.service /etc/systemd/system/kubelet.service


### PR DESCRIPTION
**Issue #, if available:**

Closes #1239 

**Description of changes:**

In previous releases, the `--image-credential-provider-config` and `--image-credential-provider-bin-dir` flags were passed to kubelet by modifying the `systemd` units.

The unit files contained the text `--cloud-provider aws`. To insert the credential provider flags, `aws` was replaced with `aws $IMAGE_CREDENTIAL_PROVIDER_FLAGS`.

In #1203, `--cloud-provider aws` was removed from the `systemd` units, meaning the image credential provider flags were not inserted properly.

This PR adds the flags to the `systemd` units, because we no longer support Kubernetes versions less than 1.22. It also sets the `KubeletCredentialProviders` feature flag in the `kubelet` JSON config file to `true`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.