### PR TITLE
Require builder instance to use IMDSv2

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -110,7 +110,10 @@
         "ssm_agent_version": "{{ user `ssm_agent_version`}}"
       },
       "ami_name": "{{user `ami_name`}}",
-      "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}"
+      "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}",
+      "metadata_options": {
+        "http_tokens": "required"
+      }
     }
   ],
   "provisioners": [


### PR DESCRIPTION
**Issue #, if available:**n/a

**Description of changes:** this configures the instance to use imdsv2 instead of imdsv1 per https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/latest/components/builder/ebs#metadata-settings. 

(imdsv1 instances are getting flagged by employer (: )

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done** n/a (don't know how to test, link broken)

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
