### PR TITLE
Define region so CLI uses correct endpoint for localzones

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -528,7 +528,11 @@ else
   # then /etc/hostname is not the same as EC2's PrivateDnsName.
   # The name of the Node object must be equal to EC2's PrivateDnsName for the aws-iam-authenticator to allow this kubelet to manage it.
   INSTANCE_ID=$(imds /latest/meta-data/instance-id)
-  PRIVATE_DNS_NAME=$(AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=10 aws ec2 describe-instances --instance-ids $INSTANCE_ID --query 'Reservations[].Instances[].PrivateDnsName' --output text)
+  # the AWS CLI currently constructs the wrong endpoint URL on localzones (the availability zone group will be used instead of the parent region)
+  # more info: https://github.com/aws/aws-cli/issues/7043
+  REGION=$(imds /latest/meta-data/placement/region)
+  PRIVATE_DNS_NAME=$(AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=10 aws ec2 describe-instances --region $REGION --instance-ids $INSTANCE_ID --query 'Reservations[].Instances[].PrivateDnsName' 
+--output text)
   KUBELET_ARGS="$KUBELET_ARGS --hostname-override=$PRIVATE_DNS_NAME"
 fi
 

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -531,8 +531,7 @@ else
   # the AWS CLI currently constructs the wrong endpoint URL on localzones (the availability zone group will be used instead of the parent region)
   # more info: https://github.com/aws/aws-cli/issues/7043
   REGION=$(imds /latest/meta-data/placement/region)
-  PRIVATE_DNS_NAME=$(AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=10 aws ec2 describe-instances --region $REGION --instance-ids $INSTANCE_ID --query 'Reservations[].Instances[].PrivateDnsName' 
---output text)
+  PRIVATE_DNS_NAME=$(AWS_RETRY_MODE=standard AWS_MAX_ATTEMPTS=10 aws ec2 describe-instances --region $REGION --instance-ids $INSTANCE_ID --query 'Reservations[].Instances[].PrivateDnsName' --output text)
   KUBELET_ARGS="$KUBELET_ARGS --hostname-override=$PRIVATE_DNS_NAME"
 fi
 


### PR DESCRIPTION
**Issue #, if available:**

This is caused by a CLI bug: https://github.com/aws/aws-cli/issues/7043

**Description of changes:**

When the CLI is used in a localzone; it constructs the wrong endpoint URL and the `describe-instances` call will always fail, such as:
```
> aws ec2 describe-instances --instance-ids i-0449a527fa4347213

Could not connect to the endpoint URL: "https://ec2.us-west-2-lax-1.amazonaws.com/"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

The above failure is resolved by adding the `--region` flag. Tested on an instance in a local zone.