### PR TITLE
Install latest containerd 1.6.x

### DIFF
--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -13,7 +13,7 @@
     "binary_bucket_region": "us-west-2",
     "cache_container_images": "false",    
     "cni_plugin_version": "v0.8.6",
-    "containerd_version": "1.6.6-1.amzn2.0.2",
+    "containerd_version": "1.6.*",
     "creator": "{{env `USER`}}",
     "docker_version": "20.10.17-1.amzn2.0.1",
     "encrypted": "false",


### PR DESCRIPTION
**Description of changes:**

The `containerd_version` pattern needs to be updated for every single patch release of the package. We can instead use a broader pattern to pull in updates without a PR here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

This installs the latest version of the package (`1.6.8-2.amzn2.0.1 ` at the time of writing):
```
sudo yum install "containerd-1.6.*"
```

And:
```
make 1.25
...
Installing:
  containerd     x86_64     1.6.8-2.amzn2.0.1        amzn2extra-docker      27 M
```