### PR TITLE
Do not set KubeletCredentialProviders feature flag for 1.28+

### DIFF
--- a/files/kubelet-config.json
+++ b/files/kubelet-config.json
@@ -27,8 +27,7 @@
   "cgroupDriver": "cgroupfs",
   "cgroupRoot": "/",
   "featureGates": {
-    "RotateKubeletServerCertificate": true,
-    "KubeletCredentialProviders": true
+    "RotateKubeletServerCertificate": true
   },
   "protectKernelDefaults": true,
   "serializeImagePulls": false,

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -317,7 +317,7 @@ sudo chown root:root /var/lib/kubelet/kubeconfig
 # Inject CSIServiceAccountToken feature gate to kubelet config if kubernetes version starts with 1.20.
 # This is only injected for 1.20 since CSIServiceAccountToken will be moved to beta starting 1.21.
 if [[ $KUBERNETES_VERSION == "1.20"* ]]; then
-  KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED=$(cat $WORKING_DIR/kubelet-config.json | jq '.featureGates -= {CSIServiceAccountToken: true}')
+  KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED=$(cat $WORKING_DIR/kubelet-config.json | jq '.featureGates += {CSIServiceAccountToken: true}')
   echo $KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED > $WORKING_DIR/kubelet-config.json
 fi
 

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -317,8 +317,15 @@ sudo chown root:root /var/lib/kubelet/kubeconfig
 # Inject CSIServiceAccountToken feature gate to kubelet config if kubernetes version starts with 1.20.
 # This is only injected for 1.20 since CSIServiceAccountToken will be moved to beta starting 1.21.
 if [[ $KUBERNETES_VERSION == "1.20"* ]]; then
-  KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED=$(cat $WORKING_DIR/kubelet-config.json | jq '.featureGates += {CSIServiceAccountToken: true}')
+  KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED=$(cat $WORKING_DIR/kubelet-config.json | jq '.featureGates -= {CSIServiceAccountToken: true}')
   echo $KUBELET_CONFIG_WITH_CSI_SERVICE_ACCOUNT_TOKEN_ENABLED > $WORKING_DIR/kubelet-config.json
+fi
+
+# Enable Feature Gate for KubeletCredentialProviders in versions less than 1.28 since this feature flag was removed in 1.28.
+# TODO: Remove this during 1.27 EOL
+if vercmp $KUBERNETES_VERSION lt "1.28"; then
+  KUBELET_CONFIG_WITH_KUBELET_CREDENTIAL_PROVIDER_FEATURE_GATE_ENABLED=$(cat $WORKING_DIR/kubelet-config.json | jq '.featureGates += {KubeletCredentialProviders: true}')
+  echo $KUBELET_CONFIG_WITH_KUBELET_CREDENTIAL_PROVIDER_FEATURE_GATE_ENABLED > $WORKING_DIR/kubelet-config.json
 fi
 
 sudo mv $WORKING_DIR/kubelet.service /etc/systemd/system/kubelet.service


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1.28 test AMI builds are failing because KubeletCredentialProviders feature flag is no longer supported:
```
"command failed" err="failed to set feature gates from initial flags-based config: unrecognized feature gate: KubeletCredentialProviders"
```
This change removes KubeletCredentialProviders from featureFlags for 1.28, and adds the flag by version in the install-worker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Validated 1.28 AMI creation succeeds, and that conformance tests pass.
```
Plugin: e2e
Status: passed
Total: 7392
Passed: 169
Failed: 0
Skipped: 7223

Plugin: systemd-logs
Status: passed
Total: 3
Passed: 3
Failed: 0
Skipped: 0

Run Details:
API Server version: v1.28.0-rc.0-eks-caced21
Node health: 3/3 (100%)
Pods health: 14/14 (100%)
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
