### PR TITLE
Add FIPS building support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,19 +26,22 @@ ifeq ($(call vercmp,$(kubernetes_version),gteq,1.25.0), true)
 	ami_component_description ?= (k8s: {{ user `kubernetes_version` }}, containerd: {{ user `containerd_version` }})
 endif
 
-OS=
+AMI_VERSION ?= v$(shell date '+%Y%m%d')
+AMI_VARIANT ?= amazon-eks
 ifneq (,$(findstring al2023, $(PACKER_TEMPLATE_FILE)))
-	OS=-al2023
+	AMI_VARIANT := $(AMI_VARIANT)-al2023
 endif
-
 arch ?= x86_64
 ifeq ($(arch), arm64)
 	instance_type ?= m6g.large
-	ami_name ?= amazon-eks-arm64-node$(OS)-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
+	AMI_VARIANT := $(AMI_VARIANT)-arm64
 else
 	instance_type ?= m5.large
-	ami_name ?= amazon-eks-node$(OS)-$(K8S_VERSION_MINOR)-v$(shell date +'%Y%m%d')
 endif
+ifeq ($(enable_fips), true)
+	AMI_VARIANT := $(AMI_VARIANT)-fips
+endif
+ami_name ?= $(AMI_VARIANT)-node-$(K8S_VERSION_MINOR)-$(AMI_VERSION)
 
 ifeq ($(aws_region), cn-northwest-1)
 	source_ami_owners ?= 141808717104

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -41,6 +41,7 @@ Users have the following options for specifying their own values:
 | `creator` | ```{{env `USER`}}``` |  |
 | `docker_version` | ```20.10.23-1.amzn2.0.1``` |  |
 | `encrypted` | ```false``` |  |
+| `enable_fips` | ```false``` | Install openssl and enable fips related kernel parameters |
 | `instance_type` | *None* |  |
 | `kernel_version` | `""` |  |
 | `kms_key_id` | `""` |  |

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -16,6 +16,7 @@
     "containerd_version": "1.6.*",
     "creator": "{{env `USER`}}",
     "docker_version": "20.10.23-1.amzn2.0.1",
+    "enable_fips": "false",
     "encrypted": "false",
     "kernel_version": "",
     "kms_key_id": "",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -21,6 +21,7 @@
     "creator": null,
     "docker_version": null,
     "encrypted": null,
+    "enable_fips": null,
     "instance_type": null,
     "kernel_version": null,
     "kms_key_id": null,
@@ -152,13 +153,25 @@
     {
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
-      "expect_disconnect": true,
-      "pause_after": "90s",
       "script": "{{template_dir}}/scripts/upgrade_kernel.sh",
       "environment_vars": [
         "KUBERNETES_VERSION={{user `kubernetes_version`}}",
         "KERNEL_VERSION={{user `kernel_version`}}"
       ]
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "script": "{{template_dir}}/scripts/enable-fips.sh",
+      "environment_vars": [
+        "ENABLE_FIPS={{user `enable_fips`}}"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": ["sudo reboot"],
+      "expect_disconnect": true,
+      "pause_after": "90s"
     },
     {
       "type": "shell",

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -169,6 +169,7 @@
     },
     {
       "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
       "inline": ["sudo reboot"],
       "expect_disconnect": true,
       "pause_after": "90s"

--- a/files/get-ecr-uri.sh
+++ b/files/get-ecr-uri.sh
@@ -69,4 +69,10 @@ else
   esac
 fi
 
-echo "${acct}.dkr.ecr.${region}.${aws_domain}"
+AWS_ECR_SUBDOMAIN="ecr"
+# if FIPS is enabled on the machine, use the FIPS endpoint.
+if [[ "$(sysctl -n crypto.fips_enabled)" == 1 ]]; then
+  AWS_ECR_SUBDOMAIN="ecr-fips"
+fi
+
+echo "${acct}.dkr.${AWS_ECR_SUBDOMAIN}.${region}.${aws_domain}"

--- a/scripts/enable-fips.sh
+++ b/scripts/enable-fips.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# https://aws.amazon.com/blogs/publicsector/enabling-fips-mode-amazon-linux-2/
+if [[ "$ENABLE_FIPS" == "true" ]]; then
+  # install and enable fips modules
+  sudo yum install -y dracut-fips openssl
+  sudo dracut -f
+
+  # enable fips in the boot command
+  sudo /sbin/grubby --update-kernel=ALL --args="fips=1"
+fi

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -31,5 +31,3 @@ sudo grubby \
 sudo grubby \
   --update-kernel=ALL \
   --args="clocksource=tsc tsc=reliable"
-
-sudo reboot


### PR DESCRIPTION
Addresses #1002.

Description of Changes:

Based on #1028 which was based on #898.

This change adds a new variable called `enable_fips` which will install openssl and enable fips mode as a kernel paramter on boot. Additionally fips mode can be enabled while running make by setting `enable_fips=true` on the command line which will add `-fips` to the ami name and set `enable_fips` to `true` when building.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Built an AMI and verified it is usable with EKS. Additionally verified fips is enabled by checking `sysctl crypto.fips_enabled` is returning 1.
