### PR TITLE
Make imds-token directory world-writeable

### DIFF
--- a/files/bin/imds
+++ b/files/bin/imds
@@ -50,7 +50,7 @@ function imdscurl() {
 
 function get-token() {
   local TOKEN_DIR=/tmp/imds-tokens
-  mkdir -p $TOKEN_DIR
+  mkdir -p -m a+wrx $TOKEN_DIR
 
   # cleanup expired tokens
   local DELETED_TOKENS=0


### PR DESCRIPTION
**Description of changes:**

Fixes a small issue with IMDS token cleanup. If the temp directory used to store the token files is not writable by all users, they can't delete old tokens. The `imds` helper is first called by `root` during `bootstrap.sh`, so if another user later uses it, they'll see something like this in `stderr`:
```
> imds /latest
rm: cannot remove ‘/tmp/imds-tokens/1681422597’: Permission denied
/usr/bin/imds: line 73: /tmp/imds-tokens/1681594398: Permission denied
chmod: cannot access ‘/tmp/imds-tokens/1681594398’: No such file or directory
cat: /tmp/imds-tokens/1681594398: No such file or directory
dynamic
meta-data
user-data
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.