### PR TITLE
Amazon Linux 2023 proof-of-concept (Take 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,18 @@ ifeq ($(call vercmp,$(kubernetes_version),gteq,1.25.0), true)
 	ami_component_description ?= (k8s: {{ user `kubernetes_version` }}, containerd: {{ user `containerd_version` }})
 endif
 
+OS=
+ifneq (,$(findstring al2023, $(PACKER_TEMPLATE_FILE)))
+	OS=-al2023
+endif
+
 arch ?= x86_64
 ifeq ($(arch), arm64)
 	instance_type ?= m6g.large
-	ami_name ?= amazon-eks-arm64-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
+	ami_name ?= amazon-eks-arm64-node$(OS)-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 else
 	instance_type ?= m5.large
-	ami_name ?= amazon-eks-node-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
+	ami_name ?= amazon-eks-node$(OS)-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 endif
 
 ifeq ($(aws_region), cn-northwest-1)

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,12 @@ ifeq (, $(SHELLCHECK_COMMAND))
 endif
 SHELL_FILES := $(shell find $(MAKEFILE_DIR) -type f -name '*.sh')
 
+.PHONY: transform-al2-to-al2023
+transform-al2-to-al2023:
+	PACKER_TEMPLATE_FILE=$(PACKER_TEMPLATE_FILE) \
+	PACKER_DEFAULT_VARIABLE_FILE=$(PACKER_DEFAULT_VARIABLE_FILE) \
+		hack/transform-al2-to-al2023.sh
+
 .PHONY: lint
 lint: ## Check the source files for syntax and format issues
 	$(SHFMT_COMMAND) $(SHFMT_FLAGS) --diff $(MAKEFILE_DIR)

--- a/hack/transform-al2-to-al2023.sh
+++ b/hack/transform-al2-to-al2023.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+set -o nounset
+set -o errexit
+
+if [[ -z "${PACKER_TEMPLATE_FILE:-}" ]]; then
+  echo "PACKER_TEMPLATE_FILE must be set." >&2
+  exit 1
+fi
+if [[ -z "${PACKER_DEFAULT_VARIABLE_FILE:-}" ]]; then
+  echo "PACKER_DEFAULT_VARIABLE_FILE must be set." >&2
+  exit 1
+fi
+
+# rsa keys are not supported in al2023, switch to ed25519
+# delete the upgrade kernel provisioner as we don't need it for al2023
+cat "${PACKER_TEMPLATE_FILE}" \
+  | jq '._comment = "All template variables are enumerated here; and most variables have a default value defined in eks-worker-al2023-variables.json"' \
+  | jq '.variables.temporary_key_pair_type = "ed25519"' \
+  | jq 'del(.provisioners[5])' \
+    > "${PACKER_TEMPLATE_FILE/al2/al2023}"
+
+# use newer versions of containerd and runc, do not install docker
+# use al2023 6.1 minimal image
+cat "${PACKER_DEFAULT_VARIABLE_FILE}" \
+  | jq '.ami_component_description = "(k8s: {{ user `kubernetes_version` }}, containerd: {{ user `containerd_version` }})"' \
+  | jq '.ami_description = "EKS-optimized Kubernetes node based on Amazon Linux 2023"' \
+  | jq '.containerd_version = "*" | .runc_version = "*" | .docker_version = "" ' \
+  | jq '.source_ami_filter_name = "al2023-ami-minimal-2023.*-kernel-6.1-x86_64"' \
+  | jq '.volume_type = "gp3"' \
+    > "${PACKER_DEFAULT_VARIABLE_FILE/al2/al2023}"

--- a/hack/transform-al2-to-al2023.sh
+++ b/hack/transform-al2-to-al2023.sh
@@ -18,7 +18,7 @@ fi
 cat "${PACKER_TEMPLATE_FILE}" \
   | jq '._comment = "All template variables are enumerated here; and most variables have a default value defined in eks-worker-al2023-variables.json"' \
   | jq '.variables.temporary_key_pair_type = "ed25519"' \
-  | jq 'del(.provisioners[5])' \
+  | jq '.provisioners |= map(select(.script//empty|endswith("upgrade_kernel.sh")|not))' \
     > "${PACKER_TEMPLATE_FILE/al2/al2023}"
 
 # use newer versions of containerd and runc, do not install docker

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -59,7 +59,6 @@ sudo yum install -y \
   aws-cfn-bootstrap \
   chrony \
   conntrack \
-  curl \
   ec2-instance-connect \
   ethtool \
   ipvsadm \
@@ -73,8 +72,20 @@ sudo yum install -y \
   mdadm \
   pigz
 
-# Remove any old kernel versions. `--count=1` here means "only leave 1 kernel version installed"
-sudo package-cleanup --oldkernels --count=1 -y
+# skip kernel version cleanup on al2023
+if ! cat /etc/*release | grep "al2023" > /dev/null 2>&1; then
+  # Remove any old kernel versions. `--count=1` here means "only leave 1 kernel version installed"
+  sudo package-cleanup --oldkernels --count=1 -y
+fi
+
+# packages that need special handling
+if cat /etc/*release | grep "al2023" > /dev/null 2>&1; then
+  # exists in al2023 only (needed by kubelet)
+  sudo yum install -y iptables-legacy
+else
+  # curl-minimal already exists in al2023 so install curl only on al2
+  sudo yum install -y curl
+fi
 
 sudo yum versionlock kernel-$(uname -r)
 


### PR DESCRIPTION
Makefile has a converter that generates al2023 configs from existing al2 ones

Very minimal changes to other files to ensure al2023 works and does not get in the way of AL2 ongoing development.

Based on earlier work by @cartermckinnon in: 
https://github.com/awslabs/amazon-eks-ami/pull/1212