### PR TITLE
Generate version info for cached images only when `containerd` is active

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -204,7 +204,10 @@
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
       "script": "{{template_dir}}/scripts/generate-version-info.sh",
-      "execute_command": "chmod +x {{ .Path }}; {{ .Path }} {{user `working_dir`}}/version-info.json"
+      "execute_command": "chmod +x {{ .Path }}; {{ .Path }} {{user `working_dir`}}/version-info.json",
+      "environment_vars": [
+        "CACHE_CONTAINER_IMAGES={{user `cache_container_images`}}"
+      ]
     },
     {
       "type": "file",

--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -20,4 +20,9 @@ echo $(jq ".binaries.kubelet = \"$(kubelet --version | awk '{print $2}')\"" $OUT
 echo $(jq ".binaries.awscli = \"$(aws --version | awk '{print $1}' | cut -d '/' -f 2)\"" $OUTPUT_FILE) > $OUTPUT_FILE
 
 # cached images
-echo $(jq ".images = [ $(sudo ctr -n k8s.io image ls -q | cut -d'/' -f2- | sort | uniq | grep -v 'sha256' | xargs -r printf "\"%s\"," | sed 's/,$//') ]" $OUTPUT_FILE) > $OUTPUT_FILE
+if systemctl is-active --quiet containerd; then
+  echo $(jq ".images = [ $(sudo ctr -n k8s.io image ls -q | cut -d'/' -f2- | sort | uniq | grep -v 'sha256' | xargs -r printf "\"%s\"," | sed 's/,$//') ]" $OUTPUT_FILE) > $OUTPUT_FILE
+elif [ "${CACHE_CONTAINER_IMAGES}" = "true" ]; then
+  echo "containerd must be active to generate version info for cached images"
+  exit 1
+fi


### PR DESCRIPTION
**Issue #, if available:**

#1331 

**Description of changes:**

The warning printed by `ctr` when `containerd` isn't active (as a result of the `cache_container_images` feature being disabled) has been confusing. This adds a condition so that image info is only gathered when `containerd` is running. If `containerd` *isn't* running, and the `cache_container_images` feature is enabled, the script exits with an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Succeeds:
```
make
```