### PR TITLE
Revert "avoid hard coding provisioner index array"

### DIFF
--- a/hack/transform-al2-to-al2023.sh
+++ b/hack/transform-al2-to-al2023.sh
@@ -18,7 +18,7 @@ fi
 cat "${PACKER_TEMPLATE_FILE}" \
   | jq '._comment = "All template variables are enumerated here; and most variables have a default value defined in eks-worker-al2023-variables.json"' \
   | jq '.variables.temporary_key_pair_type = "ed25519"' \
-  | jq '.provisioners |= map(select(.script//empty|endswith("upgrade_kernel.sh")|not))' \
+  | jq 'del(.provisioners[5])' \
     > "${PACKER_TEMPLATE_FILE/al2/al2023}"
 
 # use newer versions of containerd and runc, do not install docker


### PR DESCRIPTION
@cartermckinnon the logic doesn't work :( it bites off more than intended. let's land this revert and then iterate again. Once we have the CI running then it's easier to see when the new path ways fail. see logs below where you can see that the unintended changes trip up the build

- https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_provider-aws-test-infra/74/pull-kubernetes-node-e2e-containerd-ec2-eks-canary/1679042186831728640/build-log.txt
- https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_provider-aws-test-infra/74/pull-kubernetes-node-e2e-containerd-serial-ec2-eks-canary/1679042186894643200/build-log.txt

```
$ diff -Bbwu eks-worker-al2.json eks-worker-al2023.json
--- eks-worker-al2.json	2023-07-12 09:43:50.000000000 +0100
+++ eks-worker-al2023.json	2023-07-12 09:50:13.000000000 +0100
@@ -1,5 +1,5 @@
 {
-  "_comment": "All template variables are enumerated here; and most variables have a default value defined in eks-worker-al2-variables.json",
+  "_comment": "All template variables are enumerated here; and most variables have a default value defined in eks-worker-al2023-variables.json",
   "variables": {
     "additional_yum_repos": null,
     "ami_component_description": null,
@@ -40,7 +40,8 @@
     "subnet_id": null,
     "temporary_security_group_source_cidrs": null,
     "volume_type": null,
-    "working_dir": null
+    "working_dir": null,
+    "temporary_key_pair_type": "ed25519"
   },
   "builders": [
     {
@@ -114,13 +115,6 @@
   "provisioners": [
     {
       "type": "shell",
-      "inline": [
-        "mkdir -p {{user `working_dir`}}",
-        "mkdir -p {{user `working_dir`}}/log-collector-script"
-      ]
-    },
-    {
-      "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
       "script": "{{template_dir}}/scripts/install_additional_repos.sh",
       "environment_vars": [
@@ -128,34 +122,6 @@
       ]
     },
     {
-      "type": "file",
-      "source": "{{template_dir}}/files/",
-      "destination": "{{user `working_dir`}}"
-    },
-    {
-      "type": "file",
-      "source": "{{template_dir}}/log-collector-script/linux/",
-      "destination": "{{user `working_dir`}}/log-collector-script/"
-    },
-    {
-      "type": "shell",
-      "inline": [
-        "sudo chmod -R a+x {{user `working_dir`}}/bin/",
-        "sudo mv {{user `working_dir`}}/bin/* /usr/bin/"
-      ]
-    },
-    {
-      "type": "shell",
-      "remote_folder": "{{ user `remote_folder`}}",
-      "expect_disconnect": true,
-      "pause_after": "90s",
-      "script": "{{template_dir}}/scripts/upgrade_kernel.sh",
-      "environment_vars": [
-        "KUBERNETES_VERSION={{user `kubernetes_version`}}",
-        "KERNEL_VERSION={{user `kernel_version`}}"
-      ]
-    },
-    {
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
       "script": "{{template_dir}}/scripts/install-worker.sh",
@@ -206,18 +172,6 @@
       "environment_vars": [
         "CACHE_CONTAINER_IMAGES={{user `cache_container_images`}}"
       ]
-    },
-    {
-      "type": "file",
-      "direction": "download",
-      "source": "{{user `working_dir`}}/version-info.json",
-      "destination": "{{ user `ami_name` }}-version-info.json"
-    },
-    {
-      "type": "shell",
-      "inline": [
-        "rm -rf {{user `working_dir`}}"
-      ]
     }
   ],
   "post-processors": [
```
