### PR TITLE
Cleanup /var/log/audit

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -24,6 +24,7 @@ sudo rm -rf \
   /var/log/secure \
   /var/log/wtmp \
   /var/log/messages \
+  /var/log/audit/* \
   /tmp/imds-tokens
 
 sudo touch /etc/machine-id


### PR DESCRIPTION
**Description of changes:**

Some traces of the build process/initial instance launch are left behind in various log files (such as SSH logins by Packer). This whacks everything under `/var/log`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

`make` succeeds.