### PR TITLE
Remove --container-runtime kubelet flag for 1.27+

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -21,7 +21,7 @@ function print_help {
   echo "--aws-api-retry-attempts Number of retry attempts for AWS API call (DescribeCluster) (default: 3)"
   echo "--b64-cluster-ca The base64 encoded cluster CA content. Only valid when used with --apiserver-endpoint. Bypasses calling \"aws eks describe-cluster\""
   echo "--cluster-id Specify the id of EKS cluster"
-  echo "--container-runtime Specify a container runtime (default: dockerd)"
+  echo "--container-runtime Specify a container runtime. For Kubernetes 1.23 and below, possible values are [dockerd, containerd] and the default value is dockerd. For Kubernetes 1.24 and above, containerd is the only valid value. This flag is deprecated and will be removed in a future release."
   echo "--containerd-config-file File containing the containerd configuration to be used in place of AMI defaults."
   echo "--dns-cluster-ip Overrides the IP address to use for DNS queries within the cluster. Defaults to 10.100.0.10 or 172.20.0.10 based on the IP address of the primary interface"
   echo "--docker-config-json The contents of the /etc/docker/daemon.json file. Useful if you want a custom config differing from the default one in the AMI"
@@ -542,6 +542,7 @@ if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
   sudo containerd config dump > /dev/null
 
   # --container-runtime flag is gone in 1.27+
+  # TODO: remove this when 1.26 is EOL
   if vercmp "$KUBELET_VERSION" lt "1.27.0"; then
     KUBELET_ARGS="$KUBELET_ARGS --container-runtime=remote"
   fi

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -191,8 +191,6 @@ if vercmp "$KUBELET_VERSION" lt "1.27.0"; then
 fi
 MOUNT_BPF_FS="${MOUNT_BPF_FS:-$DEFAULT_MOUNT_BPF_FS}"
 
-KUBELET_ARGS=""
-
 # Helper function which calculates the amount of the given resource (either CPU or memory)
 # to reserve in a given resource range, specified by a start and end of the range and a percentage
 # of the resource to reserve. Note that we return zero if the start of the resource range is

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -473,7 +473,7 @@ if [[ "$USE_MAX_PODS" = "true" ]]; then
   echo "$(jq ".maxPods=$MAX_PODS" $KUBELET_CONFIG)" > $KUBELET_CONFIG
 fi
 
-KUBELET_ARGS="$KUBELET_ARGS --node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER --v=2"
+KUBELET_ARGS="--node-ip=$INTERNAL_IP --pod-infra-container-image=$PAUSE_CONTAINER --v=2"
 
 if vercmp "$KUBELET_VERSION" lt "1.26.0"; then
   # TODO: remove this when 1.25 is EOL

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -542,7 +542,7 @@ if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
   sudo containerd config dump > /dev/null
 
   # --container-runtime flag is gone in 1.27+
-  if vercmp "${KUBELET_VERSION}" lt "1.27.0"; then
+  if vercmp "$KUBELET_VERSION" lt "1.27.0"; then
     KUBELET_ARGS="$KUBELET_ARGS --container-runtime=remote"
   fi
 elif [[ "$CONTAINER_RUNTIME" = "dockerd" ]]; then

--- a/files/kubelet-containerd.service
+++ b/files/kubelet-containerd.service
@@ -10,7 +10,6 @@ ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
 ExecStart=/usr/bin/kubelet \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
-    --container-runtime remote \
     --container-runtime-endpoint unix:///run/containerd/containerd.sock \
     --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \
     --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider \


### PR DESCRIPTION
**Description of changes:**

This flag is gone in 1.27, so it's removed in the default `systemd` service unit, and conditionally added back for 1.26-.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

TODO