### PR TITLE
Upgrade amazon-ssm-agent version to 3.2.1377.0

### DIFF
--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -69,6 +69,7 @@ Users have the following options for specifying their own values:
 | `source_ami_owners` | ```{{user `remote_folder`}}/worker``` |  |
 | `ssh_interface` | `""` |  |
 | `ssh_username` | ```{{user `remote_folder`}}/worker``` |  |
+| `ssm_agent_rpm_bucket_region` | ```{{user `remote_folder`}}/worker``` |  |
 | `ssm_agent_version` | ```{{user `remote_folder`}}/worker``` |  |
 | `subnet_id` | `""` |  |
 | `temporary_security_group_source_cidrs` | `""` |  |

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -69,7 +69,6 @@ Users have the following options for specifying their own values:
 | `source_ami_owners` | ```{{user `remote_folder`}}/worker``` |  |
 | `ssh_interface` | `""` |  |
 | `ssh_username` | ```{{user `remote_folder`}}/worker``` |  |
-| `ssm_agent_rpm_bucket_region` | ```{{user `remote_folder`}}/worker``` |  |
 | `ssm_agent_version` | ```{{user `remote_folder`}}/worker``` |  |
 | `subnet_id` | `""` |  |
 | `temporary_security_group_source_cidrs` | `""` |  |

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -64,12 +64,12 @@ Users have the following options for specifying their own values:
 | `remote_folder` | ```{{user `remote_folder`}}/worker``` | Directory path for shell provisioner scripts on the builder instance |
 | `runc_version` | ```{{user `remote_folder`}}/worker``` |  |
 | `security_group_id` | `""` |  |
-| `sonobuoy_e2e_registry` | `""` |  |
 | `source_ami_filter_name` | ```{{user `remote_folder`}}/worker``` |  |
 | `source_ami_id` | `""` |  |
 | `source_ami_owners` | ```{{user `remote_folder`}}/worker``` |  |
 | `ssh_interface` | `""` |  |
 | `ssh_username` | ```{{user `remote_folder`}}/worker``` |  |
+| `ssm_agent_version` | ```{{user `remote_folder`}}/worker``` |  |
 | `subnet_id` | `""` |  |
 | `temporary_security_group_source_cidrs` | `""` |  |
 | `volume_type` | ```{{user `remote_folder`}}/worker``` |  |

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -30,6 +30,7 @@
     "source_ami_owners": "137112412989",
     "ssh_interface": "",
     "ssh_username": "ec2-user",
+    "ssm_agent_version": "3.2.1377.0",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
     "volume_type": "gp2",

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -30,7 +30,6 @@
     "source_ami_owners": "137112412989",
     "ssh_interface": "",
     "ssh_username": "ec2-user",
-    "ssm_agent_rpm_bucket_region": "us-west-2",
     "ssm_agent_version": "3.2.1377.0",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -30,7 +30,7 @@
     "source_ami_owners": "137112412989",
     "ssh_interface": "",
     "ssh_username": "ec2-user",
-    "ssm_agent_version": "3.2.1377.0",
+    "ssm_agent_version": "latest",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
     "volume_type": "gp2",

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -30,6 +30,7 @@
     "source_ami_owners": "137112412989",
     "ssh_interface": "",
     "ssh_username": "ec2-user",
+    "ssm_agent_rpm_bucket_region": "us-west-2",
     "ssm_agent_version": "3.2.1377.0",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -37,6 +37,7 @@
     "source_ami_owners": null,
     "ssh_interface": null,
     "ssh_username": null,
+    "ssm_agent_version": null,
     "subnet_id": null,
     "temporary_security_group_source_cidrs": null,
     "volume_type": null,
@@ -105,7 +106,8 @@
         "docker_version": "{{ user `docker_version`}}",
         "containerd_version": "{{ user `containerd_version`}}",
         "kubernetes": "{{ user `kubernetes_version`}}/{{ user `kubernetes_build_date` }}/bin/linux/{{ user `arch` }}",
-        "cni_plugin_version": "{{ user `cni_plugin_version`}}"
+        "cni_plugin_version": "{{ user `cni_plugin_version`}}",
+        "ssm_agent_version": "{{ user `ssm_agent_version`}}"
       },
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}"
@@ -174,7 +176,8 @@
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
         "PAUSE_CONTAINER_VERSION={{user `pause_container_version`}}",
         "CACHE_CONTAINER_IMAGES={{user `cache_container_images`}}",
-        "WORKING_DIR={{user `working_dir`}}"
+        "WORKING_DIR={{user `working_dir`}}",
+        "SSM_AGENT_VERSION={{user `ssm_agent_version`}}"
       ]
     },
     {

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -37,7 +37,6 @@
     "source_ami_owners": null,
     "ssh_interface": null,
     "ssh_username": null,
-    "ssm_agent_rpm_bucket_region": null,
     "ssm_agent_version": null,
     "subnet_id": null,
     "temporary_security_group_source_cidrs": null,
@@ -178,7 +177,6 @@
         "PAUSE_CONTAINER_VERSION={{user `pause_container_version`}}",
         "CACHE_CONTAINER_IMAGES={{user `cache_container_images`}}",
         "WORKING_DIR={{user `working_dir`}}",
-        "SSM_AGENT_RPM_BUCKET_REGION={{user `ssm_agent_rpm_bucket_region`}}",
         "SSM_AGENT_VERSION={{user `ssm_agent_version`}}"
       ]
     },

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -37,6 +37,7 @@
     "source_ami_owners": null,
     "ssh_interface": null,
     "ssh_username": null,
+    "ssm_agent_rpm_bucket_region": null,
     "ssm_agent_version": null,
     "subnet_id": null,
     "temporary_security_group_source_cidrs": null,
@@ -177,6 +178,7 @@
         "PAUSE_CONTAINER_VERSION={{user `pause_container_version`}}",
         "CACHE_CONTAINER_IMAGES={{user `cache_container_images`}}",
         "WORKING_DIR={{user `working_dir`}}",
+        "SSM_AGENT_RPM_BUCKET_REGION={{user `ssm_agent_rpm_bucket_region`}}",
         "SSM_AGENT_VERSION={{user `ssm_agent_version`}}"
       ]
     },

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -32,7 +32,6 @@ validate_env_set PULL_CNI_FROM_GITHUB
 validate_env_set PAUSE_CONTAINER_VERSION
 validate_env_set CACHE_CONTAINER_IMAGES
 validate_env_set WORKING_DIR
-validate_env_set SSM_AGENT_RPM_BUCKET_REGION
 validate_env_set SSM_AGENT_VERSION
 
 ################################################################################
@@ -475,7 +474,7 @@ fi
 ### SSM Agent ##################################################################
 ################################################################################
 
-sudo yum install -y https://s3.${SSM_AGENT_RPM_BUCKET_REGION}.amazonaws.com/amazon-ssm-${SSM_AGENT_RPM_BUCKET_REGION}/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm
+sudo yum install -y https://s3.${BINARY_BUCKET_REGION}.${S3_DOMAIN}/amazon-ssm-${BINARY_BUCKET_REGION}/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm
 
 ################################################################################
 ### AMI Metadata ###############################################################

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -474,7 +474,12 @@ fi
 ### SSM Agent ##################################################################
 ################################################################################
 
-sudo yum install -y https://s3.${BINARY_BUCKET_REGION}.${S3_DOMAIN}/amazon-ssm-${BINARY_BUCKET_REGION}/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm
+echo "Installing amazon-ssm-agent"
+if ! [[ ${ISOLATED_REGIONS} =~ $BINARY_BUCKET_REGION ]]; then
+  sudo yum install -y https://s3.${BINARY_BUCKET_REGION}.${S3_DOMAIN}/amazon-ssm-${BINARY_BUCKET_REGION}/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm
+else
+  sudo yum install -y amazon-ssm-agent
+fi
 
 ################################################################################
 ### AMI Metadata ###############################################################

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -32,6 +32,7 @@ validate_env_set PULL_CNI_FROM_GITHUB
 validate_env_set PAUSE_CONTAINER_VERSION
 validate_env_set CACHE_CONTAINER_IMAGES
 validate_env_set WORKING_DIR
+validate_env_set SSM_AGENT_VERSION
 
 ################################################################################
 ### Machine Architecture #######################################################
@@ -473,7 +474,7 @@ fi
 ### SSM Agent ##################################################################
 ################################################################################
 
-sudo yum install -y amazon-ssm-agent
+sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/${SSM_AGENT_VERSION}/linux_amd64/amazon-ssm-agent.rpm
 
 ################################################################################
 ### AMI Metadata ###############################################################

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -32,6 +32,7 @@ validate_env_set PULL_CNI_FROM_GITHUB
 validate_env_set PAUSE_CONTAINER_VERSION
 validate_env_set CACHE_CONTAINER_IMAGES
 validate_env_set WORKING_DIR
+validate_env_set SSM_AGENT_RPM_BUCKET_REGION
 validate_env_set SSM_AGENT_VERSION
 
 ################################################################################
@@ -474,7 +475,7 @@ fi
 ### SSM Agent ##################################################################
 ################################################################################
 
-sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/${SSM_AGENT_VERSION}/linux_amd64/amazon-ssm-agent.rpm
+sudo yum install -y https://s3.${SSM_AGENT_RPM_BUCKET_REGION}.amazonaws.com/amazon-ssm-${SSM_AGENT_RPM_BUCKET_REGION}/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm
 
 ################################################################################
 ### AMI Metadata ###############################################################


### PR DESCRIPTION
**Issue #, if available:**
closes #1369

**Description of changes:**

* Use amazon-ssm-agent rpm from s3

* Set ssm-agent version configurable

* Upgrade ssm-agent to latest version (3.2.1377.0)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

I have successfully launched the tests, built and published an AMI with the `make` command, then launched an instance from this ami and verified that the `amazon-ssm-agent` was correctly installed and running.
