### PR TITLE
Mount bpffs on all supported Kubernetes versions

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -33,7 +33,7 @@ function print_help {
   echo "--ip-family Specify ip family of the cluster"
   echo "--kubelet-extra-args Extra arguments to add to the kubelet. Useful for adding labels or taints."
   echo "--local-disks Setup instance storage NVMe disks in raid0 or mount the individual disks for use by pods [mount | raid0]"
-  echo "--mount-bpf-fs Mount a bpffs at /sys/fs/bpf (default: true, for Kubernetes 1.25+; false otherwise)"
+  echo "--mount-bpf-fs Mount a bpffs at /sys/fs/bpf (default: true)"
   echo "--pause-container-account The AWS account (number) to pull the pause container from"
   echo "--pause-container-version The tag of the pause container"
   echo "--service-ipv6-cidr ipv6 cidr range of the cluster"
@@ -224,11 +224,7 @@ if [[ ! -z ${LOCAL_DISKS} ]]; then
   setup-local-disks "${LOCAL_DISKS}"
 fi
 
-DEFAULT_MOUNT_BPF_FS="true"
-if vercmp "$KUBELET_VERSION" lt "1.25.0"; then
-  DEFAULT_MOUNT_BPF_FS="false"
-fi
-MOUNT_BPF_FS="${MOUNT_BPF_FS:-$DEFAULT_MOUNT_BPF_FS}"
+MOUNT_BPF_FS="${MOUNT_BPF_FS:-true}"
 
 # Helper function which calculates the amount of the given resource (either CPU or memory)
 # to reserve in a given resource range, specified by a start and end of the range and a percentage

--- a/test/cases/mount-bpf-fs.sh
+++ b/test/cases/mount-bpf-fs.sh
@@ -49,7 +49,7 @@ fi
 export -nf mount
 rm $SYSTEMD_UNIT
 
-echo "--> Should default to true on 1.27+"
+echo "--> Should default to true"
 export KUBELET_VERSION=v1.27.0-eks-ba74326
 MOUNT_BPF_FS_MOCK=$(mktemp)
 function mount-bpf-fs() {
@@ -72,8 +72,8 @@ if [ ! "$(cat $MOUNT_BPF_FS_MOCK)" = "called" ]; then
 fi
 export -nf mount-bpf-fs
 
-echo "--> Should default to false on 1.24-"
-export KUBELET_VERSION=v1.24.0-eks-ba74326
+echo "--> Should be disabled by flag"
+export KUBELET_VERSION=v1.27.0-eks-ba74326
 MOUNT_BPF_FS_MOCK=$(mktemp)
 function mount-bpf-fs() {
   echo "called" >> $MOUNT_BPF_FS_MOCK
@@ -84,6 +84,7 @@ EXIT_CODE=0
 /etc/eks/bootstrap.sh \
   --b64-cluster-ca dGVzdA== \
   --apiserver-endpoint http://my-api-endpoint \
+  --mount-bpf-fs false \
   test || EXIT_CODE=$?
 if [[ ${EXIT_CODE} -ne 0 ]]; then
   echo "❌ Test Failed: expected a zero exit code but got '${EXIT_CODE}'"


### PR DESCRIPTION
**Description of changes:**

We've been gradually rolling out this default, with the latest AMI release enabling it for 1.25+. This enables it for the remaining versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.