### PR TITLE
Bump Kubernetes target for latest to 1.28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 .PHONY: latest
-latest: 1.27 ## Build EKS Optimized AL2 AMI with the latest supported version of Kubernetes
+latest: 1.28 ## Build EKS Optimized AL2 AMI with the latest supported version of Kubernetes
 
 # ensure that these flags are equivalent to the rules in the .editorconfig
 SHFMT_FLAGS := --list \


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Bump Kubernetes target for latest to 1.28

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
```
$ make latest
...
make k8s kubernetes_version=1.28.1 kubernetes_build_date=2023-09-14
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
