### PR TITLE
Modified check for AWS_ACCESS_KEY_ID

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -266,7 +266,7 @@ BINARIES=(
   aws-iam-authenticator
 )
 for binary in ${BINARIES[*]}; do
-  if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+  if [[ -v "AWS_ACCESS_KEY_ID" -n "$AWS_ACCESS_KEY_ID" ]]; then
     echo "AWS cli present - using it to copy binaries from s3."
     aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
     aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
@@ -300,7 +300,7 @@ if [ "$PULL_CNI_FROM_GITHUB" = "true" ]; then
   sudo sha512sum -c "${CNI_PLUGIN_FILENAME}.tgz.sha512"
   rm "${CNI_PLUGIN_FILENAME}.tgz.sha512"
 else
-  if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+  if [[ -v "AWS_ACCESS_KEY_ID" -n "$AWS_ACCESS_KEY_ID" ]]; then
     echo "AWS cli present - using it to copy binaries from s3."
     aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz .
     aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz.sha256 .
@@ -361,7 +361,7 @@ sudo chmod +x /etc/eks/max-pods-calculator.sh
 ### ECR CREDENTIAL PROVIDER ####################################################
 ################################################################################
 ECR_CREDENTIAL_PROVIDER_BINARY="ecr-credential-provider"
-if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
+if [[ -v "AWS_ACCESS_KEY_ID" -n "$AWS_ACCESS_KEY_ID" ]]; then
   echo "AWS cli present - using it to copy ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3."
   aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .
 else


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Modified the install-worker.sh script to check for the existence (-v) of the AWS_ACCESS_KEY_ID variable on top of just checking whether or not the variable is empty (-n). This modification will allow the installation script to work as a build component in an EC2 Image Builder pipeline. Currently these checks generate "unbound variable" errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
Tested using AWS CloudShell with and without the variable being set locally. Both tests were successful.

Testing with the variable NOT set:

2023-09-27T03:34:41Z:     amazon-ebs: Downloading binaries from: s3://amazon-eks
2023-09-27T03:34:41Z:     amazon-ebs: AWS cli missing - using wget to fetch binaries from s3. Note: This won't work for private bucket.
2023-09-27T03:34:41Z:     amazon-ebs: --2023-09-27 03:34:41--  https://amazon-eks.s3.us-west-2.amazonaws.com/1.25.13/2023-09-14/bin/linux/amd64/kubelet
2023-09-27T03:34:41Z:     amazon-ebs: Resolving amazon-eks.s3.us-west-2.amazonaws.com (amazon-eks.s3.us-west-2.amazonaws.com)... 52.218.152.169, 3.5.82.15, 52.218.247.201, ...
2023-09-27T03:34:41Z:     amazon-ebs: Connecting to amazon-eks.s3.us-west-2.amazonaws.com (amazon-eks.s3.us-west-2.amazonaws.com)|52.218.152.169|:443... connected.
2023-09-27T03:34:41Z:     amazon-ebs: HTTP request sent, awaiting response... 200 OK
2023-09-27T03:34:41Z:     amazon-ebs: Length: 120654560 (115M) [binary/octet-stream]
2023-09-27T03:34:41Z:     amazon-ebs: Saving to: ‘kubelet’
2023-09-27T03:34:41Z:     amazon-ebs:
2023-09-27T03:34:48Z:     amazon-ebs: 100%[======================================>] 120,654,560 15.6MB/s   in 7.0s

--------------------------------------------------------------------------------

Testing with the variable set:

2023-09-27T03:35:34Z:     amazon-ebs: Downloading binaries from: s3://amazon-eks
2023-09-27T03:35:34Z:     amazon-ebs: AWS cli present - using it to copy binaries from s3.
2023-09-27T03:35:36Z:     amazon-ebs: download: s3://amazon-eks/1.25.13/2023-09-14/bin/linux/amd64/kubelet to ./kubelet
2023-09-27T03:35:37Z:     amazon-ebs: download: s3://amazon-eks/1.25.13/2023-09-14/bin/linux/amd64/kubelet.sha256 to ./kubelet.sha256
2023-09-27T03:35:37Z:     amazon-ebs: kubelet: OK
2023-09-27T03:35:37Z:     amazon-ebs: AWS cli present - using it to copy binaries from s3.
2023-09-27T03:35:39Z:     amazon-ebs: download: s3://amazon-eks/1.25.13/2023-09-14/bin/linux/amd64/aws-iam-authenticator to ./aws-iam-authenticator
2023-09-27T03:35:40Z:     amazon-ebs: download: s3://amazon-eks/1.25.13/2023-09-14/bin/linux/amd64/aws-iam-authenticator.sha256 to ./aws-iam-authenticator.sha256
2023-09-27T03:35:41Z:     amazon-ebs: aws-iam-authenticator: OK

--------------------------------------------------------------------------------

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
