### PR TITLE
update the kubelet API QPS for K8s 1.27

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -437,8 +437,9 @@ else
 fi
 INSTANCE_TYPE=$(imds 'latest/meta-data/instance-type')
 
-if vercmp "$KUBELET_VERSION" gteq "1.22.0"; then
+if vercmp "$KUBELET_VERSION" gteq "1.22.0" && vercmp "$KUBELET_VERSION" lt "1.27.0"; then
   # for K8s versions that suport API Priority & Fairness, increase our API server QPS
+  # in 1.27, the default is already increased to 50/100, so use the higher defaults
   echo $(jq ".kubeAPIQPS=( .kubeAPIQPS // 10)|.kubeAPIBurst=( .kubeAPIBurst // 20)" $KUBELET_CONFIG) > $KUBELET_CONFIG
 fi
 

--- a/test/cases/api-qps-k8s-1.22-to-1.26.sh
+++ b/test/cases/api-qps-k8s-1.22-to-1.26.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "--> Should increase API server QPS for K8s 1.22 - 1.26"
+exit_code=0
+export KUBELET_VERSION=v1.22.0-eks-ba74326
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+expected_api_qps="10"
+expected_api_burst="20"
+
+actual_api_qps=$(jq -r '.kubeAPIQPS' < /etc/kubernetes/kubelet/kubelet-config.json)
+actual_api_burst=$(jq -r '.kubeAPIBurst' < /etc/kubernetes/kubelet/kubelet-config.json)
+if [[ ${actual_api_qps} != ${expected_api_qps} ]]; then
+  echo "❌ Test Failed: expected kubeAPIQPS = '${expected_api_qps}' but got '${actual_api_qps}'"
+  exit 1
+fi
+
+if [[ ${actual_api_burst} != ${expected_api_burst} ]]; then
+  echo "❌ Test Failed: expected kubeAPIBurst = '${expected_api_burst}' but got '${actual_api_burst}'"
+  exit 1
+fi
+
+export KUBELET_VERSION=v1.26.0-eks-ba74326
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+expected_api_qps="10"
+expected_api_burst="20"
+
+actual_api_qps=$(jq -r '.kubeAPIQPS' < /etc/kubernetes/kubelet/kubelet-config.json)
+actual_api_burst=$(jq -r '.kubeAPIBurst' < /etc/kubernetes/kubelet/kubelet-config.json)
+if [[ ${actual_api_qps} != ${expected_api_qps} ]]; then
+  echo "❌ Test Failed: expected kubeAPIQPS = '${expected_api_qps}' but got '${actual_api_qps}'"
+  exit 1
+fi
+
+if [[ ${actual_api_burst} != ${expected_api_burst} ]]; then
+  echo "❌ Test Failed: expected kubeAPIBurst = '${expected_api_burst}' but got '${actual_api_burst}'"
+  exit 1
+fi

--- a/test/cases/api-qps-k8s-1.27-above.sh
+++ b/test/cases/api-qps-k8s-1.27-above.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "--> Should increase API server QPS for K8s 1.22+"
+echo "--> Should use default API server QPS for K8s 1.27+"
 exit_code=0
-export KUBELET_VERSION=v1.22.0-eks-ba74326
+export KUBELET_VERSION=v1.27.0-eks-ba74326
 /etc/eks/bootstrap.sh \
   --b64-cluster-ca dGVzdA== \
   --apiserver-endpoint http://my-api-endpoint \
@@ -14,8 +14,9 @@ if [[ ${exit_code} -ne 0 ]]; then
   exit 1
 fi
 
-expected_api_qps="10"
-expected_api_burst="20"
+# values should not be set
+expected_api_qps="null"
+expected_api_burst="null"
 
 actual_api_qps=$(jq -r '.kubeAPIQPS' < /etc/kubernetes/kubelet/kubelet-config.json)
 actual_api_burst=$(jq -r '.kubeAPIBurst' < /etc/kubernetes/kubelet/kubelet-config.json)


### PR DESCRIPTION
**Description of changes:**

For K8s 1.27+, don't set the kubelet API QPS to our higher value, as the default has been raised now in https://github.com/kubernetes/kubernetes/pull/116121

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

New unit tests

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
