### PR TITLE
Update eks-log-collector.sh to support iptables-legacy

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -344,7 +344,7 @@ get_iptables_legacy_info() {
   if ! command -v iptables-legacy > /dev/null 2>&1; then
     echo "IPtables-legacy not installed" | tee -a "${COLLECT_DIR}"/iptables-legacy.txt
   else
-    try "collect iptables information"
+    try "collect iptables-legacy information"
     iptables-legacy --wait 1 --numeric --verbose --list --table mangle | tee "${COLLECT_DIR}"/networking/iptables-legacy-mangle.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-legacy-mangle.txt
     iptables-legacy --wait 1 --numeric --verbose --list --table filter | tee "${COLLECT_DIR}"/networking/iptables-legacy-filter.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-legacy-filter.txt
     iptables-legacy --wait 1 --numeric --verbose --list --table nat | tee "${COLLECT_DIR}"/networking/iptables-legacy-nat.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-legacy-nat.txt

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -268,6 +268,7 @@ collect() {
   get_mounts_info
   get_selinux_info
   get_iptables_info
+  get_iptables_legacy_info
   get_pkglist
   get_system_services
   get_containerd_info
@@ -326,7 +327,7 @@ get_selinux_info() {
 
 get_iptables_info() {
   if ! command -v iptables > /dev/null 2>&1; then
-    echo "IPtables not installed" | tee -a iptables.txt
+    echo "IPtables not installed" | tee -a "${COLLECT_DIR}"/iptables.txt
   else
     try "collect iptables information"
     iptables --wait 1 --numeric --verbose --list --table mangle | tee "${COLLECT_DIR}"/networking/iptables-mangle.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-mangle.txt
@@ -334,6 +335,21 @@ get_iptables_info() {
     iptables --wait 1 --numeric --verbose --list --table nat | tee "${COLLECT_DIR}"/networking/iptables-nat.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-nat.txt
     iptables --wait 1 --numeric --verbose --list | tee "${COLLECT_DIR}"/networking/iptables.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables.txt
     iptables-save > "${COLLECT_DIR}"/networking/iptables-save.txt
+  fi
+
+  ok
+}
+
+get_iptables_legacy_info() {
+  if ! command -v iptables-legacy > /dev/null 2>&1; then
+    echo "IPtables-legacy not installed" | tee -a "${COLLECT_DIR}"/iptables-legacy.txt
+  else
+    try "collect iptables information"
+    iptables-legacy --wait 1 --numeric --verbose --list --table mangle | tee "${COLLECT_DIR}"/networking/iptables-legacy-mangle.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-legacy-mangle.txt
+    iptables-legacy --wait 1 --numeric --verbose --list --table filter | tee "${COLLECT_DIR}"/networking/iptables-legacy-filter.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-legacy-filter.txt
+    iptables-legacy --wait 1 --numeric --verbose --list --table nat | tee "${COLLECT_DIR}"/networking/iptables-legacy-nat.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-legacy-nat.txt
+    iptables-legacy --wait 1 --numeric --verbose --list | tee "${COLLECT_DIR}"/networking/iptables-legacy.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-legacy.txt
+    iptables-legacy-save > "${COLLECT_DIR}"/networking/iptables-legacy-save.txt
   fi
 
   ok


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
The existing eks-log-collector.sh script assumes iptables and doesn't collect iptables-legacy data. Where custom worker AMIs are defined, using RHEL9, AlmaLinux9, Ubuntu 22.04 that ship with nftables, this additional legacy data needs to be captured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
