### PR TITLE
Fix imds setting for multiple enis on ipv6

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -400,7 +400,7 @@ fi
 
 ### kubelet.service configuration
 
-MAC=$(imds 'latest/meta-data/network/interfaces/macs/' | head -n 1 | sed 's/\/$//')
+MAC=$(imds 'latest/meta-data/mac')
 
 if [[ -z "${DNS_CLUSTER_IP}" ]]; then
   if [[ "${IP_FAMILY}" == "ipv6" ]]; then


### PR DESCRIPTION
**Issue #, if available:**
Closes #1103 .
**Description of changes:**
This changes the imds metadata path to choose the [latest/meta-data/mac](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html) rather than the network interfaces level which can incorrectly label the node ip field of the kubelet args when an ipv6 instance has multiple ENIs. The incorrect latest/meta-data/network/interfaces/macs/ will not guarantee eth0 as the mac address choice causing the below errors. 

This will resolve the following kubectl error when trying to view pod logs on an ipv6 incorrectly configured instance:
```
Error from server: no preferred addresses found; known addresses: []
```

Or in the kubelet logs it will say:
```
Failed to set some node status fields" err="failed to validate nodeIP: node IP:
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
I've modified this line using patch on my user_data script to this new imds path to ensure the functionality works as intended.


<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
