### PR TITLE
Improve bootstrap logging

### DIFF
--- a/files/bin/vercmp
+++ b/files/bin/vercmp
@@ -82,7 +82,7 @@ case $OPERATOR in
 esac
 
 VERCMP_QUIET="${VERCMP_QUIET:-false}"
-if [ "$VERCMP_QUIET" = "true" ]; then
+if [ ! "$VERCMP_QUIET" = "true" ]; then
   echo "$OUTCOME"
 fi
 

--- a/files/bin/vercmp
+++ b/files/bin/vercmp
@@ -81,7 +81,10 @@ case $OPERATOR in
     ;;
 esac
 
-echo "$OUTCOME"
+VERCMP_QUIET="${VERCMP_QUIET:-false}"
+if [ "$VERCMP_QUIET" = "true" ]; then
+  echo "$OUTCOME"
+fi
 
 if [ "$OUTCOME" = "true" ]; then
   exit 0


### PR DESCRIPTION
**Description of changes:**

This adds a common `log` function to the bootstrap script, so the resulting lines in `/var/log/cloud-init-output.log` are more useful. Also adds a log line for each flag passed to the bootstrap script.

This also adds an environment variable, `VERCMP_QUIET`, that will disable the stdout from `vercmp` (this clutters up the bootstrap's own logs with `true`, `false`, blah blah).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.