### PR TITLE
Improve scripts readability and prevent word split issues

### DIFF
--- a/files/pull-sandbox-image.sh
+++ b/files/pull-sandbox-image.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 source <(grep "sandbox_image" /etc/containerd/config.toml | tr -d ' ')
 
 ### Short-circuit fetching sandbox image if its already present
-if [[ "$(sudo ctr --namespace k8s.io image ls | grep $sandbox_image)" != "" ]]; then
+if [[ "$(sudo ctr --namespace k8s.io image ls | grep "${sandbox_image}")" != "" ]]; then
   exit 0
 fi
 

--- a/scripts/cleanup_additional_repos.sh
+++ b/scripts/cleanup_additional_repos.sh
@@ -23,4 +23,4 @@ BEGIN {RS=";";FS=","}
 }
 {cmd="rm -f " Repo; system(cmd)}
 '
-sudo awk "$AWK_CMD" <<< "${ADDITIONAL_YUM_REPOS}"
+sudo awk "${AWK_CMD}" <<< "${ADDITIONAL_YUM_REPOS}"

--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # generates a JSON file containing version information for the software in this AMI
 
@@ -13,11 +13,14 @@ fi
 OUTPUT_FILE="$1"
 
 # packages
-sudo rpm --query --all --queryformat '\{"%{NAME}": "%{VERSION}-%{RELEASE}"\}\n' | jq --slurp --sort-keys 'add | {packages:(.)}' > "$OUTPUT_FILE"
+sudo rpm --query --all --queryformat '\{"%{NAME}": "%{VERSION}-%{RELEASE}"\}\n' | jq --slurp --sort-keys 'add | {packages:(.)}' > "${OUTPUT_FILE}"
 
 # binaries
-echo $(jq ".binaries.kubelet = \"$(kubelet --version | awk '{print $2}')\"" $OUTPUT_FILE) > $OUTPUT_FILE
-echo $(jq ".binaries.awscli = \"$(aws --version | awk '{print $1}' | cut -d '/' -f 2)\"" $OUTPUT_FILE) > $OUTPUT_FILE
+KUBELET_VERSION=$(kubelet --version | cut -d' ' -f2)
+echo "$(jq ".binaries.kubelet = \"${KUBELET_VERSION}\"" "${OUTPUT_FILE}")" > "${OUTPUT_FILE}"
+
+AWSCLI_VERSION=$(aws --version | cut -d' ' -f1 | cut -d'/' -f2)
+echo "$(jq ".binaries.awscli = \"${AWSCLI_VERSION}\"" "${OUTPUT_FILE}")" > "${OUTPUT_FILE}"
 
 # cached images
-echo $(jq ".images = [ $(sudo ctr -n k8s.io image ls -q | cut -d'/' -f2- | sort | uniq | grep -v 'sha256' | xargs -r printf "\"%s\"," | sed 's/,$//') ]" $OUTPUT_FILE) > $OUTPUT_FILE
+echo "$(jq ".images = [ $(sudo ctr -n k8s.io image ls -q | cut -d'/' -f2- | sort | uniq | grep -v 'sha256' | xargs -r printf "\"%s\"," | sed 's/,$//') ]" "${OUTPUT_FILE}")" > "${OUTPUT_FILE}"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -3,6 +3,7 @@
 set -o pipefail
 set -o nounset
 set -o errexit
+
 IFS=$'\n\t'
 export AWS_DEFAULT_OUTPUT="json"
 
@@ -39,12 +40,12 @@ validate_env_set CACHE_CONTAINER_IMAGES
 ################################################################################
 
 MACHINE=$(uname -m)
-if [ "$MACHINE" == "x86_64" ]; then
+if [ "${MACHINE}" == "x86_64" ]; then
   ARCH="amd64"
-elif [ "$MACHINE" == "aarch64" ]; then
+elif [ "${MACHINE}" == "aarch64" ]; then
   ARCH="arm64"
 else
-  echo "Unknown machine architecture '$MACHINE'" >&2
+  echo "Unknown machine architecture '${MACHINE}'" >&2
   exit 1
 fi
 
@@ -75,10 +76,12 @@ sudo yum install -y \
 # Remove any old kernel versions. `--count=1` here means "only leave 1 kernel version installed"
 sudo package-cleanup --oldkernels --count=1 -y
 
-sudo yum versionlock kernel-$(uname -r)
+sudo yum versionlock "kernel-$(uname -r)"
 
 # Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
-if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi
+if yum list installed | grep ec2-net-utils; then
+  sudo yum remove ec2-net-utils -y -q
+fi
 
 ################################################################################
 ### Time #######################################################################
@@ -114,13 +117,13 @@ sudo systemctl restart sshd.service
 ### iptables ###################################################################
 ################################################################################
 sudo mkdir -p /etc/eks
-sudo mv $TEMPLATE_DIR/iptables-restore.service /etc/eks/iptables-restore.service
+sudo mv "${TEMPLATE_DIR}/iptables-restore.service" /etc/eks/iptables-restore.service
 
 ################################################################################
 ### awscli #####################################################
 ################################################################################
 
-if [[ "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "us-isob-east-1" ]]; then
+if [[ "${BINARY_BUCKET_REGION}" != "us-iso-east-1" && "${BINARY_BUCKET_REGION}" != "us-isob-east-1" ]]; then
   # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
   echo "Installing awscli v2 bundle"
   AWSCLI_DIR=$(mktemp -d)
@@ -130,7 +133,7 @@ if [[ "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "
     --retry 10 \
     --retry-delay 1 \
     -L "https://awscli.amazonaws.com/awscli-exe-linux-${MACHINE}.zip" -o "${AWSCLI_DIR}/awscliv2.zip"
-  unzip -q "${AWSCLI_DIR}/awscliv2.zip" -d ${AWSCLI_DIR}
+  unzip -q "${AWSCLI_DIR}/awscliv2.zip" -d "${AWSCLI_DIR}"
   sudo "${AWSCLI_DIR}/aws/install" --bin-dir /bin/ --update
 else
   echo "Installing awscli package"
@@ -148,11 +151,11 @@ sudo mv "${TEMPLATE_DIR}/runtime.slice" /etc/systemd/system/runtime.slice
 ###############################################################################
 
 # install runc and lock version
-sudo yum install -y runc-${RUNC_VERSION}
+sudo yum install -y "runc-${RUNC_VERSION}"
 sudo yum versionlock runc-*
 
 # install containerd and lock version
-sudo yum install -y containerd-${CONTAINERD_VERSION}
+sudo yum install -y "containerd-${CONTAINERD_VERSION}"
 sudo yum versionlock containerd-*
 
 sudo mkdir -p /etc/eks/containerd
@@ -160,13 +163,13 @@ if [ -f "/etc/eks/containerd/containerd-config.toml" ]; then
   ## this means we are building a gpu ami and have already placed a containerd configuration file in /etc/eks
   echo "containerd config is already present"
 else
-  sudo mv $TEMPLATE_DIR/containerd-config.toml /etc/eks/containerd/containerd-config.toml
+  sudo mv "${TEMPLATE_DIR}/containerd-config.toml" /etc/eks/containerd/containerd-config.toml
 fi
 
-sudo mv $TEMPLATE_DIR/kubelet-containerd.service /etc/eks/containerd/kubelet-containerd.service
-sudo mv $TEMPLATE_DIR/sandbox-image.service /etc/eks/containerd/sandbox-image.service
-sudo mv $TEMPLATE_DIR/pull-sandbox-image.sh /etc/eks/containerd/pull-sandbox-image.sh
-sudo mv $TEMPLATE_DIR/pull-image.sh /etc/eks/containerd/pull-image.sh
+sudo mv "${TEMPLATE_DIR}/kubelet-containerd.service" /etc/eks/containerd/kubelet-containerd.service
+sudo mv "${TEMPLATE_DIR}/sandbox-image.service" /etc/eks/containerd/sandbox-image.service
+sudo mv "${TEMPLATE_DIR}/pull-sandbox-image.sh" /etc/eks/containerd/pull-sandbox-image.sh
+sudo mv "${TEMPLATE_DIR}/pull-image.sh" /etc/eks/containerd/pull-image.sh
 sudo chmod +x /etc/eks/containerd/pull-sandbox-image.sh
 sudo chmod +x /etc/eks/containerd/pull-image.sh
 
@@ -194,26 +197,26 @@ EOF
 sudo yum install -y device-mapper-persistent-data lvm2
 
 if [[ ! -v "INSTALL_DOCKER" ]]; then
-  INSTALL_DOCKER=$(vercmp "$KUBERNETES_VERSION" lt "1.25.0" || true)
+  INSTALL_DOCKER=$(vercmp "${KUBERNETES_VERSION}" lt "1.25.0" || true)
 else
   echo "WARNING: using override INSTALL_DOCKER=${INSTALL_DOCKER}. This option is deprecated and will be removed in a future release."
 fi
 
-if [[ "$INSTALL_DOCKER" == "true" ]]; then
+if [[ "${INSTALL_DOCKER}" == "true" ]]; then
   sudo amazon-linux-extras enable docker
   sudo groupadd -og 1950 docker
-  sudo useradd --gid $(getent group docker | cut -d: -f3) docker
+  sudo useradd --gid "$(getent group docker | cut -d: -f3)" docker
 
   # install docker and lock version
-  sudo yum install -y docker-${DOCKER_VERSION}*
+  sudo yum install -y "docker-${DOCKER_VERSION}"*
   sudo yum versionlock docker-*
-  sudo usermod -aG docker $USER
+  sudo usermod -aG docker "${USER}"
 
   # Remove all options from sysconfig docker.
   sudo sed -i '/OPTIONS/d' /etc/sysconfig/docker
 
   sudo mkdir -p /etc/docker
-  sudo mv $TEMPLATE_DIR/docker-daemon.json /etc/docker/daemon.json
+  sudo mv "${TEMPLATE_DIR}/docker-daemon.json" /etc/docker/daemon.json
   sudo chown root:root /etc/docker/daemon.json
 
   # Enable docker daemon to start on boot.
@@ -226,8 +229,8 @@ fi
 
 # kubelet uses journald which has built-in rotation and capped size.
 # See man 5 journald.conf
-sudo mv $TEMPLATE_DIR/logrotate-kube-proxy /etc/logrotate.d/kube-proxy
-sudo mv $TEMPLATE_DIR/logrotate.conf /etc/logrotate.conf
+sudo mv "${TEMPLATE_DIR}/logrotate-kube-proxy" /etc/logrotate.d/kube-proxy
+sudo mv "${TEMPLATE_DIR}/logrotate.conf" /etc/logrotate.conf
 sudo chown root:root /etc/logrotate.d/kube-proxy
 sudo chown root:root /etc/logrotate.conf
 sudo mkdir -p /var/log/journal
@@ -241,61 +244,60 @@ sudo mkdir -p /var/lib/kubernetes
 sudo mkdir -p /var/lib/kubelet
 sudo mkdir -p /opt/cni/bin
 
-echo "Downloading binaries from: s3://$BINARY_BUCKET_NAME"
+echo "Downloading binaries from: s3://${BINARY_BUCKET_NAME}"
 S3_DOMAIN="amazonaws.com"
-if [ "$BINARY_BUCKET_REGION" = "cn-north-1" ] || [ "$BINARY_BUCKET_REGION" = "cn-northwest-1" ]; then
+if [ "${BINARY_BUCKET_REGION}" = "cn-north-1" ] || [ "${BINARY_BUCKET_REGION}" = "cn-northwest-1" ]; then
   S3_DOMAIN="amazonaws.com.cn"
-elif [ "$BINARY_BUCKET_REGION" = "us-iso-east-1" ]; then
+elif [ "${BINARY_BUCKET_REGION}" = "us-iso-east-1" ]; then
   S3_DOMAIN="c2s.ic.gov"
-elif [ "$BINARY_BUCKET_REGION" = "us-isob-east-1" ]; then
+elif [ "${BINARY_BUCKET_REGION}" = "us-isob-east-1" ]; then
   S3_DOMAIN="sc2s.sgov.gov"
 fi
-S3_URL_BASE="https://$BINARY_BUCKET_NAME.s3.$BINARY_BUCKET_REGION.$S3_DOMAIN/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
-S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
+S3_URL_BASE="https://${BINARY_BUCKET_NAME}.s3.${BINARY_BUCKET_REGION}.${S3_DOMAIN}/${KUBERNETES_VERSION}/${KUBERNETES_BUILD_DATE}/bin/linux/${ARCH}"
+S3_PATH="s3://${BINARY_BUCKET_NAME}/${KUBERNETES_VERSION}/${KUBERNETES_BUILD_DATE}/bin/linux/${ARCH}"
 
 BINARIES=(
   kubelet
   aws-iam-authenticator
 )
-for binary in ${BINARIES[*]}; do
-  if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+for binary in "${BINARIES[@]}"; do
+  if [[ -n "${AWS_ACCESS_KEY_ID}" ]]; then
     echo "AWS cli present - using it to copy binaries from s3."
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
+    aws s3 cp --region "${BINARY_BUCKET_REGION}" "${S3_PATH}/${binary}" .
+    aws s3 cp --region "${BINARY_BUCKET_REGION}" "${S3_PATH}/${binary}.sha256" .
   else
     echo "AWS cli missing - using wget to fetch binaries from s3. Note: This won't work for private bucket."
-    sudo wget $S3_URL_BASE/$binary
-    sudo wget $S3_URL_BASE/$binary.sha256
+    sudo wget "${S3_URL_BASE}/${binary}"
+    sudo wget "${S3_URL_BASE}/${binary}.sha256"
   fi
-  sudo sha256sum -c $binary.sha256
-  sudo chmod +x $binary
-  sudo mv $binary /usr/bin/
+  sudo sha256sum -c "${binary}.sha256"
+  sudo chmod +x "${binary}"
+  sudo mv "${binary}" /usr/bin/
 done
 
 # Verify that the aws-iam-authenticator is at last v0.5.9 or greater. Otherwise, nodes will be
 # unable to join clusters due to upgrading to client.authentication.k8s.io/v1beta1
 iam_auth_version=$(sudo /usr/bin/aws-iam-authenticator version | jq -r .Version)
-if vercmp "$iam_auth_version" lt "v0.5.9"; then
+if vercmp "${iam_auth_version}" lt "v0.5.9"; then
   # To resolve this issue, you need to update the aws-iam-authenticator binary. Using binaries distributed by EKS
   # with kubernetes_build_date 2022-10-31 or later include v0.5.10 or greater.
-  echo "❌ The aws-iam-authenticator should be on version v0.5.9 or later. Found $iam_auth_version"
+  echo "❌ The aws-iam-authenticator should be on version v0.5.9 or later. Found ${iam_auth_version}"
   exit 1
 fi
 
 # Since CNI 0.7.0, all releases are done in the plugins repo.
 CNI_PLUGIN_FILENAME="cni-plugins-linux-${ARCH}-${CNI_PLUGIN_VERSION}"
 
-if [ "$PULL_CNI_FROM_GITHUB" = "true" ]; then
+if [ "${PULL_CNI_FROM_GITHUB}" = "true" ]; then
   echo "Downloading CNI plugins from Github"
   wget "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/${CNI_PLUGIN_FILENAME}.tgz"
   wget "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/${CNI_PLUGIN_FILENAME}.tgz.sha512"
   sudo sha512sum -c "${CNI_PLUGIN_FILENAME}.tgz.sha512"
-  rm "${CNI_PLUGIN_FILENAME}.tgz.sha512"
 else
-  if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+  if [[ -n "${AWS_ACCESS_KEY_ID}" ]]; then
     echo "AWS cli present - using it to copy binaries from s3."
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz .
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz.sha256 .
+    aws s3 cp --region "${BINARY_BUCKET_REGION}" "${S3_PATH}/${CNI_PLUGIN_FILENAME}.tgz" .
+    aws s3 cp --region "${BINARY_BUCKET_REGION}" "${S3_PATH}/${CNI_PLUGIN_FILENAME}.tgz.sha256" .
   else
     echo "AWS cli missing - using wget to fetch cni binaries from s3. Note: This won't work for private bucket."
     sudo wget "$S3_URL_BASE/${CNI_PLUGIN_FILENAME}.tgz"
@@ -306,23 +308,23 @@ fi
 sudo tar -xvf "${CNI_PLUGIN_FILENAME}.tgz" -C /opt/cni/bin
 rm "${CNI_PLUGIN_FILENAME}.tgz"
 
-sudo rm ./*.sha256
+sudo rm ./*.sha256 ./*.sha512
 
 sudo mkdir -p /etc/kubernetes/kubelet
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
-sudo mv $TEMPLATE_DIR/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
+sudo mv "${TEMPLATE_DIR}/kubelet-kubeconfig" /var/lib/kubelet/kubeconfig
 sudo chown root:root /var/lib/kubelet/kubeconfig
 
 # Inject CSIServiceAccountToken feature gate to kubelet config if kubernetes version starts with 1.20.
 # This is only injected for 1.20 since CSIServiceAccountToken will be moved to beta starting 1.21.
-if [[ $KUBERNETES_VERSION == "1.20"* ]]; then
-  KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED=$(cat $TEMPLATE_DIR/kubelet-config.json | jq '.featureGates += {CSIServiceAccountToken: true}')
-  echo $KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED > $TEMPLATE_DIR/kubelet-config.json
+if [[ "${KUBERNETES_VERSION}" == "1.20"* ]]; then
+  KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED=$(jq '.featureGates += {CSIServiceAccountToken: true}' "${TEMPLATE_DIR}/kubelet-config.json")
+  echo "$KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED" > "${TEMPLATE_DIR}/kubelet-config.json"
 fi
 
-sudo mv $TEMPLATE_DIR/kubelet.service /etc/systemd/system/kubelet.service
+sudo mv "${TEMPLATE_DIR}/kubelet.service" /etc/systemd/system/kubelet.service
 sudo chown root:root /etc/systemd/system/kubelet.service
-sudo mv $TEMPLATE_DIR/kubelet-config.json /etc/kubernetes/kubelet/kubelet-config.json
+sudo mv "${TEMPLATE_DIR}/kubelet-config.json" /etc/kubernetes/kubelet/kubelet-config.json
 sudo chown root:root /etc/kubernetes/kubelet/kubelet-config.json
 
 sudo systemctl daemon-reload
@@ -334,45 +336,45 @@ sudo systemctl disable kubelet
 ################################################################################
 
 sudo mkdir -p /etc/eks
-sudo mv $TEMPLATE_DIR/get-ecr-uri.sh /etc/eks/get-ecr-uri.sh
+sudo mv "${TEMPLATE_DIR}/get-ecr-uri.sh" /etc/eks/get-ecr-uri.sh
 sudo chmod +x /etc/eks/get-ecr-uri.sh
-sudo mv $TEMPLATE_DIR/eni-max-pods.txt /etc/eks/eni-max-pods.txt
-sudo mv $TEMPLATE_DIR/bootstrap.sh /etc/eks/bootstrap.sh
+sudo mv "${TEMPLATE_DIR}/eni-max-pods.txt" /etc/eks/eni-max-pods.txt
+sudo mv "${TEMPLATE_DIR}/bootstrap.sh" /etc/eks/bootstrap.sh
 sudo chmod +x /etc/eks/bootstrap.sh
-sudo mv $TEMPLATE_DIR/max-pods-calculator.sh /etc/eks/max-pods-calculator.sh
+sudo mv "${TEMPLATE_DIR}/max-pods-calculator.sh" /etc/eks/max-pods-calculator.sh
 sudo chmod +x /etc/eks/max-pods-calculator.sh
 
 SONOBUOY_E2E_REGISTRY="${SONOBUOY_E2E_REGISTRY:-}"
-if [[ -n "$SONOBUOY_E2E_REGISTRY" ]]; then
-  sudo mv $TEMPLATE_DIR/sonobuoy-e2e-registry-config /etc/eks/sonobuoy-e2e-registry-config
-  sudo sed -i s,SONOBUOY_E2E_REGISTRY,$SONOBUOY_E2E_REGISTRY,g /etc/eks/sonobuoy-e2e-registry-config
+if [[ -n "${SONOBUOY_E2E_REGISTRY}" ]]; then
+  sudo mv "${TEMPLATE_DIR}/sonobuoy-e2e-registry-config" /etc/eks/sonobuoy-e2e-registry-config
+  sudo sed -i "s,SONOBUOY_E2E_REGISTRY,${SONOBUOY_E2E_REGISTRY},g" /etc/eks/sonobuoy-e2e-registry-config
 fi
 
 ################################################################################
 ### ECR CREDENTIAL PROVIDER ####################################################
 ################################################################################
 ECR_CREDENTIAL_PROVIDER_BINARY="ecr-credential-provider"
-if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+if [[ -n "${AWS_ACCESS_KEY_ID}" ]]; then
   echo "AWS cli present - using it to copy ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3."
-  aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .
+  aws s3 cp --region "${BINARY_BUCKET_REGION}" "${S3_PATH}/${ECR_CREDENTIAL_PROVIDER_BINARY}" .
 else
   echo "AWS cli missing - using wget to fetch ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3. Note: This won't work for private bucket."
-  sudo wget "$S3_URL_BASE/$ECR_CREDENTIAL_PROVIDER_BINARY"
+  sudo wget "${S3_URL_BASE}/${ECR_CREDENTIAL_PROVIDER_BINARY}"
 fi
-sudo chmod +x $ECR_CREDENTIAL_PROVIDER_BINARY
+sudo chmod +x "${ECR_CREDENTIAL_PROVIDER_BINARY}"
 sudo mkdir -p /etc/eks/image-credential-provider
-sudo mv $ECR_CREDENTIAL_PROVIDER_BINARY /etc/eks/image-credential-provider/
-sudo mv $TEMPLATE_DIR/ecr-credential-provider-config.json /etc/eks/image-credential-provider/config.json
+sudo mv "${ECR_CREDENTIAL_PROVIDER_BINARY}" /etc/eks/image-credential-provider/
+sudo mv "${TEMPLATE_DIR}/ecr-credential-provider-config.json" /etc/eks/image-credential-provider/config.json
 
 ################################################################################
 ### Cache Images ###############################################################
 ################################################################################
-if [[ "$CACHE_CONTAINER_IMAGES" == "true" && "$BINARY_BUCKET_REGION" != "us-iso-east-1" && "$BINARY_BUCKET_REGION" != "us-isob-east-1" ]]; then
+if [[ "${CACHE_CONTAINER_IMAGES}" == "true" && "${BINARY_BUCKET_REGION}" != "us-iso-east-1" && "${BINARY_BUCKET_REGION}" != "us-isob-east-1" ]]; then
   AWS_DOMAIN=$(imds 'latest/meta-data/services/domain')
   ECR_URI=$(/etc/eks/get-ecr-uri.sh "${BINARY_BUCKET_REGION}" "${AWS_DOMAIN}")
 
   PAUSE_CONTAINER="${ECR_URI}/eks/pause:${PAUSE_CONTAINER_VERSION}"
-  cat /etc/eks/containerd/containerd-config.toml | sed s,SANDBOX_IMAGE,$PAUSE_CONTAINER,g | sudo tee /etc/eks/containerd/containerd-cached-pause-config.toml
+  sed "s,SANDBOX_IMAGE,${PAUSE_CONTAINER},g" /etc/eks/containerd/containerd-config.toml | sudo tee /etc/eks/containerd/containerd-cached-pause-config.toml
   sudo cp -v /etc/eks/containerd/containerd-cached-pause-config.toml /etc/containerd/config.toml
   sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service
   sudo chown root:root /etc/systemd/system/sandbox-image.service
@@ -383,9 +385,9 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" && "$BINARY_BUCKET_REGION" != "us-iso-
   K8S_MINOR_VERSION=$(echo "${KUBERNETES_VERSION}" | cut -d'.' -f1-2)
 
   #### Cache kube-proxy images starting with the addon default version and the latest version
-  KUBE_PROXY_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name kube-proxy --kubernetes-version=${K8S_MINOR_VERSION})
+  KUBE_PROXY_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name kube-proxy --kubernetes-version="${K8S_MINOR_VERSION}")
   KUBE_PROXY_IMGS=()
-  if [[ $(jq '.addons | length' <<< $KUBE_PROXY_ADDON_VERSIONS) -gt 0 ]]; then
+  if [[ $(jq '.addons | length' <<< "${KUBE_PROXY_ADDON_VERSIONS}") -gt 0 ]]; then
     DEFAULT_KUBE_PROXY_FULL_VERSION=$(echo "${KUBE_PROXY_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] | select(.compatibilities[] .defaultVersion==true).addonVersion')
     DEFAULT_KUBE_PROXY_VERSION=$(echo "${DEFAULT_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f1)
     DEFAULT_KUBE_PROXY_PLATFORM_VERSION=$(echo "${DEFAULT_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f2)
@@ -406,9 +408,9 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" && "$BINARY_BUCKET_REGION" != "us-iso-
   fi
 
   #### Cache VPC CNI images starting with the addon default version and the latest version
-  VPC_CNI_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name vpc-cni --kubernetes-version=${K8S_MINOR_VERSION})
+  VPC_CNI_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name vpc-cni --kubernetes-version="${K8S_MINOR_VERSION}")
   VPC_CNI_IMGS=()
-  if [[ $(jq '.addons | length' <<< $VPC_CNI_ADDON_VERSIONS) -gt 0 ]]; then
+  if [[ $(jq '.addons | length' <<< "${VPC_CNI_ADDON_VERSIONS}") -gt 0 ]]; then
     DEFAULT_VPC_CNI_VERSION=$(echo "${VPC_CNI_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] | select(.compatibilities[] .defaultVersion==true).addonVersion')
     LATEST_VPC_CNI_VERSION=$(echo "${VPC_CNI_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] .addonVersion' | sort -V | tail -n1)
     CNI_IMG="${ECR_URI}/amazon-k8s-cni"
@@ -457,7 +459,7 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" && "$BINARY_BUCKET_REGION" != "us-iso-
   #### Tag the pulled down image for all other regions in the partition
   for region in $(aws ec2 describe-regions --all-regions | jq -r '.Regions[] .RegionName'); do
     for img in "${PULLED_IMGS[@]}"; do
-      regional_img="${img/$BINARY_BUCKET_REGION/$region}"
+      regional_img="${img/${BINARY_BUCKET_REGION}/${region}}"
       sudo ctr -n k8s.io image tag "${img}" "${regional_img}" || :
       ## Tag ECR fips endpoint for supported regions
       if [[ "${region}" =~ (us-east-1|us-east-2|us-west-1|us-west-2|us-gov-east-1|us-gov-east-2) ]]; then
@@ -485,7 +487,7 @@ sudo yum install -y amazon-ssm-agent
 
 BASE_AMI_ID=$(imds /latest/meta-data/ami-id)
 cat << EOF > /tmp/release
-BASE_AMI_ID="$BASE_AMI_ID"
+BASE_AMI_ID="${BASE_AMI_ID}"
 BUILD_TIME="$(date)"
 BUILD_KERNEL="$(uname -r)"
 ARCH="$(uname -m)"
@@ -515,7 +517,7 @@ echo vm.max_map_count=524288 | sudo tee -a /etc/sysctl.conf
 ### adding log-collector-script ################################################
 ################################################################################
 sudo mkdir -p /etc/eks/log-collector-script/
-sudo cp $TEMPLATE_DIR/log-collector-script/eks-log-collector.sh /etc/eks/log-collector-script/
+sudo cp "${TEMPLATE_DIR}/log-collector-script/eks-log-collector.sh" /etc/eks/log-collector-script/
 
 ################################################################################
 ### Remove Yum Update from cloud-init config ###################################

--- a/scripts/install_additional_repos.sh
+++ b/scripts/install_additional_repos.sh
@@ -33,4 +33,4 @@ BEGIN {RS=";";FS=","}
 {print "baseurl="vars["baseurl"] > Repo}
 {if (length(vars["priority"]) != 0) print "priority="vars["priority"] > Repo}
 '
-sudo awk "$AWK_CMD" <<< "${ADDITIONAL_YUM_REPOS}"
+sudo awk "${AWK_CMD}" <<< "${ADDITIONAL_YUM_REPOS}"

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -4,16 +4,16 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
-if [[ -z "$KERNEL_VERSION" ]]; then
-  if vercmp "$KUBERNETES_VERSION" gteq "1.24.0"; then
+if [[ -z "${KERNEL_VERSION}" ]]; then
+  if vercmp "${KUBERNETES_VERSION}" gteq "1.24.0"; then
     KERNEL_VERSION=5.10
   else
     KERNEL_VERSION=5.4
   fi
-  echo "kernel_version is unset. Setting to $KERNEL_VERSION based on Kubernetes version $KUBERNETES_VERSION."
+  echo "kernel_version is unset. Setting to ${KERNEL_VERSION} based on Kubernetes version ${KUBERNETES_VERSION}."
 fi
 
-if [[ $KERNEL_VERSION == "4.14" ]]; then
+if [[ "${KERNEL_VERSION}" == "4.14" ]]; then
   sudo yum update -y kernel
 else
   sudo amazon-linux-extras install -y "kernel-${KERNEL_VERSION}"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -10,8 +10,8 @@
 #   1 if a file exists, after printing an error
 validate_file_nonexists() {
   local file_blob=$1
-  for f in $file_blob; do
-    if [ -e "$f" ]; then
+  for f in ${file_blob}; do
+    if [ -e "${f}" ]; then
       echo "$f shouldn't exists"
       exit 1
     fi
@@ -36,9 +36,9 @@ validate_file_nonexists '/var/log/secure'
 validate_file_nonexists '/var/log/wtmp'
 
 actual_kernel=$(uname -r)
-echo "Verifying that kernel version $actual_kernel matches $KERNEL_VERSION..."
+echo "Verifying that kernel version ${actual_kernel} matches ${KERNEL_VERSION}..."
 
-if [[ $actual_kernel == $KERNEL_VERSION* ]]; then
+if [[ ${actual_kernel} == ${KERNEL_VERSION}* ]]; then
   echo "Kernel matches expected version!"
 else
   echo "Kernel does not match expected version!"
@@ -59,15 +59,15 @@ function versionlock-packages() {
 }
 
 for ENTRY in $(versionlock-entries); do
-  if ! rpm --query "$ENTRY" &> /dev/null; then
-    echo "There is no package matching the versionlock entry: '$ENTRY'"
+  if ! rpm --query "${ENTRY}" &> /dev/null; then
+    echo "There is no package matching the versionlock entry: '${ENTRY}'"
     exit 1
   fi
 done
 
 LOCKED_PACKAGES=$(versionlock-packages | wc -l)
 UNIQUE_LOCKED_PACKAGES=$(versionlock-packages | sort -u | wc -l)
-if [ $LOCKED_PACKAGES -ne $UNIQUE_LOCKED_PACKAGES ]; then
+if [ ${LOCKED_PACKAGES} -ne ${UNIQUE_LOCKED_PACKAGES} ]; then
   echo "Package(s) have multiple version locks!"
   versionlock-entries
 fi

--- a/test/cases/api-qps-k8s-1.21-below.sh
+++ b/test/cases/api-qps-k8s-1.21-below.sh
@@ -20,12 +20,12 @@ expected_api_burst="null"
 
 actual_api_qps=$(jq -r '.kubeAPIQPS' < /etc/kubernetes/kubelet/kubelet-config.json)
 actual_api_burst=$(jq -r '.kubeAPIBurst' < /etc/kubernetes/kubelet/kubelet-config.json)
-if [[ ${actual_api_qps} != ${expected_api_qps} ]]; then
+if [[ "${actual_api_qps}" != "${expected_api_qps}" ]]; then
   echo "❌ Test Failed: expected kubeAPIQPS = '${expected_api_qps}' but got '${actual_api_qps}'"
   exit 1
 fi
 
-if [[ ${actual_api_burst} != ${expected_api_burst} ]]; then
+if [[ "${actual_api_burst}" != "${expected_api_burst}" ]]; then
   echo "❌ Test Failed: expected kubeAPIBurst = '${expected_api_burst}' but got '${actual_api_burst}'"
   exit 1
 fi

--- a/test/cases/api-qps-k8s-1.22-to-1.26.sh
+++ b/test/cases/api-qps-k8s-1.22-to-1.26.sh
@@ -19,12 +19,12 @@ expected_api_burst="20"
 
 actual_api_qps=$(jq -r '.kubeAPIQPS' < /etc/kubernetes/kubelet/kubelet-config.json)
 actual_api_burst=$(jq -r '.kubeAPIBurst' < /etc/kubernetes/kubelet/kubelet-config.json)
-if [[ ${actual_api_qps} != ${expected_api_qps} ]]; then
+if [[ "${actual_api_qps}" != "${expected_api_qps}" ]]; then
   echo "❌ Test Failed: expected kubeAPIQPS = '${expected_api_qps}' but got '${actual_api_qps}'"
   exit 1
 fi
 
-if [[ ${actual_api_burst} != ${expected_api_burst} ]]; then
+if [[ "${actual_api_burst}" != "${expected_api_burst}" ]]; then
   echo "❌ Test Failed: expected kubeAPIBurst = '${expected_api_burst}' but got '${actual_api_burst}'"
   exit 1
 fi
@@ -45,12 +45,12 @@ expected_api_burst="20"
 
 actual_api_qps=$(jq -r '.kubeAPIQPS' < /etc/kubernetes/kubelet/kubelet-config.json)
 actual_api_burst=$(jq -r '.kubeAPIBurst' < /etc/kubernetes/kubelet/kubelet-config.json)
-if [[ ${actual_api_qps} != ${expected_api_qps} ]]; then
+if [[ "${actual_api_qps}" != "${expected_api_qps}" ]]; then
   echo "❌ Test Failed: expected kubeAPIQPS = '${expected_api_qps}' but got '${actual_api_qps}'"
   exit 1
 fi
 
-if [[ ${actual_api_burst} != ${expected_api_burst} ]]; then
+if [[ "${actual_api_burst}" != "${expected_api_burst}" ]]; then
   echo "❌ Test Failed: expected kubeAPIBurst = '${expected_api_burst}' but got '${actual_api_burst}'"
   exit 1
 fi

--- a/test/cases/api-qps-k8s-1.27-above.sh
+++ b/test/cases/api-qps-k8s-1.27-above.sh
@@ -20,12 +20,12 @@ expected_api_burst="null"
 
 actual_api_qps=$(jq -r '.kubeAPIQPS' < /etc/kubernetes/kubelet/kubelet-config.json)
 actual_api_burst=$(jq -r '.kubeAPIBurst' < /etc/kubernetes/kubelet/kubelet-config.json)
-if [[ ${actual_api_qps} != ${expected_api_qps} ]]; then
+if [[ "${actual_api_qps}" != "${expected_api_qps}" ]]; then
   echo "❌ Test Failed: expected kubeAPIQPS = '${expected_api_qps}' but got '${actual_api_qps}'"
   exit 1
 fi
 
-if [[ ${actual_api_burst} != ${expected_api_burst} ]]; then
+if [[ "${actual_api_burst}" != "${expected_api_burst}" ]]; then
   echo "❌ Test Failed: expected kubeAPIBurst = '${expected_api_burst}' but got '${actual_api_burst}'"
   exit 1
 fi

--- a/test/cases/cloud-provider-config.sh
+++ b/test/cases/cloud-provider-config.sh
@@ -10,9 +10,9 @@ KUBELET_CONFIG_FILE="/etc/kubernetes/kubelet/kubelet-config.json"
 function fail() {
   echo "❌ Test Failed:" "$@"
   echo "Kubelet systemd units:"
-  find $KUBELET_UNIT_DIR -type f | xargs cat
+  find "${KUBELET_UNIT_DIR}" -type f | xargs cat
   echo "Kubelet config file:"
-  cat $KUBELET_CONFIG_FILE | jq '.'
+  cat "${KUBELET_CONFIG_FILE}" | jq '.'
   exit 1
 }
 
@@ -30,13 +30,13 @@ if [[ ${EXIT_CODE} -ne 0 ]]; then
   fail "expected a zero exit code but got '${EXIT_CODE}'"
 fi
 EXIT_CODE=0
-grep -RFq -e "--cloud-provider=aws" $KUBELET_UNIT_DIR || EXIT_CODE=$?
+grep -RFq -e "--cloud-provider=aws" ${KUBELET_UNIT_DIR} || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   fail "expected --cloud-provider=aws to be present in kubelet's systemd units"
 fi
-ACTUAL_PROVIDER_ID=$(jq -r '.providerID' $KUBELET_CONFIG_FILE)
-if [ ! "$ACTUAL_PROVIDER_ID" = "null" ]; then
-  fail "expected .providerID to be absent in kubelet's config file but was '$ACTUAL_PROVIDER_ID'"
+ACTUAL_PROVIDER_ID=$(jq -r '.providerID' "${KUBELET_CONFIG_FILE}")
+if [ ! "${ACTUAL_PROVIDER_ID}" = "null" ]; then
+  fail "expected .providerID to be absent in kubelet's config file but was '${ACTUAL_PROVIDER_ID}'"
 fi
 
 echo "--> Should use external cloud provider at k8s version 1.26"
@@ -51,13 +51,13 @@ if [[ ${EXIT_CODE} -ne 0 ]]; then
   fail "expected a zero exit code but got '${EXIT_CODE}'"
 fi
 EXIT_CODE=0
-grep -RFq -e "--cloud-provider=external" $KUBELET_UNIT_DIR || EXIT_CODE=$?
+grep -RFq -e "--cloud-provider=external" "${KUBELET_UNIT_DIR}" || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   fail "expected --cloud-provider=external to be present in kubelet's systemd units"
 fi
-ACTUAL_PROVIDER_ID=$(jq -r '.providerID' $KUBELET_CONFIG_FILE)
-if [ ! "$ACTUAL_PROVIDER_ID" = "$EXPECTED_PROVIDER_ID" ]; then
-  fail "expected .providerID=$EXPECTED_PROVIDER_ID to be present in kubelet's config file but was '$ACTUAL_PROVIDER_ID'"
+ACTUAL_PROVIDER_ID=$(jq -r '.providerID' "${KUBELET_CONFIG_FILE}")
+if [ ! "${ACTUAL_PROVIDER_ID}" = "${EXPECTED_PROVIDER_ID}" ]; then
+  fail "expected .providerID=${EXPECTED_PROVIDER_ID} to be present in kubelet's config file but was '${ACTUAL_PROVIDER_ID}'"
 fi
 
 echo "--> Should use external cloud provider above k8s version 1.26"
@@ -72,11 +72,11 @@ if [[ ${EXIT_CODE} -ne 0 ]]; then
   fail "expected a zero exit code but got '${EXIT_CODE}'"
 fi
 EXIT_CODE=0
-grep -RFq -e "--cloud-provider=external" $KUBELET_UNIT_DIR || EXIT_CODE=$?
+grep -RFq -e "--cloud-provider=external" "${KUBELET_UNIT_DIR}" || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   fail "expected --cloud-provider=external to be present in kubelet's systemd units"
 fi
-ACTUAL_PROVIDER_ID=$(jq -r '.providerID' $KUBELET_CONFIG_FILE)
-if [ ! "$ACTUAL_PROVIDER_ID" = "$EXPECTED_PROVIDER_ID" ]; then
-  fail "expected .providerID=$EXPECTED_PROVIDER_ID to be present in kubelet's config file but was '$ACTUAL_PROVIDER_ID"
+ACTUAL_PROVIDER_ID=$(jq -r '.providerID' "${KUBELET_CONFIG_FILE}")
+if [ ! "${ACTUAL_PROVIDER_ID}" = "${EXPECTED_PROVIDER_ID}" ]; then
+  fail "expected .providerID=${EXPECTED_PROVIDER_ID} to be present in kubelet's config file but was '${ACTUAL_PROVIDER_ID}"
 fi

--- a/test/cases/ecr-credential-provider-config.sh
+++ b/test/cases/ecr-credential-provider-config.sh
@@ -2,17 +2,16 @@
 set -euo pipefail
 
 exit_code=0
-TEMP_DIR=$(mktemp -d)
 
 export CRED_PROVIDER_FILE="/etc/eks/image-credential-provider/config.json"
 export CRED_PROVIDER_RESET_FILE="./cred-provider-config"
 
 # Store the original version of the config
-cp $CRED_PROVIDER_FILE $CRED_PROVIDER_RESET_FILE
+cp "${CRED_PROVIDER_FILE}" "${CRED_PROVIDER_RESET_FILE}"
 # Reset the file that may have changed
 function reset_scenario {
   echo "Resetting test scenario"
-  cp $CRED_PROVIDER_RESET_FILE $CRED_PROVIDER_FILE
+  cp "${CRED_PROVIDER_RESET_FILE}" "${CRED_PROVIDER_FILE}"
 }
 
 echo "--> Should default to credentialprovider.kubelet.k8s.io/v1alpha1 and kubelet.config.k8s.io/v1alpha1 when below k8s version 1.27"
@@ -31,16 +30,16 @@ if [[ ${exit_code} -ne 0 ]]; then
 fi
 
 expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1alpha1"
-actual=$(jq -r '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
-if [[ "$expected_cred_provider_api" != "$actual" ]]; then
-  echo "❌ Test Failed: expected 1.22 credential provider file to contain $expected_cred_provider_api"
+actual=$(jq -r '.providers[0].apiVersion' "${CRED_PROVIDER_FILE}")
+if [[ "${expected_cred_provider_api}" != "${actual}" ]]; then
+  echo "❌ Test Failed: expected 1.22 credential provider file to contain ${expected_cred_provider_api}"
   exit 1
 fi
 
 expected_kubelet_config_api="kubelet.config.k8s.io/v1alpha1"
-actual=$(jq -r '.apiVersion' $CRED_PROVIDER_FILE)
-if [[ "$expected_kubelet_config_api" != "$actual" ]]; then
-  echo "❌ Test Failed: expected 1.22 credential provider file to contain $expected_kubelet_config_api"
+actual=$(jq -r '.apiVersion' "${CRED_PROVIDER_FILE}")
+if [[ "${expected_cred_provider_api}" != "${actual}" ]]; then
+  echo "❌ Test Failed: expected 1.22 credential provider file to contain ${expected_kubelet_config_api}"
   exit 1
 fi
 
@@ -60,16 +59,16 @@ if [[ ${exit_code} -ne 0 ]]; then
 fi
 
 expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1alpha1"
-actual=$(jq -r '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
-if [[ "$expected_cred_provider_api" != "$actual" ]]; then
-  echo "❌ Test Failed: expected 1.26 credential provider file to contain $expected_cred_provider_api"
+actual=$(jq -r '.providers[0].apiVersion' "${CRED_PROVIDER_FILE}")
+if [[ "${expected_cred_provider_api}" != "${actual}" ]]; then
+  echo "❌ Test Failed: expected 1.26 credential provider file to contain ${expected_cred_provider_api}"
   exit 1
 fi
 
 expected_kubelet_config_api="kubelet.config.k8s.io/v1alpha1"
-actual=$(jq -r '.apiVersion' $CRED_PROVIDER_FILE)
-if [[ "$expected_kubelet_config_api" != "$actual" ]]; then
-  echo "❌ Test Failed: expected 1.26 credential provider file to contain $expected_kubelet_config_api"
+actual=$(jq -r '.apiVersion' "${CRED_PROVIDER_FILE}")
+if [[ "${expected_cred_provider_api}" != "${actual}" ]]; then
+  echo "❌ Test Failed: expected 1.26 credential provider file to contain ${expected_kubelet_config_api}"
   exit 1
 fi
 
@@ -88,15 +87,15 @@ if [[ ${exit_code} -ne 0 ]]; then
 fi
 
 expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1"
-actual=$(jq -r '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
-if [[ "$expected_cred_provider_api" != "$actual" ]]; then
-  echo "❌ Test Failed: expected 1.27 credential provider file to contain $expected_cred_provider_api"
+actual=$(jq -r '.providers[0].apiVersion' "${CRED_PROVIDER_FILE}")
+if [[ "${expected_cred_provider_api}" != "${actual}" ]]; then
+  echo "❌ Test Failed: expected 1.27 credential provider file to contain ${expected_cred_provider_api}"
   exit 1
 fi
 
 expected_kubelet_config_api="kubelet.config.k8s.io/v1"
-actual=$(jq -r '.apiVersion' $CRED_PROVIDER_FILE)
-if [[ "$expected_kubelet_config_api" != "$actual" ]]; then
-  echo "❌ Test Failed: expected 1.27 credential provider file to contain $expected_kubelet_config_api"
+actual=$(jq -r '.apiVersion' "${CRED_PROVIDER_FILE}")
+if [[ "${expected_cred_provider_api}" != "${actual}" ]]; then
+  echo "❌ Test Failed: expected 1.27 credential provider file to contain ${expected_kubelet_config_api}"
   exit 1
 fi

--- a/test/cases/ipv6-dns-cluster-ip-given-service-ipv6-cidr.sh
+++ b/test/cases/ipv6-dns-cluster-ip-given-service-ipv6-cidr.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 echo "-> Should return IPv6 DNS cluster IP when given service-ipv6-cidr"
 exit_code=0
-TEMP_DIR=$(mktemp -d)
+TEMP_DIR="$(mktemp -d)"
 /etc/eks/bootstrap.sh \
   --b64-cluster-ca dGVzdA== \
   --apiserver-endpoint http://my-api-endpoint \

--- a/test/cases/mount-bpf-fs.sh
+++ b/test/cases/mount-bpf-fs.sh
@@ -14,7 +14,7 @@ export -f mount
 EXIT_CODE=0
 mount-bpf-fs || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
-  echo "❌ Test Failed: expected a zero exit code but got: $EXIT_CODE"
+  echo "❌ Test Failed: expected a zero exit code but got: ${EXIT_CODE}"
   exit 1
 fi
 export -nf mount
@@ -27,7 +27,7 @@ export -f mount
 EXIT_CODE=0
 mount-bpf-fs || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
-  echo "❌ Test Failed: expected a zero exit code but got: $EXIT_CODE"
+  echo "❌ Test Failed: expected a zero exit code but got: ${EXIT_CODE}"
   exit 1
 fi
 export -nf mount
@@ -38,12 +38,12 @@ function mount() {
 }
 export -f mount
 SYSTEMD_UNIT=/etc/systemd/system/sys-fs-bpf.mount
-mkdir -p $(dirname $SYSTEMD_UNIT)
-echo "foo" > $SYSTEMD_UNIT
+mkdir -p "$(dirname "${SYSTEMD_UNIT}")"
+echo "foo" > "${SYSTEMD_UNIT}"
 EXIT_CODE=0
 mount-bpf-fs || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
-  echo "❌ Test Failed: expected a zero exit code but got: $EXIT_CODE"
+  echo "❌ Test Failed: expected a zero exit code but got: ${EXIT_CODE}"
   exit 1
 fi
 export -nf mount
@@ -61,7 +61,7 @@ EXIT_CODE=0
 /etc/eks/bootstrap.sh \
   --b64-cluster-ca dGVzdA== \
   --apiserver-endpoint http://my-api-endpoint \
-  test || exit_code=$?
+  test || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
   exit 1
@@ -84,12 +84,13 @@ EXIT_CODE=0
 /etc/eks/bootstrap.sh \
   --b64-cluster-ca dGVzdA== \
   --apiserver-endpoint http://my-api-endpoint \
-  test || exit_code=$?
+  test || EXIT_CODE=$?
+
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
   exit 1
 fi
-if [ "$(cat $MOUNT_BPF_FS_MOCK)" = "called" ]; then
+if [ "$(cat ${MOUNT_BPF_FS_MOCK})" = "called" ]; then
   echo "❌ Test Failed: expected mount-bpf-fs to not be called but it was!"
   exit 1
 fi

--- a/test/cases/provider-id.sh
+++ b/test/cases/provider-id.sh
@@ -7,16 +7,16 @@ set -o pipefail
 echo "--> Should fetch imds details correctly"
 EXPECTED_INSTANCE_ID="i-1234567890abcdef0"
 EXPECTED_AVAILABILITY_ZONE="us-east-1a"
-EXPECTED_PROVIDER_ID="aws:///$EXPECTED_AVAILABILITY_ZONE/$EXPECTED_INSTANCE_ID"
+EXPECTED_PROVIDER_ID="aws:///${EXPECTED_AVAILABILITY_ZONE}/${EXPECTED_INSTANCE_ID}"
 PROVIDER_ID=$(provider-id)
-if [ ! "$PROVIDER_ID" = "$EXPECTED_PROVIDER_ID" ]; then
-  echo "❌ Test Failed: expected provider-id=$EXPECTED_PROVIDER_ID but got '${PROVIDER_ID}'"
+if [ ! "${PROVIDER_ID}" = "${EXPECTED_PROVIDER_ID}" ]; then
+  echo "❌ Test Failed: expected provider-id=${EXPECTED_PROVIDER_ID} but got '${PROVIDER_ID}'"
   exit 1
 fi
 
 echo "--> Should fail when imds is unreachable"
 echo '#!/usr/bin/sh
-exit 1' > $(which imds)
+exit 1' > "$(which imds)"
 EXIT_CODE=0
 provider-id || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -eq 0 ]]; then

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPTPATH="$(
-  cd "$(dirname "$0")"
+  cd "$(dirname "${0}")"
   pwd -P
 )"
 

--- a/test/test-harness.sh
+++ b/test/test-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export SCRIPTPATH="$(
-  cd "$(dirname "$0")"
+  cd "$(dirname "${0}")"
   pwd -P
 )"
 set -euo pipefail
@@ -21,14 +21,14 @@ EOM
 while getopts "c:h" opt; do
   case ${opt} in
     c) # Case Script Path
-      TEST_CASE_SCRIPT="$OPTARG"
+      TEST_CASE_SCRIPT="${OPTARG}"
       ;;
     h) # help
-      echo "$USAGE" 1>&2
+      echo "${USAGE}" 1>&2
       exit
       ;;
     \?)
-      echo "$USAGE" 1>&2
+      echo "${USAGE}" 1>&2
       exit
       ;;
   esac
@@ -37,32 +37,32 @@ done
 docker build -t eks-optimized-ami -f "${SCRIPTPATH}/Dockerfile" "${SCRIPTPATH}/../"
 overall_status=0
 
-test_run_log_file=$(mktemp)
+test_run_log_file="$(mktemp)"
 
 function run() {
-  docker run -v "$(realpath $1):/test.sh" \
+  docker run -v "$(realpath "${1}"):/test.sh" \
     --attach STDOUT \
     --attach STDERR \
     --rm \
-    eks-optimized-ami > $test_run_log_file 2>&1
+    eks-optimized-ami > "${test_run_log_file}" 2>&1
 }
 
-if [[ ! -z ${TEST_CASE_SCRIPT} ]]; then
+if [[ -n ${TEST_CASE_SCRIPT} ]]; then
   test_cases=${TEST_CASE_SCRIPT}
 else
-  test_cases=($(find ${SCRIPTPATH}/cases -name "*.sh" -type f))
+  test_cases=($(find "${SCRIPTPATH}/cases" -name "*.sh" -type f))
 fi
 
 for case in "${test_cases[@]}"; do
   status=0
   echo "================================================================================================================="
-  echo "-> Executing Test Case: $(basename ${case})"
+  echo "-> Executing Test Case: $(basename "${case}")"
   run ${case} || status=1
   if [[ ${status} -eq 0 ]]; then
-    echo "✅ ✅ $(basename ${case}) Tests Passed! ✅ ✅"
+    echo "✅ ✅ $(basename "${case}") Tests Passed! ✅ ✅"
   else
-    cat $test_run_log_file
-    echo "❌ ❌ $(basename ${case}) Tests Failed! ❌ ❌"
+    cat "${test_run_log_file}"
+    echo "❌ ❌ $(basename "${case}") Tests Failed! ❌ ❌"
     overall_status=1
   fi
   echo "================================================================================================================="
@@ -73,4 +73,4 @@ if [[ ${overall_status} -eq 0 ]]; then
 else
   echo "❌ ❌ Some Tests Failed! ❌ ❌"
 fi
-exit $overall_status
+exit ${overall_status}


### PR DESCRIPTION
**Issue #, if available:**

`n/a`

**Description of changes:**

Currently `--severity` for `shellcheck` is set to `error` which may skip common word split issues, scripts under "./scripts" directory is relative more important for building AMI, would better to have check SC2046, SC2068, SC2086.

### References:
- https://github.com/koalaman/shellcheck/wiki/SC2046
- https://github.com/koalaman/shellcheck/wiki/SC2068
- https://github.com/koalaman/shellcheck/wiki/SC2086

**Testing Results**

### AMI Build

```bash
...

--> amazon-ebs: AMIs were created:
us-east-1: ami-01234567890123456
```

### Launch Test

```bash
% kubectl get nodes ip-192-168-94-246.ec2.internal -o json | jq '.metadata.labels."eks.amazonaws.com/nodegroup-image"'
"ami-01234567890123456"
```

```bash
% kubectl get nodes ip-192-168-94-246.ec2.internal -o json | jq '.status.conditions[] | select(.type == "Ready")'
{
  "lastHeartbeatTime": "2023-04-01T11:12:18Z",
  "lastTransitionTime": "2023-04-01T10:56:38Z",
  "message": "kubelet is posting ready status",
  "reason": "KubeletReady",
  "status": "True",
  "type": "Ready"
}
```