### PR TITLE
Update ECR URL suffix for China

### DIFF
--- a/files/ecr-credential-provider-config.json
+++ b/files/ecr-credential-provider-config.json
@@ -6,7 +6,7 @@
       "name": "ecr-credential-provider",
       "matchImages": [
         "*.dkr.ecr.*.amazonaws.com",
-        "*.dkr.ecr.*.amazonaws.cn",
+        "*.dkr.ecr.*.amazonaws.com.cn",
         "*.dkr.ecr-fips.*.amazonaws.com",
         "*.dkr.ecr.us-iso-east-1.c2s.ic.gov",
         "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

ECR URL suffix for China is `amazonaws.com.cn` instead of `amazonaws.cn`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
