### PR TITLE
Add missing remote_folder properties when using the shell provisioner

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -119,6 +119,7 @@
   "provisioners": [
     {
       "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
       "inline": [
         "mkdir -p {{user `working_dir`}}",
         "mkdir -p {{user `working_dir`}}/log-collector-script"
@@ -144,6 +145,7 @@
     },
     {
       "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
       "inline": [
         "sudo chmod -R a+x {{user `working_dir`}}/bin/",
         "sudo mv {{user `working_dir`}}/bin/* /usr/bin/"
@@ -221,6 +223,7 @@
     },
     {
       "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
       "inline": [
         "rm -rf {{user `working_dir`}}"
       ]


### PR DESCRIPTION
**Description of changes:**

This change sets the `remote_folder` property for all use of the shell provisioner. This is to support source AMIs with a noexec option set on the /tmp partition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

This was tested with a custom AmazonLinux2 image as source AMI.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
