### PR TITLE
Pretty print ipamd JSON log for log collector

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -459,7 +459,7 @@ get_ipamd_info() {
   if [[ "${ignore_introspection}" == "false" ]]; then
     try "collect L-IPAMD introspection information"
     for entry in ${IPAMD_DATA[*]}; do
-      curl --max-time 3 --silent http://localhost:61679/v1/"${entry}" >> "${COLLECT_DIR}"/ipamd/"${entry}".json
+      curl --max-time 3 --silent http://localhost:61679/v1/"${entry}" | $(which python3) -m json.tool >> "${COLLECT_DIR}"/ipamd/"${entry}".json
     done
   else
     echo "Ignoring IPAM introspection stats as mentioned" | tee -a "${COLLECT_DIR}"/ipamd/ipam_introspection_ignore.txt
@@ -467,7 +467,7 @@ get_ipamd_info() {
 
   if [[ "${ignore_metrics}" == "false" ]]; then
     try "collect L-IPAMD prometheus metrics"
-    curl --max-time 3 --silent http://localhost:61678/metrics > "${COLLECT_DIR}"/ipamd/metrics.json 2>&1
+    curl --max-time 3 --silent http://localhost:61678/metrics > "${COLLECT_DIR}"/ipamd/metrics.txt 2>&1
   else
     echo "Ignoring Prometheus Metrics collection as mentioned" | tee -a "${COLLECT_DIR}"/ipamd/ipam_metrics_ignore.txt
   fi


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

`/v1/enis` output with compact JSON output is hard to read when we are doing troubleshooting.

With pretty print ipamd log output with simple `python3 -m json.tool`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Output for `/v1/enis` maybe too large for demo, so let's take `/v1/networkutils-env-settings` as sample output.

### Before change

```bash
$ curl --max-time 3 --silent http://localhost:61679/v1/networkutils-env-settings
{"AWS_VPC_CNI_NODE_PORT_SUPPORT":true,"AWS_VPC_ENI_MTU":9001,"AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER":false,"AWS_VPC_K8S_CNI_CONNMARK":128,"AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS":null,"AWS_VPC_K8S_CNI_EXTERNALSNAT":false,"AWS_VPC_K8S_CNI_RANDOMIZESNAT":2,"AWS_VPC_K8S_CNI_VETHPREFIX":"eni"}
```

### After change

```bash
$ curl --max-time 3 --silent http://localhost:61679/v1/networkutils-env-settings | $(which python3) -m json.tool
{
    "AWS_VPC_CNI_NODE_PORT_SUPPORT": true,
    "AWS_VPC_ENI_MTU": 9001,
    "AWS_VPC_K8S_CNI_CONFIGURE_RPFILTER": false,
    "AWS_VPC_K8S_CNI_CONNMARK": 128,
    "AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS": null,
    "AWS_VPC_K8S_CNI_EXTERNALSNAT": false,
    "AWS_VPC_K8S_CNI_RANDOMIZESNAT": 2,
    "AWS_VPC_K8S_CNI_VETHPREFIX": "eni"
}
```

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
