### PR TITLE
Add logging for aws managed csi drivers

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -50,6 +50,7 @@ REQUIRED_UTILS=(
 
 COMMON_DIRECTORIES=(
   kernel
+  modinfo
   system
   docker
   containerd
@@ -263,6 +264,7 @@ collect() {
   get_region
   get_common_logs
   get_kernel_info
+  get_modinfo
   get_mounts_info
   get_selinux_info
   get_iptables_info
@@ -384,6 +386,12 @@ get_kernel_info() {
   uname -a > "${COLLECT_DIR}/kernel/uname.txt"
 
   ok
+}
+
+# collect modinfo on specific modules for debugging purposes
+get_modinfo() {
+  try "collect modinfo"
+  modinfo lustre > "${COLLECT_DIR}/modinfo/lustre"
 }
 
 get_docker_logs() {

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -20,7 +20,7 @@ export LANG="C"
 export LC_ALL="C"
 
 # Global options
-readonly PROGRAM_VERSION="0.7.5"
+readonly PROGRAM_VERSION="0.7.6"
 readonly PROGRAM_SOURCE="https://github.com/awslabs/amazon-eks-ami/blob/master/log-collector-script/"
 readonly PROGRAM_NAME="$(basename "$0" .sh)"
 readonly PROGRAM_DIR="/opt/log-collector"
@@ -356,6 +356,7 @@ get_common_logs() {
         cp --force --dereference --recursive /var/log/containers/ebs-csi* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/containers/efs-csi* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/containers/fsx-csi* "${COLLECT_DIR}"/var_log/ 2> /dev/null
+        cp --force --dereference --recursive /var/log/containers/fsx-openzfs-csi* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/containers/file-cache-csi* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         continue
       fi
@@ -366,6 +367,9 @@ get_common_logs() {
         cp --force --dereference --recursive /var/log/pods/kube-system_kube-proxy* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/pods/kube-system_ebs-csi-* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/pods/kube-system_efs-csi-* "${COLLECT_DIR}"/var_log/ 2> /dev/null
+        cp --force --dereference --recursive /var/log/pods/kube-system_fsx-csi-* "${COLLECT_DIR}"/var_log/ 2> /dev/null
+        cp --force --dereference --recursive /var/log/pods/kube-system_fsx-openzfs-csi-* "${COLLECT_DIR}"/var_log/ 2> /dev/null
+        cp --force --dereference --recursive /var/log/pods/kube-system_file-cache-csi-* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         continue
       fi
       cp --force --recursive --dereference /var/log/"${entry}" "${COLLECT_DIR}"/var_log/ 2> /dev/null


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Adding log collection for FSx for OpenZFS CSI Driver
- Expanding log collection for FSx for Lustre and Amazon File Cache

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
- Started up the respective CSI Drivers from my personal cluster and ran the eks-log-collector script from a node in my cluster to confirm logs were collected as expected

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
