### PR TITLE
Update core CNI plugins version

### DIFF
--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -12,7 +12,7 @@
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
     "cache_container_images": "false",
-    "cni_plugin_version": "v0.8.6",
+    "cni_plugin_version": "v1.2.0",
     "containerd_version": "1.6.*",
     "creator": "{{env `USER`}}",
     "docker_version": "20.10.23-1.amzn2.0.1",


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/amazon-eks-ami/issues/1214

**Description of changes:**
This PR upgrades the CNI plugin versions pulled into the AMI to be the latest upstream release: v1.2.0: https://github.com/containernetworking/plugins/releases/tag/v1.2.0

This was initially done in https://github.com/awslabs/amazon-eks-ami/pull/1279, but I accidentally blew that away while rebasing 😢 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**
Verified that AMI could be built and tests passed. Built AMI with pull_cni_from_github set to true and false.

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
