### PR TITLE
Allow runc and containerd installation skips in install-worker

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -147,13 +147,21 @@ sudo mv "${TEMPLATE_DIR}/runtime.slice" /etc/systemd/system/runtime.slice
 ### Containerd setup ##########################################################
 ###############################################################################
 
-# install runc and lock version
-sudo yum install -y runc-${RUNC_VERSION}
-sudo yum versionlock runc-*
+if [[ ! -v "SKIP_INSTALL_RUNC" ]]; then
+  # install runc and lock version
+  sudo yum install -y runc-${RUNC_VERSION}
+  sudo yum versionlock runc-*
+else
+  echo "skipping runc install"
+fi
 
-# install containerd and lock version
-sudo yum install -y containerd-${CONTAINERD_VERSION}
-sudo yum versionlock containerd-*
+if [[ ! -v "SKIP_INSTALL_CONTAINERD" ]]; then
+  # install containerd and lock version
+  sudo yum install -y containerd-${CONTAINERD_VERSION}
+  sudo yum versionlock containerd-*
+else
+  echo "skipping containerd install"
+fi
 
 sudo mkdir -p /etc/eks/containerd
 if [ -f "/etc/eks/containerd/containerd-config.toml" ]; then


### PR DESCRIPTION
**Description of changes:**
This patch provides two optional environment variables of 
* `SKIP_INSTALL_RUNC` 
* `SKIP_INSTALL_CONTAINERD` 

Similar in function and implementation of `INSTALL_DOCKER`, when one or both of the environment variables are set install-worker.sh will skip over the yum install and version lock steps, respectfully to the vars.

By default, the variables being undefined and optional, no change to install behavior is made.

**Justification**
In cases where containerd or runc are installed from outside of yum availability (such as from source) the current yum install steps will fail, triggering `errexit`. This option allows for greater flexibility, but is sufficiently simple as to not introduce unnecessary complexity or upkeep burden.

**Testing Done**
Followed your instruction, validated that regression to the existing installation is not introduced. (Additionally tested AMI construction on my side.)
```
$ make fmt test 
...
===============================
✅ ✅ All Tests Passed! ✅ ✅
```
