### PR TITLE
Add .git-commit to archivebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *version-info.json
 .DS_Store
 site/
+.git-commit

--- a/ArchiveBuildConfig.yaml
+++ b/ArchiveBuildConfig.yaml
@@ -14,6 +14,7 @@ dependencies:
       - src: Makefile
       - src: eks-worker-al2.json
       - src: eks-worker-al2-variables.json
+      - src: .git-commit
 archive:
   name: amazon-eks-ami.tar.gz
   type: tgz

--- a/build-tools/bin/archivebuild-wrapper
+++ b/build-tools/bin/archivebuild-wrapper
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# This file is for Amazon internal build processes
+
+git rev-parse HEAD > .git-commit
+archivebuild


### PR DESCRIPTION
**Description of changes:**

Adds a file containing the HEAD commit SHA (`.git-commit`) to the archive created during the internal build process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.