### PR TITLE
Use v1 credential provider API in 1.27+

### DIFF
--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -318,6 +318,6 @@ sudo yum versionlock clear
 Prior to Kubernetes 1.27, the `kubelet` could obtain credentials for ECR out of the box. This legacy credential process has been removed in Kubernetes 1.27, and
 ECR credentials should now be obtained via a plugin, the `ecr-credential-provider`. This plugin is installed in the AMI at `/etc/eks/image-credential-provider/ecr-credential-provider`. More information about this plugin is available in the [`cloud-provider-aws` documentation](https://cloud-provider-aws.sigs.k8s.io/credential_provider/).
 
-Additional image credential provider plugins may be appended to `/etc/eks/image-credential-provider/config.json`. In Kubernetes versions before 1.27, all plugins in this file must support `credentialprovider.kubelet.k8s.io/v1alpha1`. In Kubernetes versions 1.27 and above, they must support `credentialprovider.kubelet.k8s.io/v1`.
+Additional image credential provider plugins may be appended to `/etc/eks/image-credential-provider/config.json`. In Kubernetes versions 1.26 and below, all plugins in this file must support `credentialprovider.kubelet.k8s.io/v1alpha1`. In Kubernetes versions 1.27 and above, they must support `credentialprovider.kubelet.k8s.io/v1`.
 
 For more information about image credential provider plugins, refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/).

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -11,6 +11,7 @@ This document includes details about using the AMI template and the resulting AM
 1. [AL2 and Linux kernel information](#al2-and-linux-kernel-information)
 1. [Updating known instance types](#updating-known-instance-types)
 1. [Version-locked packages](#version-locked-packages)
+1. [Image credential provider plugins](#image-credential-provider-plugins)
 
 ---
 
@@ -309,3 +310,14 @@ sudo yum versionlock delete $PACKAGE_NAME
 # unlock all packages
 sudo yum versionlock clear
 ```
+
+---
+
+## Image credential provider plugins
+
+Prior to Kubernetes 1.27, the `kubelet` could obtain credentials for ECR out of the box. This legacy credential process has been removed in Kubernetes 1.27, and
+ECR credentials should now be obtained via a plugin, the `ecr-credential-provider`. More information about this plugin is available in the [`cloud-provider-aws` documentation](https://cloud-provider-aws.sigs.k8s.io/credential_provider/).
+
+This plugin is installed in the AMI at `/etc/eks/image-credential-provider/ecr-credential-provider`, and additional image credential provider plugins may be appended to `/etc/eks/image-credential-provider/config.json`.
+
+For more information about image credential provider plugins, refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/).

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -316,8 +316,8 @@ sudo yum versionlock clear
 ## Image credential provider plugins
 
 Prior to Kubernetes 1.27, the `kubelet` could obtain credentials for ECR out of the box. This legacy credential process has been removed in Kubernetes 1.27, and
-ECR credentials should now be obtained via a plugin, the `ecr-credential-provider`. More information about this plugin is available in the [`cloud-provider-aws` documentation](https://cloud-provider-aws.sigs.k8s.io/credential_provider/).
+ECR credentials should now be obtained via a plugin, the `ecr-credential-provider`. This plugin is installed in the AMI at `/etc/eks/image-credential-provider/ecr-credential-provider`. More information about this plugin is available in the [`cloud-provider-aws` documentation](https://cloud-provider-aws.sigs.k8s.io/credential_provider/).
 
-This plugin is installed in the AMI at `/etc/eks/image-credential-provider/ecr-credential-provider`, and additional image credential provider plugins may be appended to `/etc/eks/image-credential-provider/config.json`.
+Additional image credential provider plugins may be appended to `/etc/eks/image-credential-provider/config.json`. In Kubernetes versions before 1.27, all plugins in this file must support `credentialprovider.kubelet.k8s.io/v1alpha1`. In Kubernetes versions 1.27 and above, they must support `credentialprovider.kubelet.k8s.io/v1`.
 
 For more information about image credential provider plugins, refer to the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/).

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -150,7 +150,7 @@ echo "Using kubelet version $KUBELET_VERSION"
 if vercmp "$KUBELET_VERSION" lt "1.27.0"; then
   ECR_CREDENTIAL_PROVIDER_CONFIG=/etc/eks/ecr-credential-provider/ecr-credential-provider-config
   echo "$(jq '.apiVersion = "kubelet.config.k8s.io/v1alpha1"' $ECR_CREDENTIAL_PROVIDER_CONFIG)" > $ECR_CREDENTIAL_PROVIDER_CONFIG
-  echo "$(jq '.providers[].apiVersion = "credentialprovider.kubelet.k8s.io/v1alpha1"' $ECR_CREDENTIAL_PROVIDER_CONFIG)" > $ECR_CREDENTIAL_PROVIDER_CONFIG  
+  echo "$(jq '.providers[].apiVersion = "credentialprovider.kubelet.k8s.io/v1alpha1"' $ECR_CREDENTIAL_PROVIDER_CONFIG)" > $ECR_CREDENTIAL_PROVIDER_CONFIG
 fi
 
 # Set container runtime related variables

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -145,12 +145,12 @@ set -u
 KUBELET_VERSION=$(kubelet --version | grep -Eo '[0-9]\.[0-9]+\.[0-9]+')
 echo "Using kubelet version $KUBELET_VERSION"
 
-# ecr-credential-provider only implements credentialprovider.kubelet.k8s.io/v1alpha1 prior to 1.27: https://github.com/kubernetes/cloud-provider-aws/pull/597
+# ecr-credential-provider only implements credentialprovider.kubelet.k8s.io/v1alpha1 prior to 1.27.1: https://github.com/kubernetes/cloud-provider-aws/pull/597
 # TODO: remove this when 1.26 is EOL
 if vercmp "$KUBELET_VERSION" lt "1.27.0"; then
-  ECR_CREDENTIAL_PROVIDER_CONFIG=/etc/eks/ecr-credential-provider/ecr-credential-provider-config
-  echo "$(jq '.apiVersion = "kubelet.config.k8s.io/v1alpha1"' $ECR_CREDENTIAL_PROVIDER_CONFIG)" > $ECR_CREDENTIAL_PROVIDER_CONFIG
-  echo "$(jq '.providers[].apiVersion = "credentialprovider.kubelet.k8s.io/v1alpha1"' $ECR_CREDENTIAL_PROVIDER_CONFIG)" > $ECR_CREDENTIAL_PROVIDER_CONFIG
+  IMAGE_CREDENTIAL_PROVIDER_CONFIG=/etc/eks/image-credential-provider/config.json
+  echo "$(jq '.apiVersion = "kubelet.config.k8s.io/v1alpha1"' $IMAGE_CREDENTIAL_PROVIDER_CONFIG)" > $IMAGE_CREDENTIAL_PROVIDER_CONFIG
+  echo "$(jq '.providers[].apiVersion = "credentialprovider.kubelet.k8s.io/v1alpha1"' $IMAGE_CREDENTIAL_PROVIDER_CONFIG)" > $IMAGE_CREDENTIAL_PROVIDER_CONFIG
 fi
 
 # Set container runtime related variables

--- a/files/ecr-credential-provider-config
+++ b/files/ecr-credential-provider-config
@@ -1,14 +1,21 @@
-apiVersion: kubelet.config.k8s.io/v1beta1
-kind: CredentialProviderConfig
-providers:
-  - name: ecr-credential-provider
-    matchImages:
-      - "*.dkr.ecr.*.amazonaws.com"
-      - "*.dkr.ecr.*.amazonaws.cn"
-      - "*.dkr.ecr-fips.*.amazonaws.com"
-      - "*.dkr.ecr.us-iso-east-1.c2s.ic.gov"
-      - "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
-    defaultCacheDuration: "12h"
-    apiVersion: credentialprovider.kubelet.k8s.io/v1beta1
-    args:
-      - get-credentials
+{
+  "apiVersion": "kubelet.config.k8s.io/v1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "ecr-credential-provider",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr.ecr.*.amazonaws.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr.ecr.us-iso-east-1.c2s.ic.gov",
+        "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1",
+      "args": [
+        "get-credentials"
+      ]
+    }
+  ]
+}

--- a/files/ecr-credential-provider-config.json
+++ b/files/ecr-credential-provider-config.json
@@ -12,10 +12,7 @@
         "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
       ],
       "defaultCacheDuration": "12h",
-      "apiVersion": "credentialprovider.kubelet.k8s.io/v1",
-      "args": [
-        "get-credentials"
-      ]
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1"
     }
   ]
 }

--- a/files/kubelet-containerd.service
+++ b/files/kubelet-containerd.service
@@ -11,8 +11,8 @@ ExecStart=/usr/bin/kubelet \
     --config /etc/kubernetes/kubelet/kubelet-config.json \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime-endpoint unix:///run/containerd/containerd.sock \
-    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \
-    --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider \
+    --image-credential-provider-config /etc/eks/image-credential-provider/config.json \
+    --image-credential-provider-bin-dir /etc/eks/image-credential-provider \
     $KUBELET_ARGS \
     $KUBELET_EXTRA_ARGS
 

--- a/files/kubelet.service
+++ b/files/kubelet.service
@@ -11,8 +11,8 @@ ExecStart=/usr/bin/kubelet \
     --kubeconfig /var/lib/kubelet/kubeconfig \
     --container-runtime docker \
     --network-plugin cni \
-    --image-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config \
-    --image-credential-provider-bin-dir /etc/eks/ecr-credential-provider \
+    --image-credential-provider-config /etc/eks/image-credential-provider/config.json \
+    --image-credential-provider-bin-dir /etc/eks/image-credential-provider \
     $KUBELET_ARGS \
     $KUBELET_EXTRA_ARGS
 

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -351,22 +351,18 @@ fi
 ################################################################################
 ### ECR CREDENTIAL PROVIDER ####################################################
 ################################################################################
-if vercmp "$KUBERNETES_VERSION" gteq "1.22.0"; then
-  ECR_BINARY="ecr-credential-provider"
-  if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
-    echo "AWS cli present - using it to copy ecr-credential-provider binaries from s3."
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_BINARY .
-  else
-    echo "AWS cli missing - using wget to fetch ecr-credential-provider binaries from s3. Note: This won't work for private bucket."
-    sudo wget "$S3_URL_BASE/$ECR_BINARY"
-  fi
-  sudo chmod +x $ECR_BINARY
-  sudo mkdir -p /etc/eks/ecr-credential-provider
-  sudo mv $ECR_BINARY /etc/eks/ecr-credential-provider
-
-  # copying credential provider config file to eks folder
-  sudo mv $TEMPLATE_DIR/ecr-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config
+ECR_CREDENTIAL_PROVIDER_BINARY="ecr-credential-provider"
+if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+  echo "AWS cli present - using it to copy ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3."
+  aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .
+else
+  echo "AWS cli missing - using wget to fetch ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3. Note: This won't work for private bucket."
+  sudo wget "$S3_URL_BASE/$ECR_CREDENTIAL_PROVIDER_BINARY"
 fi
+sudo chmod +x $ECR_CREDENTIAL_PROVIDER_BINARY
+sudo mkdir -p /etc/eks/image-credential-provider
+sudo mv $ECR_CREDENTIAL_PROVIDER_BINARY /etc/eks/image-credential-provider/
+sudo mv $TEMPLATE_DIR/ecr-credential-provider-config.json /etc/eks/image-credential-provider/config.json
 
 ################################################################################
 ### Cache Images ###############################################################

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -12,7 +12,7 @@ COPY files/ /etc/eks/
 COPY files/containerd-config.toml files/kubelet-containerd.service files/pull-sandbox-image.sh files/sandbox-image.service /etc/eks/containerd/
 COPY files/kubelet-config.json /etc/kubernetes/kubelet/kubelet-config.json
 COPY files/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
-COPY files/ecr-credential-provider-config /etc/eks/ecr-credential-provider/ecr-credential-provider-config
+COPY files/ecr-credential-provider-config.json /etc/eks/image-credential-provider/config.json
 COPY test/entrypoint.sh /entrypoint.sh
 COPY files/bin/* /usr/bin/
 COPY test/mocks/ /sbin/

--- a/test/cases/ecr-credential-provider-config.sh
+++ b/test/cases/ecr-credential-provider-config.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 exit_code=0
 TEMP_DIR=$(mktemp -d)
 
-export CRED_PROVIDER_FILE="/etc/eks/ecr-credential-provider/ecr-credential-provider-config"
+export CRED_PROVIDER_FILE="/etc/eks/image-credential-provider/config.json"
 export CRED_PROVIDER_RESET_FILE="./cred-provider-config"
 
 # Store the original version of the config

--- a/test/cases/ecr-credential-provider-config.sh
+++ b/test/cases/ecr-credential-provider-config.sh
@@ -62,21 +62,21 @@ fi
 expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1alpha1"
 actual=$(jq -r '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
 if [[ "$expected_cred_provider_api" != "$actual" ]]; then
-  echo "❌ Test Failed: expected 1.22 credential provider file to contain $expected_cred_provider_api"
+  echo "❌ Test Failed: expected 1.26 credential provider file to contain $expected_cred_provider_api"
   exit 1
 fi
 
 expected_kubelet_config_api="kubelet.config.k8s.io/v1alpha1"
 actual=$(jq -r '.apiVersion' $CRED_PROVIDER_FILE)
 if [[ "$expected_kubelet_config_api" != "$actual" ]]; then
-  echo "❌ Test Failed: expected 1.22 credential provider file to contain $expected_kubelet_config_api"
+  echo "❌ Test Failed: expected 1.26 credential provider file to contain $expected_kubelet_config_api"
   exit 1
 fi
 
 echo "--> Should default to credentialprovider.kubelet.k8s.io/v1 and kubelet.config.k8s.io/v1 when at or above k8s version 1.27"
 reset_scenario
 
-export KUBELET_VERSION=v1.24.15-eks-ba74326
+export KUBELET_VERSION=v1.27.1-eks-ba74326
 /etc/eks/bootstrap.sh \
   --b64-cluster-ca dGVzdA== \
   --apiserver-endpoint http://my-api-endpoint \
@@ -87,16 +87,16 @@ if [[ ${exit_code} -ne 0 ]]; then
   exit 1
 fi
 
-expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1beta1"
+expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1"
 actual=$(jq -r '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
 if [[ "$expected_cred_provider_api" != "$actual" ]]; then
-  echo "❌ Test Failed: expected 1.24 credential provider file to contain $expected_cred_provider_api"
+  echo "❌ Test Failed: expected 1.27 credential provider file to contain $expected_cred_provider_api"
   exit 1
 fi
 
-expected_kubelet_config_api="kubelet.config.k8s.io/v1beta1"
+expected_kubelet_config_api="kubelet.config.k8s.io/v1"
 actual=$(jq -r '.apiVersion' $CRED_PROVIDER_FILE)
 if [[ "$expected_kubelet_config_api" != "$actual" ]]; then
-  echo "❌ Test Failed: expected 1.24 credential provider file to contain $expected_kubelet_config_api"
+  echo "❌ Test Failed: expected 1.27 credential provider file to contain $expected_kubelet_config_api"
   exit 1
 fi

--- a/test/cases/ecr-credential-provider-config.sh
+++ b/test/cases/ecr-credential-provider-config.sh
@@ -15,7 +15,7 @@ function reset_scenario {
   cp $CRED_PROVIDER_RESET_FILE $CRED_PROVIDER_FILE
 }
 
-echo "--> Should default to credentialprovider.kubelet.k8s.io/v1alpha1 and kubelet.config.k8s.io/v1alpha1 when below k8s version 1.24"
+echo "--> Should default to credentialprovider.kubelet.k8s.io/v1alpha1 and kubelet.config.k8s.io/v1alpha1 when below k8s version 1.27"
 reset_scenario
 
 # This variable is used to override the default value in the kubelet mock
@@ -31,20 +31,49 @@ if [[ ${exit_code} -ne 0 ]]; then
 fi
 
 expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1alpha1"
-actual=$(yq e '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
+actual=$(jq -r '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
 if [[ "$expected_cred_provider_api" != "$actual" ]]; then
   echo "❌ Test Failed: expected 1.22 credential provider file to contain $expected_cred_provider_api"
   exit 1
 fi
 
 expected_kubelet_config_api="kubelet.config.k8s.io/v1alpha1"
-actual=$(yq e '.apiVersion' $CRED_PROVIDER_FILE)
+actual=$(jq -r '.apiVersion' $CRED_PROVIDER_FILE)
 if [[ "$expected_kubelet_config_api" != "$actual" ]]; then
   echo "❌ Test Failed: expected 1.22 credential provider file to contain $expected_kubelet_config_api"
   exit 1
 fi
 
-echo "--> Should default to credentialprovider.kubelet.k8s.io/v1beta1 and kubelet.config.k8s.io/v1beta1 when at or above k8s version 1.24"
+echo "--> Should default to credentialprovider.kubelet.k8s.io/v1alpha1 and kubelet.config.k8s.io/v1alpha1 when below k8s version 1.27"
+reset_scenario
+
+# This variable is used to override the default value in the kubelet mock
+export KUBELET_VERSION=v1.26.0-eks-ba74326
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1alpha1"
+actual=$(jq -r '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
+if [[ "$expected_cred_provider_api" != "$actual" ]]; then
+  echo "❌ Test Failed: expected 1.22 credential provider file to contain $expected_cred_provider_api"
+  exit 1
+fi
+
+expected_kubelet_config_api="kubelet.config.k8s.io/v1alpha1"
+actual=$(jq -r '.apiVersion' $CRED_PROVIDER_FILE)
+if [[ "$expected_kubelet_config_api" != "$actual" ]]; then
+  echo "❌ Test Failed: expected 1.22 credential provider file to contain $expected_kubelet_config_api"
+  exit 1
+fi
+
+echo "--> Should default to credentialprovider.kubelet.k8s.io/v1 and kubelet.config.k8s.io/v1 when at or above k8s version 1.27"
 reset_scenario
 
 export KUBELET_VERSION=v1.24.15-eks-ba74326
@@ -59,17 +88,15 @@ if [[ ${exit_code} -ne 0 ]]; then
 fi
 
 expected_cred_provider_api="credentialprovider.kubelet.k8s.io/v1beta1"
-actual=$(yq e '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
+actual=$(jq -r '.providers[0].apiVersion' $CRED_PROVIDER_FILE)
 if [[ "$expected_cred_provider_api" != "$actual" ]]; then
   echo "❌ Test Failed: expected 1.24 credential provider file to contain $expected_cred_provider_api"
   exit 1
 fi
 
 expected_kubelet_config_api="kubelet.config.k8s.io/v1beta1"
-actual=$(yq e '.apiVersion' $CRED_PROVIDER_FILE)
+actual=$(jq -r '.apiVersion' $CRED_PROVIDER_FILE)
 if [[ "$expected_kubelet_config_api" != "$actual" ]]; then
   echo "❌ Test Failed: expected 1.24 credential provider file to contain $expected_kubelet_config_api"
   exit 1
 fi
-
-exit_code=0

--- a/test/test-harness.sh
+++ b/test/test-harness.sh
@@ -37,12 +37,14 @@ done
 docker build -t eks-optimized-ami -f "${SCRIPTPATH}/Dockerfile" "${SCRIPTPATH}/../"
 overall_status=0
 
+test_run_log_file=$(mktemp)
+
 function run() {
   docker run -v "$(realpath $1):/test.sh" \
     --attach STDOUT \
     --attach STDERR \
     --rm \
-    eks-optimized-ami
+    eks-optimized-ami > $test_run_log_file 2>&1
 }
 
 if [[ ! -z ${TEST_CASE_SCRIPT} ]]; then
@@ -59,6 +61,7 @@ for case in "${test_cases[@]}"; do
   if [[ ${status} -eq 0 ]]; then
     echo "✅ ✅ $(basename ${case}) Tests Passed! ✅ ✅"
   else
+    cat $test_run_log_file
     echo "❌ ❌ $(basename ${case}) Tests Failed! ❌ ❌"
     overall_status=1
   fi


### PR DESCRIPTION
**Issue #, if available:**

Closes #1268 .

**Description of changes:**

This moves to the `v1` API for `CredentialProviderRequest`/`CredentialProviderResponse`. These API's have graduated to `v1`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

You can observe the issue by placing a shim in between `kubelet` and the `ecr-credential-provider`.

1. Create `cred-provider-shim`:
```
#!/usr/bin/env bash
REQUEST=$(cat -)
LOG_FILE=/tmp/cred-provider-shim.log
function log() {
  echo "$(date)" "$@" >> $LOG_FILE
}
log "request: $REQUEST"
RESPONSE=$(mktemp)
echo "$REQUEST" | /etc/eks/ecr-credential-provider/ecr-credential-provider > $RESPONSE 2>> $LOG_FILE
log "response: $(cat $RESPONSE)"
cat "$RESPONSE"
```
2. Modify the `ecr-credential-provider-config` to use this executable.
3. Modify kubelet's `--image-credential-provider-bin-dir` flag to the directory containing the shim executable.
4. Create a test pod on the node using an image that matches the ECR pattern:
```
kubectl \
  run test-pod \
  --image 123456789123.dkr.ecr.us-west-2.amazonaws.com/foo \
  --overrides='{"apiVersion": "v1", "spec": {"nodeSelector": { "kubernetes.io/hostname": "$HOSTNAME" }}}' 
```
5. Look at `/tmp/cred-provider-shim.log`:
```
Tue Apr 18 06:12:14 UTC 2023 request: {"kind":"CredentialProviderRequest","apiVersion":"credentialprovider.kubelet.k8s.io/v1beta1","image":"123456789123.dkr.ecr.us-west-2.amazonaws.com/foo"}
E0418 06:12:14.490885   14903 main.go:161] Error running credential provider plugin: group version credentialprovider.kubelet.k8s.io/v1beta1 is not supported
Tue Apr 18 06:12:14 UTC 2023 response:
```

You can also change the `apiVersion` in `ecr-credential-provider-config` to `v1alpha1` and see a token generated successfully.