### PR TITLE
Set pid_max to 4194304

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -519,6 +519,7 @@ EOF
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
 echo fs.inotify.max_user_instances=8192 | sudo tee -a /etc/sysctl.conf
 echo vm.max_map_count=524288 | sudo tee -a /etc/sysctl.conf
+echo 'kernel.pid_max=4194304' | sudo tee -a /etc/sysctl.conf
 
 ################################################################################
 ### adding log-collector-script ################################################


### PR DESCRIPTION
**Issue #, if available:**

Fixes #737

**Description of changes:**

The current default value of 32768 is from the 32-bit days and is defunct. Newer versions of `systemd` (244+) set this value to the maximum-possible, 4194304. That's what is currently being used on AL2023, for example, because it uses `systemd` 252.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Confirmed on the 1.27 CI image:
```
> cat /proc/sys/kernel/pid_max 
4194304
```