### PR TITLE
add pigz to explicitly installed packages

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -71,7 +71,8 @@ sudo yum install -y \
   wget \
   yum-utils \
   yum-plugin-versionlock \
-  mdadm
+  mdadm \
+  pigz
 
 # Remove any old kernel versions. `--count=1` here means "only leave 1 kernel version installed"
 sudo package-cleanup --oldkernels --count=1 -y

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -73,3 +73,14 @@ if [ $LOCKED_PACKAGES -ne $UNIQUE_LOCKED_PACKAGES ]; then
 fi
 
 echo "Package versionlocks are correct!"
+
+REQUIRED_COMMANDS=(unpigz)
+
+for ENTRY in "${REQUIRED_COMMANDS[@]}"; do
+  if ! command -v "$ENTRY" > /dev/null; then
+    echo "Required command does not exist: '$ENTRY'"
+    exit 1
+  fi
+done
+
+echo "Required commands were found: ${REQUIRED_COMMANDS[*]}"


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

When Docker was installed it explicitly depends on `pigz`, however in 1.25+ without Docker it is no longer installed.

```
$ yum deplist docker | grep pigz
  dependency: pigz
   provider: pigz.x86_64 2.3.4-1.amzn2.0.1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

```
# Before
$ time ctr i pull docker.io/library/python:latest > /dev/null

real    0m14.779s
user    0m0.832s
sys     0m0.473s 

# After (requires containerd restart)
$ time ctr i pull docker.io/library/python:latest > /dev/null

real    0m10.890s
user    0m0.768s
sys     0m0.507s
```