### PR TITLE
Updates eni-max-pods including c7gn instances

### DIFF
--- a/files/eni-max-pods.txt
+++ b/files/eni-max-pods.txt
@@ -176,6 +176,14 @@ c7g.large 29
 c7g.medium 8
 c7g.metal 737
 c7g.xlarge 58
+c7gn.12xlarge 234
+c7gn.16xlarge 737
+c7gn.2xlarge 58
+c7gn.4xlarge 234
+c7gn.8xlarge 234
+c7gn.large 29
+c7gn.medium 8
+c7gn.xlarge 58
 cr1.8xlarge 234
 d2.2xlarge 58
 d2.4xlarge 234
@@ -233,6 +241,9 @@ h1.4xlarge 234
 h1.8xlarge 234
 hpc6a.48xlarge 100
 hpc6id.32xlarge 51
+hpc7g.16xlarge 198
+hpc7g.4xlarge 198
+hpc7g.8xlarge 198
 hs1.8xlarge 234
 i2.2xlarge 58
 i2.4xlarge 234


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Updates eni-max-pods including c7gn instances. Generated as part of [this PR](https://github.com/aws/amazon-vpc-cni-k8s/pull/2438).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
none

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
