### PR TITLE
fix: Tag cached image with the ECR URI for the given target region

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -466,7 +466,7 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
   done
 
   #### Tag the pulled down image for all other regions in the partition
-  for REGION in ${REGIONS[@]}; do
+  for REGION in "${REGIONS[@]}"; do
     for img in "${PULLED_IMGS[@]}"; do
       region_uri=$(/etc/eks/get-ecr-uri.sh "${region}" "${AWS_DOMAIN}")
       regional_img="${img/$ECR_URI/$region_uri}"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -441,6 +441,7 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
     ${VPC_CNI_IMGS[@]+"${VPC_CNI_IMGS[@]}"}
   )
   PULLED_IMGS=()
+  REGIONS=$(aws ec2 describe-regions --all-regions --output text --query 'Regions[].[RegionName]')
 
   for img in "${CACHE_IMGS[@]}"; do
     ## only kube-proxy-minimal is vended for K8s 1.24+
@@ -465,7 +466,7 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
   done
 
   #### Tag the pulled down image for all other regions in the partition
-  for region in $(aws ec2 describe-regions --all-regions | jq -r '.Regions[] .RegionName'); do
+  for REGION in ${REGIONS[@]}; do
     for img in "${PULLED_IMGS[@]}"; do
       region_uri=$(/etc/eks/get-ecr-uri.sh "${region}" "${AWS_DOMAIN}")
       regional_img="${img/$ECR_URI/$region_uri}"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -467,7 +467,8 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
   #### Tag the pulled down image for all other regions in the partition
   for region in $(aws ec2 describe-regions --all-regions | jq -r '.Regions[] .RegionName'); do
     for img in "${PULLED_IMGS[@]}"; do
-      regional_img="${img/$BINARY_BUCKET_REGION/$region}"
+      region_uri=$(/etc/eks/get-ecr-uri.sh "${region}" "${AWS_DOMAIN}")
+      regional_img="${img/$ECR_URI/$region_uri}"
       sudo ctr -n k8s.io image tag "${img}" "${regional_img}" || :
       ## Tag ECR fips endpoint for supported regions
       if [[ "${region}" =~ (us-east-1|us-east-2|us-west-1|us-west-2|us-gov-east-1|us-gov-east-2) ]]; then


### PR DESCRIPTION
**Issue #, if available:**
- Resolves #1441

**Description of changes:**
- Currently, the cached images that are pulled in the AMI build process are then tagged with the intended ECR URI of the other regions where an instance may be deployed. However, the current tag is using the correct region, but not the correct account ID for that region based on https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html

This change uses the `get-ecr-uri.sh` script to fetch the correct URI and then use that when tagging the images

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

I hacked up a copy of the `install-worker` to test this out 

```sh
#!/usr/bin/env bash

AWS_DOMAIN="amazonaws.com"
BINARY_BUCKET_REGION="us-east-1"
ECR_URI=$(./files/get-ecr-uri.sh "${BINARY_BUCKET_REGION}" "${AWS_DOMAIN}")

PAUSE_CONTAINER="${ECR_URI}/eks/pause:3.5"
K8S_MINOR_VERSION="1.27"

#### Cache kube-proxy images starting with the addon default version and the latest version
KUBE_PROXY_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name kube-proxy --kubernetes-version=${K8S_MINOR_VERSION})
KUBE_PROXY_IMGS=()
if [[ $(jq '.addons | length' <<< $KUBE_PROXY_ADDON_VERSIONS) -gt 0 ]]; then
  DEFAULT_KUBE_PROXY_FULL_VERSION=$(echo "${KUBE_PROXY_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] | select(.compatibilities[] .defaultVersion==true).addonVersion')
  DEFAULT_KUBE_PROXY_VERSION=$(echo "${DEFAULT_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f1)
  DEFAULT_KUBE_PROXY_PLATFORM_VERSION=$(echo "${DEFAULT_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f2)

  LATEST_KUBE_PROXY_FULL_VERSION=$(echo "${KUBE_PROXY_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] .addonVersion' | sort -V | tail -n1)
  LATEST_KUBE_PROXY_VERSION=$(echo "${LATEST_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f1)
  LATEST_KUBE_PROXY_PLATFORM_VERSION=$(echo "${LATEST_KUBE_PROXY_FULL_VERSION}" | cut -d"-" -f2)

  KUBE_PROXY_IMGS=(
    ## Default kube-proxy images
    "${ECR_URI}/eks/kube-proxy:${DEFAULT_KUBE_PROXY_VERSION}-${DEFAULT_KUBE_PROXY_PLATFORM_VERSION}"
    "${ECR_URI}/eks/kube-proxy:${DEFAULT_KUBE_PROXY_VERSION}-minimal-${DEFAULT_KUBE_PROXY_PLATFORM_VERSION}"

    ## Latest kube-proxy images
    "${ECR_URI}/eks/kube-proxy:${LATEST_KUBE_PROXY_VERSION}-${LATEST_KUBE_PROXY_PLATFORM_VERSION}"
    "${ECR_URI}/eks/kube-proxy:${LATEST_KUBE_PROXY_VERSION}-minimal-${LATEST_KUBE_PROXY_PLATFORM_VERSION}"
  )
fi

#### Cache VPC CNI images starting with the addon default version and the latest version
VPC_CNI_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name vpc-cni --kubernetes-version=${K8S_MINOR_VERSION})
VPC_CNI_IMGS=()
if [[ $(jq '.addons | length' <<< $VPC_CNI_ADDON_VERSIONS) -gt 0 ]]; then
  DEFAULT_VPC_CNI_VERSION=$(echo "${VPC_CNI_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] | select(.compatibilities[] .defaultVersion==true).addonVersion')
  LATEST_VPC_CNI_VERSION=$(echo "${VPC_CNI_ADDON_VERSIONS}" | jq -r '.addons[] .addonVersions[] .addonVersion' | sort -V | tail -n1)
  CNI_IMG="${ECR_URI}/amazon-k8s-cni"
  CNI_INIT_IMG="${CNI_IMG}-init"

  VPC_CNI_IMGS=(
    ## Default VPC CNI Images
    "${CNI_IMG}:${DEFAULT_VPC_CNI_VERSION}"
    "${CNI_INIT_IMG}:${DEFAULT_VPC_CNI_VERSION}"

    ## Latest VPC CNI Images
    "${CNI_IMG}:${LATEST_VPC_CNI_VERSION}"
    "${CNI_INIT_IMG}:${LATEST_VPC_CNI_VERSION}"
  )
fi

CACHE_IMGS=(
  "${PAUSE_CONTAINER}"
  ${KUBE_PROXY_IMGS[@]+"${KUBE_PROXY_IMGS[@]}"}
  ${VPC_CNI_IMGS[@]+"${VPC_CNI_IMGS[@]}"}
)
PULLED_IMGS=()

for img in "${CACHE_IMGS[@]}"; do
  # ## only kube-proxy-minimal is vended for K8s 1.24+
  # if [[ "${img}" == *"kube-proxy:"* ]] && [[ "${img}" != *"-minimal-"* ]] && vercmp "${K8S_MINOR_VERSION}" gteq "1.24"; then
  #   continue
  # fi
  ## Since eksbuild.x version may not match the image tag, we need to decrement the eksbuild version until we find the latest image tag within the app semver
  eksbuild_version="1"
  if [[ ${img} == *'eksbuild.'* ]]; then
    eksbuild_version=$(echo "${img}" | grep -o 'eksbuild\.[0-9]\+' | cut -d'.' -f2)
  fi
  ## iterate through decrementing the build version each time
  for build_version in $(seq "${eksbuild_version}" -1 1); do
    img=$(echo "${img}" | sed -E "s/eksbuild.[0-9]+/eksbuild.${build_version}/")
    echo "[IMAGE] $img"
    PULLED_IMGS+=("${img}")
    # if /etc/eks/containerd/pull-image.sh "${img}"; then
    #   PULLED_IMGS+=("${img}")
    #   break
    # elif [[ "${build_version}" -eq 1 ]]; then
    #   exit 1
    # fi
  done
done

#### Tag the pulled down image for all other regions in the partition
for region in $(aws ec2 describe-regions --all-regions | jq -r '.Regions[] .RegionName'); do
  for img in "${PULLED_IMGS[@]}"; do
    region_uri=$(./files/get-ecr-uri.sh "${region}" "${AWS_DOMAIN}")
    regional_img="${img/$ECR_URI/$region_uri}"
    echo "[TAGGED] ${regional_img}"
    # ## Tag ECR fips endpoint for supported regions
    # if [[ "${region}" =~ (us-east-1|us-east-2|us-west-1|us-west-2|us-gov-east-1|us-gov-east-2) ]]; then
    #   regional_fips_img="${regional_img/.ecr./.ecr-fips.}"
    #   sudo ctr -n k8s.io image tag "${img}" "${regional_fips_img}" || :
    #   sudo ctr -n k8s.io image tag "${img}" "${regional_fips_img/-eksbuild.1/}" || :
    # fi
    # ## Cache the non-addon VPC CNI images since "v*.*.*-eksbuild.1" is equivalent to leaving off the eksbuild suffix
    # if [[ "${img}" == *"-cni"*"-eksbuild.1" ]]; then
    #   sudo ctr -n k8s.io image tag "${img}" "${regional_img/-eksbuild.1/}" || :
    # fi
  done
done
```

And the results of that are as shown below. Note the images where the account ID is NOT `602401143452` - these are now using the corresponding account ID for the given region based on the `get-ecr-uri.sh` script:

```txt
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/pause:3.5
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[IMAGE] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/eks/pause:3.5
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/eks/pause:3.5
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/eks/pause:3.5
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 455263428931.dkr.ecr.eu-south-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/eks/pause:3.5
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 759879836304.dkr.ecr.me-central-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/eks/pause:3.5
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 066635153087.dkr.ecr.il-central-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ca-central-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-central-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/eks/pause:3.5
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 900612956339.dkr.ecr.eu-central-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/eks/pause:3.5
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 877085696533.dkr.ecr.af-south-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-north-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-3.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.eu-west-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-3.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/eks/pause:3.5
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 558608220178.dkr.ecr.me-south-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-northeast-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.sa-east-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/eks/pause:3.5
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 800184023465.dkr.ecr.ap-east-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/eks/pause:3.5
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 296578399912.dkr.ecr.ap-southeast-3.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/eks/pause:3.5
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 491585149902.dkr.ecr.ap-southeast-4.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/pause:3.5
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/kube-proxy:v1.27.1-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/kube-proxy:v1.27.4-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/eks/kube-proxy:v1.27.4-minimal-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.1
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
[TAGGED] 602401143452.dkr.ecr.us-east-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.1
```

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
