### PR TITLE
Fix ECR pattern for aws-cn

### DIFF
--- a/files/ecr-credential-provider-config.json
+++ b/files/ecr-credential-provider-config.json
@@ -6,7 +6,7 @@
       "name": "ecr-credential-provider",
       "matchImages": [
         "*.dkr.ecr.*.amazonaws.com",
-        "*.dkr.ecr.*.amazonaws.cn",
+        "*.dkr.ecr.*.amazonaws.com.cn",
         "*.dkr.ecr-fips.*.amazonaws.com",
         "*.dkr.ecr.us-iso-east-1.c2s.ic.gov",
         "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"


### PR DESCRIPTION
**Issue #, if available:**

Closes #1277 .

**Description of changes:**

The ECR pattern configured for China regions is incorrect. The domain should be `amazonaws.com.cn`, not `amazonaws.cn`. Also opened a PR to fix the k8s docs on this, which is the source of our misconfig: https://github.com/kubernetes/website/pull/40841

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.