### PR TITLE
Add support to collect vpc-bridge CNI conf

### DIFF
--- a/log-collector-script/windows/eks-log-collector.ps1
+++ b/log-collector-script/windows/eks-log-collector.ps1
@@ -289,7 +289,7 @@ Function get_k8s_info{
         Write-Host "Collecting kubelet information"
         copy C:\ProgramData\kubernetes\kubeconfig $info_system\kubelet\
         copy C:\ProgramData\kubernetes\kubelet-config.json $info_system\kubelet\
-        copy C:\ProgramData\Amazon\EKS\cni\config\vpc-shared-eni.conf $info_system\cni\
+        copy C:\ProgramData\Amazon\EKS\cni\config\* $info_system\cni\
         Write-Host "OK" -foregroundcolor "green"
     }
     catch {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
EKS Windows changed CNI plugin from `vpc-shared-eni` to `vpc-bridge`. Updating script to collect logs and conf for both `vpc-shared-eni` and `vpc-bridge`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
Tested on both Windows Server 2019, 2022.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
