### PR TITLE
Upgrades docker to 20.10.23-1.amzn2.0.1

### DIFF
--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -15,7 +15,7 @@
     "cni_plugin_version": "v0.8.6",
     "containerd_version": "1.6.*",
     "creator": "{{env `USER`}}",
-    "docker_version": "20.10.17-1.amzn2.0.1",
+    "docker_version": "20.10.23-1.amzn2.0.1",
     "encrypted": "false",
     "kernel_version": "",
     "kms_key_id": "",


### PR DESCRIPTION
**Issue #, if available:**
Resolves #1291

**Description of changes:**
Upgrades docker to 20.10.23-1.amzn2.0.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Built a 1.23 AMI, created 1.23 cluster and verified that nodes joined and had the correct docker version.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
