### PR TITLE
Fix region in cached image names

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -466,7 +466,7 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
   done
 
   #### Tag the pulled down image for all other regions in the partition
-  for region in "${REGIONS[@]}"; do
+  for region in ${REGIONS[*]}; do
     for img in "${PULLED_IMGS[@]}"; do
       region_uri=$(/etc/eks/get-ecr-uri.sh "${region}" "${AWS_DOMAIN}")
       regional_img="${img/$ECR_URI/$region_uri}"


### PR DESCRIPTION
**Issue #, if available:**

Fixes #1460 

**Description of changes:**

The quotes around `${REGIONS[@]}` cause the array elements to be combined into a single string (containing newlines). The result is an ineffective image cache with wonky image names, e.g.:

```
602401143452.dkr.ecr.ap-south-2
ap-south-1
eu-south-1
eu-south-2
me-central-1
il-central-1
ca-central-1
eu-central-1
eu-central-2
us-west-1
us-west-2
af-south-1
eu-north-1
eu-west-3
eu-west-2
eu-west-1
ap-northeast-3
ap-northeast-2
me-south-1
ap-northeast-1
sa-east-1
ap-east-1
ap-southeast-1
ap-southeast-2
ap-southeast-3
ap-southeast-4
us-east-1
us-east-2.amazonaws.com/eks/pause:3.5
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Built a 1.27 AMI with `cache_container_images=true`, names are correct, e.g.:
```
2023-10-10T10:07:43-07:00:     amazon-ebs: 900889452093.dkr.ecr.ap-south-2.amazonaws.com/eks/pause:3.5
2023-10-10T10:07:43-07:00:     amazon-ebs: 900889452093.dkr.ecr.ap-south-2.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
2023-10-10T10:07:43-07:00:     amazon-ebs: 900889452093.dkr.ecr.ap-south-2.amazonaws.com/eks/kube-proxy:v1.27.6-minimal-eksbuild.2
2023-10-10T10:07:43-07:00:     amazon-ebs: 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
2023-10-10T10:07:43-07:00:     amazon-ebs: 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 900889452093.dkr.ecr.ap-south-2.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 602401143452.dkr.ecr.ap-south-1.amazonaws.com/eks/pause:3.5
2023-10-10T10:07:44-07:00:     amazon-ebs: 602401143452.dkr.ecr.ap-south-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
2023-10-10T10:07:44-07:00:     amazon-ebs: 602401143452.dkr.ecr.ap-south-1.amazonaws.com/eks/kube-proxy:v1.27.6-minimal-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 602401143452.dkr.ecr.ap-south-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 590381155156.dkr.ecr.eu-south-1.amazonaws.com/eks/pause:3.5
2023-10-10T10:07:44-07:00:     amazon-ebs: 590381155156.dkr.ecr.eu-south-1.amazonaws.com/eks/kube-proxy:v1.27.1-minimal-eksbuild.1
2023-10-10T10:07:44-07:00:     amazon-ebs: 590381155156.dkr.ecr.eu-south-1.amazonaws.com/eks/kube-proxy:v1.27.6-minimal-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni:v1.12.6-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni-init:v1.12.6-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni:v1.15.0-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 590381155156.dkr.ecr.eu-south-1.amazonaws.com/amazon-k8s-cni-init:v1.15.0-eksbuild.2
2023-10-10T10:07:44-07:00:     amazon-ebs: 455263428931.dkr.ecr.eu-south-2.amazonaws.com/eks/pause:3.5
```