### PR TITLE
feat: Adjust boost clock setting to optimize for p4de instances

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -640,8 +640,10 @@ if command -v nvidia-smi &> /dev/null; then
     log "INFO: GPU name: $GPUNAME"
 
     # set application clock to maximum
-    if [[ $GPUNAME == *"A100"* ]]; then
+    if [[ $GPUNAME == *"A100-SXM4-40GB"* ]]; then
       nvidia-smi -ac 1215,1410
+    elif [[ $GPUNAME == *"A100-SXM4-80GB"* ]]; then
+      nvidia-smi -ac 1593,1410
     elif [[ $GPUNAME == *"V100"* ]]; then
       nvidia-smi -ac 877,1530
     elif [[ $GPUNAME == *"K80"* ]]; then


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

- Adjust SMI boost clock setting to optimize the larger p4de cards - 40 GB HBM2 (in P4d instances) or 80 GB HBM2e (in P4de instances)

Ref: https://github.com/aws-samples/aws-efa-nccl-baseami-pipeline/commit/ad6420804fdc49bcd1ff78eab47fff3f0302cb87


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
