### PR TITLE
Make CI images public

### DIFF
--- a/.github/actions/ci/build/action.yaml
+++ b/.github/actions/ci/build/action.yaml
@@ -22,5 +22,5 @@ runs:
       shell: bash
       run: |
         AMI_NAME="amazon-eks-node-${{ inputs.k8s_version }}-${{ inputs.build_id }}"
-        make ${{ inputs.k8s_version }} ami_name=${AMI_NAME}
+        make ${{ inputs.k8s_version }} ami_name=${AMI_NAME} ami_public=true
         echo "ami_id=$(jq -r .builds[0].artifact_id "${AMI_NAME}-manifest.json" | cut -d ':' -f 2)" >> $GITHUB_OUTPUT

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -25,6 +25,7 @@ Users have the following options for specifying their own values:
 | `ami_component_description` | ```(k8s: {{ user `kubernetes_version` }}, docker: {{ user `docker_version` }}, containerd: {{ user `containerd_version` }})``` |  |
 | `ami_description` | ```EKS Kubernetes Worker AMI with AmazonLinux2 image``` |  |
 | `ami_name` | *None* |  |
+| `ami_public` | ```false``` | Make the AMI and underlying EBS snapshot publicly accessible. |
 | `ami_regions` | `""` |  |
 | `ami_users` | `""` |  |
 | `arch` | *None* |  |

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -3,6 +3,7 @@
     "ami_component_description": "(k8s: {{ user `kubernetes_version` }}, docker: {{ user `docker_version` }}, containerd: {{ user `containerd_version` }})",
     "ami_description": "EKS Kubernetes Worker AMI with AmazonLinux2 image",
     "ami_regions": "",
+    "ami_public": "false",
     "ami_users": "",
     "associate_public_ip_address": "",
     "aws_access_key_id": "{{env `AWS_ACCESS_KEY_ID`}}",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -5,6 +5,7 @@
     "ami_component_description": null,    
     "ami_description": null,
     "ami_name": null,
+    "ami_public": null,
     "ami_regions": null,
     "ami_users": null,
     "arch": null,
@@ -48,7 +49,9 @@
       "type": "amazon-ebs",
       "region": "{{user `aws_region`}}",
       "source_ami": "{{user `source_ami_id`}}",
+      "ami_groups": "{{user `ami_public` | replace_all `true` `all`}}",
       "ami_users": "{{user `ami_users`}}",
+      "snapshot_groups": "{{user `ami_public` | replace_all `true` `all`}}",
       "snapshot_users": "{{user `ami_users`}}",
       "source_ami_filter": {
         "filters": {


### PR DESCRIPTION
**Description of changes:**

Makes the AMI's built by the CI bot public, for easy manual testing/verification by PR authors. They'll still be deleted after 3 days.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->