### PR TITLE
Revert "Update internal build config"

### DIFF
--- a/Config
+++ b/Config
@@ -3,7 +3,7 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
-package.Amazon-eks-ami-mirror = {
+package.Amazon-eks-ami = {
     interfaces = (1.0);
 
     deploy = {


### PR DESCRIPTION
Reverts awslabs/amazon-eks-ami#1353

Builds fail due to:
`Found a different package name 'Amazon-eks-ami-mirror' in Config file, when the request contained 'Amazon-eks-ami
`

Mirror is causing conflict issues when building, reverting change to update config to default value. 