### PR TITLE
Override hostname to match EC2's PrivateDnsName

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -485,6 +485,7 @@ else
   # If the VPC has a custom `domain-name` in its DHCP options set, and the VPC has `enableDnsHostnames` set to `true`,
   # then /etc/hostname is not the same as EC2's PrivateDnsName.
   # The name of the Node object must be equal to EC2's PrivateDnsName for the aws-iam-authenticator to allow this kubelet to manage it.
+  INSTANCE_ID=$(imds /latest/meta-data/instance-id)
   PRIVATE_DNS_NAME=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query 'Reservations[].Instances[].PrivateDnsName' --output text)
   KUBELET_ARGS="$KUBELET_ARGS --hostname-override=$PRIVATE_DNS_NAME"
 fi

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -486,7 +486,7 @@ else
   # then /etc/hostname is not the same as EC2's PrivateDnsName.
   # The name of the Node object must be equal to EC2's PrivateDnsName for the aws-iam-authenticator to allow this kubelet to manage it.
   INSTANCE_ID=$(imds /latest/meta-data/instance-id)
-  PRIVATE_DNS_NAME=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query 'Reservations[].Instances[].PrivateDnsName' --output text)
+  PRIVATE_DNS_NAME=$(AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=10 aws ec2 describe-instances --instance-ids $INSTANCE_ID --query 'Reservations[].Instances[].PrivateDnsName' --output text)
   KUBELET_ARGS="$KUBELET_ARGS --hostname-override=$PRIVATE_DNS_NAME"
 fi
 


### PR DESCRIPTION
**Issue #, if available:**

Fixes #1263 .

**Description of changes:**

Details available in #1263 .

This PR ensures that the name of the `Node` object matches the `PrivateDnsName` returned by `ec2.DescribeInstances`.

This `ec2.DescribeInstances` call was already being done by the in-tree cloud provider.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Reproduce the issue by:
1. Create a 1.26 cluster: `eksctl create cluster --name 126 --version 1.26 --without-nodegroup`
2. Modify the created VPC's DHCP options set to use a custom `domain-name`:
```
domain-name: foo
domain-name-servers: AmazonProvidedDNS
```
3. Create a nodegroup: `eksctl create nodegroup --cluster 126`.
4. Nodegroup creation will fail.

Test the fix on the latest AMI release by:
1. `config.yaml`:
```
apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig
metadata:
  name: "126"
  region: us-west-2
  version: "1.26"
managedNodeGroups:
  - name: nodes
    ami: ami-022441ec63297a0c9
    amiFamily: AmazonLinux2
    minSize: 1
    maxSize: 1
    desiredCapacity: 1
    overrideBootstrapCommand: |
      #!/bin/bash
      INSTANCE_ID=$(imds /latest/meta-data/instance-id)
      PRIVATE_DNS_NAME=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query 'Reservations[].Instances[].PrivateDnsName' --output text)
      /etc/eks/bootstrap.sh 126 --kubelet-extra-args "--node-labels=eks.amazonaws.com/nodegroup=nodes,eks.amazonaws.com/nodegroup-image=ami-022441ec63297a0c9 --hostname-override=$PRIVATE_DNS_NAME"
```
2. `eksctl create cluster --config-file config.yaml`
3. Nodes join the cluster as expected.
