### PR TITLE
Use recommended clocksources

### DIFF
--- a/files/bin/configure-clocksource
+++ b/files/bin/configure-clocksource
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+CLOCK_PATH="/sys/devices/system/clocksource/clocksource0"
+
+function log() {
+  echo >&2 "$@"
+}
+
+function current-clocksource() {
+  cat "${CLOCK_PATH}/current_clocksource"
+}
+
+function check-available-clocksource() {
+  grep --quiet "${1}" "${CLOCK_PATH}/available_clocksource"
+}
+
+function try-set-clocksource() {
+  if check-available-clocksource "${1}"; then
+    echo "${1}" > "${CLOCK_PATH}/current_clocksource"
+    log "configured clocksource: ${1}"
+  else
+    log "clocksource not available: ${1}"
+  fi
+}
+
+case "$(imds /latest/meta-data/system)" in
+  nitro)
+    CLOCKSOURCE="kvm-clock"
+    ;;
+
+  **)
+    CLOCKSOURCE="tsc"
+    ;;
+esac
+
+log "desired clocksource: ${CLOCKSOURCE}"
+
+if [ ! "$(current-clocksource)" = "${CLOCKSOURCE}" ]; then
+  try-set-clocksource "${CLOCKSOURCE}"
+fi
+
+log "final clocksource: $(current-clocksource)"

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -325,6 +325,11 @@ if [ "$MOUNT_BPF_FS" = "true" ]; then
   mount-bpf-fs
 fi
 
+cp -v /etc/eks/configure-clocksource.service /etc/systemd/system/configure-clocksource.service
+chown root:root /etc/systemd/system/configure-clocksource.service
+systemctl daemon-reload
+systemctl enable --now configure-clocksource
+
 ECR_URI=$(/etc/eks/get-ecr-uri.sh "${AWS_DEFAULT_REGION}" "${AWS_SERVICES_DOMAIN}" "${PAUSE_CONTAINER_ACCOUNT:-}")
 PAUSE_CONTAINER_IMAGE=${PAUSE_CONTAINER_IMAGE:-$ECR_URI/eks/pause}
 PAUSE_CONTAINER="$PAUSE_CONTAINER_IMAGE:$PAUSE_CONTAINER_VERSION"

--- a/files/configure-clocksource.service
+++ b/files/configure-clocksource.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Configure kernel clocksource
+
+[Service]
+ExecStart=/usr/bin/configure-clocksource
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -81,27 +81,13 @@ sudo yum versionlock kernel-$(uname -r)
 # Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
 if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi
 
+sudo mkdir -p /etc/eks/
+
 ################################################################################
 ### Time #######################################################################
 ################################################################################
 
-# Make sure Amazon Time Sync Service starts on boot.
-sudo chkconfig chronyd on
-
-# Make sure that chronyd syncs RTC clock to the kernel.
-cat << EOF | sudo tee -a /etc/chrony.conf
-# This directive enables kernel synchronisation (every 11 minutes) of the
-# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
-rtcsync
-EOF
-
-# If current clocksource is xen, switch to tsc
-if grep --quiet xen /sys/devices/system/clocksource/clocksource0/current_clocksource \
-  && grep --quiet tsc /sys/devices/system/clocksource/clocksource0/available_clocksource; then
-  echo "tsc" | sudo tee /sys/devices/system/clocksource/clocksource0/current_clocksource
-else
-  echo "tsc as a clock source is not applicable, skipping."
-fi
+sudo mv $WORKING_DIR/configure-clocksource.service /etc/eks/configure-clocksource.service
 
 ################################################################################
 ### SSH ########################################################################
@@ -114,7 +100,7 @@ sudo systemctl restart sshd.service
 ################################################################################
 ### iptables ###################################################################
 ################################################################################
-sudo mkdir -p /etc/eks
+
 sudo mv $WORKING_DIR/iptables-restore.service /etc/eks/iptables-restore.service
 
 ################################################################################

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -24,4 +24,10 @@ sudo grubby \
   --update-kernel=ALL \
   --args="psi=1"
 
+# use the tsc clocksource by default
+# https://repost.aws/knowledge-center/manage-ec2-linux-clock-source
+sudo grubby \
+  --update-kernel=ALL \
+  --args="clocksource=tsc tsc=reliable"
+
 sudo reboot

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -7,6 +7,7 @@ RUN amazon-linux-extras enable docker && \
 
 ENV IMDS_ENDPOINT=127.0.0.1:1338
 COPY --from=aemm /ec2-metadata-mock /sbin/ec2-metadata-mock
+RUN mkdir -p /etc/systemd/system
 RUN mkdir -p /etc/eks/containerd
 COPY files/ /etc/eks/
 COPY files/containerd-config.toml files/kubelet-containerd.service files/pull-sandbox-image.sh files/sandbox-image.service /etc/eks/containerd/


### PR DESCRIPTION
**Issue #, if available:**

Fixes #249 

**Description of changes:**

The `tsc` clocksource is the recommended default for instances on the Xen hypervisor, as it's significantly more performant than the `xen` clocksource (there's an interesting [case study](https://www.brendangregg.com/blog/2021-09-26/the-speed-of-time.html) from Netflix).

A previous attempt (in #272) to swap `xen` for `tsc` had no effect; only the current clocksource was changed, not the default. The setting was applied during the AMI build process and had no effect after a reboot.

EC2 [recommends](https://repost.aws/knowledge-center/manage-ec2-linux-clock-source):
- Xen-based instance types: `tsc`
  - In my tests, `xen` was used by default.
- Nitro-based instance types: `kvm-clock`
  - In my tests, `tsc` was used by default.
- Graviton instance types: `arch_sys_counter`
  - In my tests, this is the only clocksource available; any other `clocksource` set on the kernel command-line is ignored.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

1. I built a 1.27 AMI on this branch (`make 1.27`).
2. I launched:
  - `m6i.large` (Nitro): `kvm-clock` used as expected.
  - `r7g.medium` (Graviton3): `arch_sys_counter` used as expected.
    - I built an `arm64` variant for this (`make 1.27 arch=arm64`).
  - `m4.large` (Xen): `tsc` used as expected.