### PR TITLE
Remove hard-coded pull_cni_from_github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,23 +113,23 @@ k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 
 .PHONY: 1.23
 1.23: ## Build EKS Optimized AL2 AMI - K8s 1.23
-	$(MAKE) k8s kubernetes_version=1.23.17 kubernetes_build_date=2023-05-11 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.23.17 kubernetes_build_date=2023-05-11
 
 .PHONY: 1.24
 1.24: ## Build EKS Optimized AL2 AMI - K8s 1.24
-	$(MAKE) k8s kubernetes_version=1.24.13 kubernetes_build_date=2023-05-11 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.24.13 kubernetes_build_date=2023-05-11
 
 .PHONY: 1.25
 1.25: ## Build EKS Optimized AL2 AMI - K8s 1.25
-	$(MAKE) k8s kubernetes_version=1.25.9 kubernetes_build_date=2023-05-11 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.25.9 kubernetes_build_date=2023-05-11
 
 .PHONY: 1.26
 1.26: ## Build EKS Optimized AL2 AMI - K8s 1.26
-	$(MAKE) k8s kubernetes_version=1.26.4 kubernetes_build_date=2023-05-11 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.26.4 kubernetes_build_date=2023-05-11
 
 .PHONY: 1.27
 1.27: ## Build EKS Optimized AL2 AMI - K8s 1.27
-	$(MAKE) k8s kubernetes_version=1.27.1 kubernetes_build_date=2023-04-19 pull_cni_from_github=true
+	$(MAKE) k8s kubernetes_version=1.27.1 kubernetes_build_date=2023-04-19
 	
 .PHONY: clean
 clean:


### PR DESCRIPTION
**Description of changes:**

The default value for this arg is already `true`. Hard-coding it on the `make` targets means you cannot set a different value when the target is used, which is unnecessary (and was annoying while preparing for #500).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.