### PR TITLE
Disable kernel TCP slow start threshold metrics

### DIFF
--- a/files/sysctl.conf
+++ b/files/sysctl.conf
@@ -1,0 +1,1 @@
+net.ipv4.tcp_no_ssthresh_metrics_save = 1

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -24,4 +24,8 @@ sudo grubby \
   --update-kernel=ALL \
   --args="psi=1"
 
+sudo mkdir -p /etc/sysctl.d
+sudo mv /tmp/worker/sysctl.conf /etc/sysctl.d/00-eks.conf
+sudo chown root:root /etc/sysctl.d/00-eks.conf
+
 sudo reboot


### PR DESCRIPTION
**Description of changes:**

We've observed poor performance due to the kernel's TCP slow start threshold cache.

In newer kernels, these metrics are disabled (not cached) by default. The kernel variable that controls this behavior has been backported to the 5.4 kernel on Amazon Linux 2, but the behavior was left as-is (enabled).

Kubernetes users are more likely to run into issues when these metrics are enabled due to the extensive use of NAT. This PR disables the TCP ssthresh metrics to align with newer kernel versions. This change only has effect for AMI's using the 5.4 kernel, as the default is `1` (disabled) in AMI's using the 5.10 kernel or later.

Mailing list discussion around this patch: https://yhbt.net/lore/all/20191209191959.100759-1-yyd@google.com/T/
```
As modern networks becoming more and more dynamic, TCP metrics cache
today often causes more harm than benefits. For example, the same IP
address is often shared by different subscribers behind NAT in residential
networks. Even if the IP address is not shared by different users,
caching the slow-start threshold of a previous short flow using loss-based
congestion control (e.g. cubic) often causes the future longer flows of
the same network path to exit slow-start prematurely with abysmal
throughput.

Caching ssthresh is very risky and can lead to terrible performance.
Therefore it makes sense to make disabling ssthresh caching by
default and opt-in for specific networks by the administrators.
This practice also has worked well for several years of deployment with
CUBIC congestion control at Google.
```

Kernel documentation about this variable: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
```
tcp_no_ssthresh_metrics_save - BOOLEAN
	Controls whether TCP saves ssthresh metrics in the route cache.
	Default is 1, which disables ssthresh metrics.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

I built a 1.23 AMI, launched an instance, and see the expected value:
```
> sudo sysctl net.ipv4.tcp_no_ssthresh_metrics_save
net.ipv4.tcp_no_ssthresh_metrics_save = 1
```