### PR TITLE
Create KUBELET_ARGS dropin after configuration container runtime

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -485,6 +485,8 @@ fi
 
 KUBELET_ARGS="$KUBELET_ARGS --cloud-provider=$KUBELET_CLOUD_PROVIDER"
 
+mkdir -p /etc/systemd/system
+
 if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
   if $ENABLE_DOCKER_BRIDGE; then
     echo "WARNING: Flag --enable-docker-bridge was set but will be ignored as it's not relevant to containerd"

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -485,20 +485,6 @@ fi
 
 KUBELET_ARGS="$KUBELET_ARGS --cloud-provider=$KUBELET_CLOUD_PROVIDER"
 
-mkdir -p /etc/systemd/system/kubelet.service.d
-
-cat << EOF > /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf
-[Service]
-Environment='KUBELET_ARGS=$KUBELET_ARGS'
-EOF
-
-if [[ -n "$KUBELET_EXTRA_ARGS" ]]; then
-  cat << EOF > /etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf
-[Service]
-Environment='KUBELET_EXTRA_ARGS=$KUBELET_EXTRA_ARGS'
-EOF
-fi
-
 if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
   if $ENABLE_DOCKER_BRIDGE; then
     echo "WARNING: Flag --enable-docker-bridge was set but will be ignored as it's not relevant to containerd"
@@ -568,6 +554,21 @@ else
   exit 1
 fi
 
+mkdir -p /etc/systemd/system/kubelet.service.d
+
+cat << EOF > /etc/systemd/system/kubelet.service.d/10-kubelet-args.conf
+[Service]
+Environment='KUBELET_ARGS=$KUBELET_ARGS'
+EOF
+
+if [[ -n "$KUBELET_EXTRA_ARGS" ]]; then
+  cat << EOF > /etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf
+[Service]
+Environment='KUBELET_EXTRA_ARGS=$KUBELET_EXTRA_ARGS'
+EOF
+fi
+
+systemctl daemon-reload
 systemctl enable kubelet
 systemctl start kubelet
 


### PR DESCRIPTION
**Issue #, if available:**

Fixes an issue introduced in #1250. Line numbers are hard 🙃 

**Description of changes:**

The previous PR appended `--container-runtime=remote` *after* we had created the dropin `systemd` unit that contains the value of `KUBELET_ARGS`. This PR moves the creation of those units until immediately before `kubelet` is started.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

```
make 1.23
```

Created a managed nodegroup with the resulting AMI and the nodes became `Ready` as expected.