### PR TITLE
Add us-iso-west-1 to credential-provider

### DIFF
--- a/files/ecr-credential-provider-config.json
+++ b/files/ecr-credential-provider-config.json
@@ -8,9 +8,8 @@
         "*.dkr.ecr.*.amazonaws.com",
         "*.dkr.ecr.*.amazonaws.com.cn",
         "*.dkr.ecr-fips.*.amazonaws.com",
-        "*.dkr.ecr.us-iso-east-1.c2s.ic.gov",
-        "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov",
-        "*.dkr.ecr.us-iso-west-1.c2s.ic.gov"
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov"
       ],
       "defaultCacheDuration": "12h",
       "apiVersion": "credentialprovider.kubelet.k8s.io/v1"

--- a/files/ecr-credential-provider-config.json
+++ b/files/ecr-credential-provider-config.json
@@ -9,7 +9,8 @@
         "*.dkr.ecr.*.amazonaws.com.cn",
         "*.dkr.ecr-fips.*.amazonaws.com",
         "*.dkr.ecr.us-iso-east-1.c2s.ic.gov",
-        "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
+        "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov",
+        "*.dkr.ecr.us-iso-west-1.c2s.ic.gov"
       ],
       "defaultCacheDuration": "12h",
       "apiVersion": "credentialprovider.kubelet.k8s.io/v1"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adding endpoint for `us-iso-west-1` to the credential-provider-config file so that we are able to pull images from ECR on nodes that don't have the in-tree cloud provider like 1.27


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
