### PR TITLE
Build with latest binaries available by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,12 @@ T_GREEN := \e[0;32m
 T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
-.PHONY: latest
-latest: 1.28 ## Build EKS Optimized AL2 AMI with the latest supported version of Kubernetes
+# default to the latest supported Kubernetes version
+k8s=1.28
+
+.PHONY: build
+build: ## Build EKS Optimized AL2 AMI
+	$(MAKE) k8s $(shell hack/latest-binaries.sh $(k8s))
 
 # ensure that these flags are equivalent to the rules in the .editorconfig
 SHFMT_FLAGS := --list \
@@ -109,31 +113,29 @@ k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 	@echo "$(T_GREEN)Building AMI for version $(T_YELLOW)$(kubernetes_version)$(T_GREEN) on $(T_YELLOW)$(arch)$(T_RESET)"
 	$(PACKER_BINARY) build -timestamp-ui -color=false $(PACKER_VAR_FLAGS) $(PACKER_TEMPLATE_FILE)
 
-# Build dates and versions taken from https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
-
 .PHONY: 1.23
 1.23: ## Build EKS Optimized AL2 AMI - K8s 1.23
-	$(MAKE) k8s kubernetes_version=1.23.17 kubernetes_build_date=2023-09-14
+	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.23)
 
 .PHONY: 1.24
 1.24: ## Build EKS Optimized AL2 AMI - K8s 1.24
-	$(MAKE) k8s kubernetes_version=1.24.17 kubernetes_build_date=2023-09-14
+	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.24)
 
 .PHONY: 1.25
 1.25: ## Build EKS Optimized AL2 AMI - K8s 1.25
-	$(MAKE) k8s kubernetes_version=1.25.13 kubernetes_build_date=2023-09-14
+	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.25)
 
 .PHONY: 1.26
 1.26: ## Build EKS Optimized AL2 AMI - K8s 1.26
-	$(MAKE) k8s kubernetes_version=1.26.8 kubernetes_build_date=2023-09-14
+	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.26)
 
 .PHONY: 1.27
 1.27: ## Build EKS Optimized AL2 AMI - K8s 1.27
-	$(MAKE) k8s kubernetes_version=1.27.5 kubernetes_build_date=2023-09-14
+	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.27)
 
 .PHONY: 1.28
 1.28: ## Build EKS Optimized AL2 AMI - K8s 1.28
-	$(MAKE) k8s kubernetes_version=1.28.1 kubernetes_build_date=2023-09-14
+	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.28)
 
 .PHONY: lint-docs
 lint-docs: ## Lint the docs

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -66,50 +66,68 @@ Users have the following options for specifying their own values:
 
 ---
 
-## Building against other versions of Kubernetes binaries
-To build an Amazon EKS Worker AMI with other versions of Kubernetes that are not listed above run the following AWS Command
-Line Interface (AWS CLI) commands to obtain values for KUBERNETES_VERSION, KUBERNETES_BUILD_DATE, PLATFORM, ARCH from S3
+## Choosing Kubernetes binaries
+
+When building the AMI, binaries such as `kubelet`, `aws-iam-authenticator`, and `ecr-credential-provider` are installed.
+
+### Using the latest binaries
+
+It is recommended that the latest available binaries are used, as they may contain important fixes for bugs or security issues.
+The latest binaries can be discovered with the following script:
 ```bash
-#List of all avalable Kuberenets Versions:
-aws s3 ls s3://amazon-eks 
-KUBERNETES_VERSION=1.23.9 # Chose a version and set the variable
-
-#List of all builds for the specified Kubernetes Version:
-aws s3 ls s3://amazon-eks/$KUBERNETES_VERSION/
-KUBERNETES_BUILD_DATE=2022-07-27 # Chose a date and set the variable
-
-#List of all platforms available for the selected Kubernetes Version and build date
-aws s3 ls s3://amazon-eks/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/
-PLATFORM=linux # Chose a platform and set the variable
-
-#List of all architectures for the selected Kubernetes Version, build date and platform
-aws s3 ls s3://amazon-eks/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/
-ARCH=x86_64 #Chose an architecture and set the variable
+hack/latest-binaries.sh $KUBERNETES_MINOR_VERSION
 ```
-Run the following command to build an Amazon EKS Worker AMI based on the chosen parameters in the previous step
+This script will return the values for the binary-related AMI template variables, for example:
+```bash
+> hack/latest-binaries.sh 1.28
+
+kubernetes_version=1.28.1 kubernetes_build_date=2023-10-01
+```
+
+### Using a specific version of the binaries
+
+Use the following commands to obtain values for the binary-related AMI template variables:
+```bash
+# List Kubernetes versions
+aws s3 ls s3://amazon-eks
+
+# List build dates
+aws s3 ls s3://amazon-eks/1.23.9/
+
+# List platforms
+aws s3 ls s3://amazon-eks/1.23.9/2022-07-27/bin/
+
+# List architectures
+aws s3 ls s3://amazon-eks/1.23.9/2022-07-27/bin/linux/
+
+# List binaries
+aws s3 ls s3://amazon-eks/1.23.9/2022-07-27/bin/linux/x86_64/
+```
+
+To build using the example binaries above:
 ```bash
 make k8s \
-  kubernetes_version=$KUBERNETES_VERSION \
-  kubernetes_build_date=$KUBERNETES_BUILD_DATE \
-  arch=$ARCH
+  kubernetes_version=1.23.9 \
+  kubernetes_build_date=2022-07-27 \
+  arch=x86_64
 ```
 
----
+### Providing your own binaries
 
-## Providing your own Kubernetes Binaries
+By default, binaries are downloaded from the public S3 bucket `amazon-eks` in `us-west-2`.
+You can instead provide your own version of Kubernetes binaries.
 
-By default, binaries are downloaded from the Amazon EKS public Amazon Simple Storage Service (Amazon S3)
-bucket amazon-eks in us-west-2. You can instead choose to provide your own version of Kubernetes binaries to be used. To use your own binaries
+To use your own binaries:
 
-1. Copy the binaries to your own S3 bucket using the AWS CLI. Here is an example that uses Kubelet binary
+1. Copy all of the necessary binaries to your own S3 bucket using the AWS CLI. For example:
 ```bash
- aws s3 cp kubelet s3://my-custom-bucket/kubernetes_version/kubernetes_build_date/bin/linux/arch/kubelet
+ aws s3 cp kubelet s3://$BUCKET/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH/kubelet
 ```
-**Note**: Replace my-custom-bucket, amazon-eks, kubernetes_version, kubernetes_build_date, and arch with your values.
 
-**Important**: You must provide all the binaries listed in the default amazon-eks bucket for a specific kubernetes_version, kubernetes_build_date, and arch combination. These binaries must be accessible through AWS Identity and Access Management (IAM) credentials configured in the Install and configure HashiCorp Packer section.
+**Important**: You must provide all the binaries present in the default `amazon-eks` bucket for a specific `KUBERNETES_VERSION`, `KUBERNETES_BUILD_DATE`, and `ARCH` combination.
+These binaries must be accessible using the credentials on the Packer builder EC2 instance.
 
-2. Run the following command to start the build process to use your own Kubernetes binaries
+2. Run the following command to start the build process to use your own Kubernetes binaries:
 ```bash
 make k8s \
   binary_bucket_name=my-custom-bucket \
@@ -118,14 +136,6 @@ make k8s \
   kubernetes_build_date=2020-01-22
 ```
 **Note**: Confirm that the binary_bucket_name, binary_bucket_region, kubernetes_version, and kubernetes_build_date parameters match the path to your binaries in Amazon S3.
-
-The Makefile runs Packer with the `eks-worker-al2.json` build specification
-template and the [amazon-ebs](https://www.packer.io/docs/builders/amazon-ebs.html)
-builder. An instance is launched and the Packer [Shell
-Provisioner](https://www.packer.io/docs/provisioners/shell.html) runs the
-`install-worker.sh` script on the instance to install software and perform other
-necessary configuration tasks.  Then, Packer creates an AMI from the instance
-and terminates the instance after the AMI is created.
 
 ---
 

--- a/hack/latest-binaries.sh
+++ b/hack/latest-binaries.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 KUBERNETES_MINOR_VERSION"
+  exit 1
+fi
+
+MINOR_VERSION="${1}"
+
+# retrieve the available "VERSION/BUILD_DATE" prefixes (e.g. "1.28.1/2023-09-14")
+# from the binary object keys, sorted in descending semver order, and pick the first one
+LATEST_BINARIES=$(aws s3api list-objects-v2 --bucket amazon-eks --prefix "${MINOR_VERSION}" --query 'Contents[*].[Key]' --output text | cut -d'/' -f-2 | sort -Vru | head -n1)
+
+if [ "${LATEST_BINARIES}" == "None" ]; then
+  echo >&2 "No binaries available for minor version: ${MINOR_VERSION}"
+  exit 1
+fi
+
+LATEST_VERSION=$(echo "${LATEST_BINARIES}" | cut -d'/' -f1)
+LATEST_BUILD_DATE=$(echo "${LATEST_BINARIES}" | cut -d'/' -f2)
+
+echo "kubernetes_version=${LATEST_VERSION} kubernetes_build_date=${LATEST_BUILD_DATE}"


### PR DESCRIPTION
**Description of changes:**

This removes the hard-coded Kubernetes binary versions and build dates from the Makefile, and adds a script to discover the latest binaries available at build time.

This aims to remove a circular dependency in the current AMI build and release process. Instead of referencing specific binaries in version control, the binaries that were used to build each AMI are present in the release notes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

```
> hack/latest-binaries.sh 1.23
kubernetes_version=1.23.17 kubernetes_build_date=2023-08-15

> make 1.23
make k8s kubernetes_version=1.23.17 kubernetes_build_date=2023-08-15
```