### PR TITLE
Revert gp3 migration due to lack of Local Zone support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,21 +17,6 @@ packer_variable_file_contains = $(if $(PACKER_VARIABLE_FILE),$(shell grep -Fq $1
 # otherwise expands to 'false'
 vercmp = $(shell $(MAKEFILE_DIR)/files/bin/vercmp "$1" "$2" "$3")
 
-# expands to 'true' if the 'aws_region' contains 'us-iso' (an isolated region)
-# otherwise, expands to 'false'
-in_iso_region = $(if $(findstring us-iso,$(aws_region)),true,false)
-
-# gp3 volumes are used by default for 1.27+
-# TODO: remove when 1.26 reaches EOL
-# TODO: remove when gp3 is supported in isolated regions
-ifneq ($(call packer_variable_file_contains,volume_type), true)
-	ifeq ($(call in_iso_region), true)
-		volume_type ?= gp2
-	else ifeq ($(call vercmp,$(kubernetes_version),lt,1.27.0), true)
-		volume_type ?= gp2
-	endif
-endif
-
 # Docker is not present on 1.25+ AMI's
 # TODO: remove this when 1.24 reaches EOL
 ifeq ($(call vercmp,$(kubernetes_version),gteq,1.25.0), true)

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -11,7 +11,7 @@
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
-    "cache_container_images": "false",    
+    "cache_container_images": "false",
     "cni_plugin_version": "v0.8.6",
     "containerd_version": "1.6.*",
     "creator": "{{env `USER`}}",
@@ -20,7 +20,7 @@
     "kernel_version": "",
     "kms_key_id": "",
     "launch_block_device_mappings_volume_size": "4",
-    "pause_container_version": "3.5",    
+    "pause_container_version": "3.5",
     "pull_cni_from_github": "true",
     "remote_folder": "",
     "runc_version": "1.1.4-1.amzn2",
@@ -33,5 +33,5 @@
     "ssh_username": "ec2-user",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
-    "volume_type": "gp3"
+    "volume_type": "gp2"
 }


### PR DESCRIPTION
**Description of changes:**

Volume type `gp3` is only available in some AWS Local Zones, so changing the default here is not appropriate, because we don't currently ship an AMI variant per-volume-type. We're instead evaluating service-side changes that will use `gp3` by default for managed nodegroups. I don't have an ETA on such a change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.