### PR TITLE
Add named arguments to bot commands

### DIFF
--- a/.github/actions/bot/README.md
+++ b/.github/actions/bot/README.md
@@ -4,9 +4,18 @@ This GitHub Action parses commands from pull request comments and executes them.
 
 Only authorized users (members and owners of this repository) are able to execute commands.
 
-Commands look like:
+Commands look like `/COMMAND ARGS`, for example:
 ```
 /echo hello world
 ```
 
 Multiple commands can be included in a comment, one per line; but each command must be unique.
+
+Some commands accept additional, named arguments specified on subsequent lines.
+Named arguments look like `+NAME ARGS`, for example:
+```
+/ci launch
++build cache_container_images=true
+```
+
+Multiple named arguments can be specified.

--- a/.github/actions/ci/build/action.yaml
+++ b/.github/actions/ci/build/action.yaml
@@ -9,6 +9,9 @@ inputs:
   k8s_version:
     required: true
     type: string
+  additional_arguments:
+    required: false
+    type: string
 outputs:
   ami_id:
     value: ${{ steps.build.outputs.ami_id }}
@@ -22,5 +25,5 @@ runs:
       shell: bash
       run: |
         AMI_NAME="amazon-eks-node-${{ inputs.k8s_version }}-${{ inputs.build_id }}"
-        make ${{ inputs.k8s_version }} ami_name=${AMI_NAME}
+        make ${{ inputs.k8s_version }} ami_name=${AMI_NAME} ${{ inputs.additional_arguments }}
         echo "ami_id=$(jq -r .builds[0].artifact_id "${AMI_NAME}-manifest.json" | cut -d ':' -f 2)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -26,6 +26,9 @@ on:
           - "build"
           - "launch"
           - "test"
+      build_arguments:
+        required: false
+        type: string
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -89,6 +92,7 @@ jobs:
           git_sha: ${{ inputs.git_sha }}
           k8s_version: ${{ matrix.k8s_version }}
           build_id: ${{ needs.setup.outputs.build_id }}
+          additional_arguments: ${{ inputs.build_arguments }}
       - if: ${{ inputs.goal == 'launch' || inputs.goal == 'test' }}
         name: "${{ needs.setup.outputs.ci_step_name_prefix }} Launch"
         id: launch


### PR DESCRIPTION
**Description of changes:**

The `/ci` command accepts a "goal" as an argument. The goals make up a DAG, `build` -> `launch` -> `test`.

We sometimes need to kick off a CI run with specific arguments for one of these goals. For example, you might want to achieve the `test` goal, but pass an additional argument to the `build` goal.

This PR adds a new syntax to pass "named arguments" to a command. For the above example, you would do:
```
/ci test
+build cache_container_images=true
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Tested in my fork: https://github.com/cartermckinnon/amazon-eks-ami/pull/6864#issuecomment-1756238390

I can see the arg passed correctly to the workflow in the logs.