### PR TITLE
Add release note config

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,5 @@
+---
+changelog:
+  exclude:
+    labels:
+      - "changelog/exclude"


### PR DESCRIPTION
**Description of changes:**

Adds an initial config file for generating release note changelog. Specifies a label that we can use to exclude certain pull-requests from the generated notes, such as the PR's that update the CHANGELOG file.

More info here: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.