### PR TITLE
Mount bpffs by default on 1.25+

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -33,7 +33,7 @@ function print_help {
   echo "--ip-family Specify ip family of the cluster"
   echo "--kubelet-extra-args Extra arguments to add to the kubelet. Useful for adding labels or taints."
   echo "--local-disks Setup instance storage NVMe disks in raid0 or mount the individual disks for use by pods [mount | raid0]"
-  echo "--mount-bpf-fs Mount a bpffs at /sys/fs/bpf (default: true, for Kubernetes 1.27+; false otherwise)"
+  echo "--mount-bpf-fs Mount a bpffs at /sys/fs/bpf (default: true, for Kubernetes 1.25+; false otherwise)"
   echo "--pause-container-account The AWS account (number) to pull the pause container from"
   echo "--pause-container-version The tag of the pause container"
   echo "--service-ipv6-cidr ipv6 cidr range of the cluster"
@@ -322,7 +322,7 @@ if [[ "$MACHINE" != "x86_64" && "$MACHINE" != "aarch64" ]]; then
 fi
 
 if [ "$MOUNT_BPF_FS" = "true" ]; then
-  sudo mount-bpf-fs
+  mount-bpf-fs
 fi
 
 ECR_URI=$(/etc/eks/get-ecr-uri.sh "${AWS_DEFAULT_REGION}" "${AWS_SERVICES_DOMAIN}" "${PAUSE_CONTAINER_ACCOUNT:-}")

--- a/test/cases/mount-bpf-fs.sh
+++ b/test/cases/mount-bpf-fs.sh
@@ -66,14 +66,14 @@ if [[ ${EXIT_CODE} -ne 0 ]]; then
   echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"
   exit 1
 fi
-if [ "$(cat $MOUNT_BPF_FS_MOCK)" = "called" ]; then
+if [ ! "$(cat $MOUNT_BPF_FS_MOCK)" = "called" ]; then
   echo "❌ Test Failed: expected mount-bpf-fs to be called once but it was not!"
   exit 1
 fi
 export -nf mount-bpf-fs
 
-echo "--> Should default to false on 1.26-"
-export KUBELET_VERSION=v1.26.0-eks-ba74326
+echo "--> Should default to false on 1.24-"
+export KUBELET_VERSION=v1.24.0-eks-ba74326
 MOUNT_BPF_FS_MOCK=$(mktemp)
 function mount-bpf-fs() {
   echo "called" >> $MOUNT_BPF_FS_MOCK


### PR DESCRIPTION
**Description of changes:**

Changes the default for `--mount-bpf-fs` to `true` for Kubernetes 1.25+.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.