### PR TITLE
Install kernel-headers, kernel-devel

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -77,7 +77,7 @@ sudo yum install -y \
 # Remove any old kernel versions. `--count=1` here means "only leave 1 kernel version installed"
 sudo package-cleanup --oldkernels --count=1 -y
 
-sudo yum versionlock kernel-$(uname -r)
+sudo yum versionlock kernel-$(uname -r) kernel-headers-$(uname -r) kernel-devel-$(uname -r)
 
 # Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
 if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -19,6 +19,8 @@ else
   sudo amazon-linux-extras install -y "kernel-${KERNEL_VERSION}"
 fi
 
+sudo yum install -y kernel-headers kernel-devel
+
 # enable pressure stall information
 sudo grubby \
   --update-kernel=ALL \

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -81,10 +81,6 @@ done
 
 echo "Required commands were found: ${REQUIRED_COMMANDS[*]}"
 
-function free-space-in-megabytes () {
-  df -m / | tail -n1 | awk '{print $4}'
-}
-
 REQUIRED_FREE_MEBIBYTES=1024
 TOTAL_MEBIBYTES=$(df -m / | tail -n1 | awk '{print $2}')
 FREE_MEBIBYTES=$(df -m / | tail -n1 | awk '{print $4}')

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
-#
-# Do basic validation of the generated AMI
 
-# Validates that a file or blob doesn't exist
-#
-# Arguments:
-#   a file name or blob
-# Returns:
-#   1 if a file exists, after printing an error
+set -o nounset
+set -o errexit
+set -o pipefail
+
 validate_file_nonexists() {
   local file_blob=$1
   for f in $file_blob; do
@@ -84,3 +80,18 @@ for ENTRY in "${REQUIRED_COMMANDS[@]}"; do
 done
 
 echo "Required commands were found: ${REQUIRED_COMMANDS[*]}"
+
+function free-space-in-megabytes () {
+  df -m / | tail -n1 | awk '{print $4}'
+}
+
+REQUIRED_FREE_MEBIBYTES=1024
+TOTAL_MEBIBYTES=$(df -m / | tail -n1 | awk '{print $2}')
+FREE_MEBIBYTES=$(df -m / | tail -n1 | awk '{print $4}')
+echo "Disk space in mebibytes (required/free/total): ${REQUIRED_FREE_MEBIBYTES}/${FREE_MEBIBYTES}/${TOTAL_MEBIBYTES}"
+if [ ${FREE_MEBIBYTES} -lt ${REQUIRED_FREE_MEBIBYTES} ]; then
+  echo "Disk space requirements not met!"
+  exit 1
+else
+  echo "Disk space requirements were met."
+fi


### PR DESCRIPTION
**Issue #, if available:**

#1266

**Description of changes:**

Software common in the k8s ecosystem requires the header + devel packages for the current kernel. This PR installs those packages at build-time, for two reasons:
1. Installing the packages at runtime adds startup latency to software that requires these packages.
2. These packages may not be available from the remote yum repository indefinitely (for example, in the case of a repository rollback).

I chose to install the packages instead of only caching the RPM's with `yum-downloadonly`, because the remote repository data would still need to be refreshed in most cases (it expires after 2 hours) to complete the installation, which wouldn't address reason 2 above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

All succeed, and the additional storage space consumed is reasonable:
```
# kernel-5.15
make 1.26 kernel_version=5.15
# Installed size: 271 M

# kernel-5.10
make 1.26
# Installed size: 266 M

# kernel-5.4
make 1.23
# Installed size: 224 M
```