### PR TITLE
Enable discard_unpacked_layers by default

### DIFF
--- a/files/containerd-config.toml
+++ b/files/containerd-config.toml
@@ -7,10 +7,10 @@ address = "/run/containerd/containerd.sock"
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
 default_runtime_name = "runc"
+discard_unpacked_layers = true
 
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "SANDBOX_IMAGE"
-discard_unpacked_layers = true
 
 [plugins."io.containerd.grpc.v1.cri".registry]
 config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"

--- a/files/containerd-config.toml
+++ b/files/containerd-config.toml
@@ -10,6 +10,7 @@ default_runtime_name = "runc"
 
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "SANDBOX_IMAGE"
+discard_unpacked_layers = true
 
 [plugins."io.containerd.grpc.v1.cri".registry]
 config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"


### PR DESCRIPTION
**Issue #, if available:**

Fixes #1359.

**Description of changes:**

Sets `discard_unpacked_layers = true` in the `containerd` config file. This is a disk space optimization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing**

Verified the config key:
```
> containerd --version
containerd github.com/containerd/containerd 1.6.19 1e1ea6e986c6c86565bc33d52e34b81b3e2bc71f

> containerd config default | grep -A3 -B3 discard_unpacked_layers
    [plugins."io.containerd.grpc.v1.cri".containerd]
      default_runtime_name = "runc"
      disable_snapshot_annotations = true
      discard_unpacked_layers = false
      ignore_rdt_not_enabled_errors = false
      no_pivot = false
      snapshotter = "overlayfs"
```