### PR TITLE
get-ecr-uri.sh falls back to use another region in partition if regio…

### DIFF
--- a/files/get-ecr-uri.sh
+++ b/files/get-ecr-uri.sh
@@ -39,14 +39,14 @@ else
     af-south-1)
       acct="877085696533"
       ;;
-    eu-south-1)
-      acct="590381155156"
-      ;;
     ap-southeast-3)
       acct="296578399912"
       ;;
     me-central-1)
       acct="759879836304"
+      ;;
+    eu-south-1)
+      acct="590381155156"
       ;;
     eu-south-2)
       acct="455263428931"
@@ -63,10 +63,51 @@ else
     il-central-1)
       acct="066635153087"
       ;;
-    *)
+    # This sections includes all commercial non-opt-in regions, which use
+    # the same account for ECR pause container images, but still have in-region
+    # registries.
+    ap-northeast-1 | \
+      ap-northeast-2 | \
+      ap-northeast-3 | \
+      ap-south-1 | \
+      ap-southeast-1 | \
+      ap-southeast-2 | \
+      ca-central-1 | \
+      eu-central-1 | \
+      eu-north-1 | \
+      eu-west-1 | \
+      eu-west-2 | \
+      eu-west-3 | \
+      sa-east-1 | \
+      us-east-1 | \
+      us-east-2 | \
+      us-west-1 | \
+      us-west-2)
       acct="602401143452"
       ;;
-  esac
+    # If the region is not mapped to an account, let's try to choose another region
+    # in that partition.
+    us-gov-*)
+      acct="013241004608"
+      region="us-gov-west-1"
+      ;;
+    cn-*)
+      acct="961992271922"
+      region="cn-northwest-1"
+      ;;
+    us-iso-*)
+      acct="725322719131"
+      region="us-iso-east-1"
+      ;;
+    us-isob-*)
+      acct="187977181151"
+      region="us-isob-east-1"
+      ;;
+    *)
+      acct="602401143452"
+      region="us-west-2"
+      ;;
+  esac # end region check
 fi
 
 AWS_ECR_SUBDOMAIN="ecr"

--- a/test/cases/get-ecr-uri.sh
+++ b/test/cases/get-ecr-uri.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+echo "--> Should use specified account when passed in"
+EXPECTED_ECR_URI="999999999999.dkr.ecr.mars-west-1.amazonaws.com.mars"
+REGION="mars-west-1"
+DOMAIN="amazonaws.com.mars"
+ECR_URI=$(/etc/eks/get-ecr-uri.sh "${REGION}" "${DOMAIN}" "999999999999")
+if [ ! "$ECR_URI" = "$EXPECTED_ECR_URI" ]; then
+  echo "❌ Test Failed: expected ecr-uri=$EXPECTED_ECR_URI but got '${ECR_URI}'"
+  exit 1
+fi
+
+echo "--> Should use account mapped to the region when set"
+EXPECTED_ECR_URI="590381155156.dkr.ecr.eu-south-1.amazonaws.com"
+REGION="eu-south-1"
+DOMAIN="amazonaws.com"
+ECR_URI=$(/etc/eks/get-ecr-uri.sh "${REGION}" "${DOMAIN}")
+if [ ! "$ECR_URI" = "$EXPECTED_ECR_URI" ]; then
+  echo "❌ Test Failed: expected ecr-uri=$EXPECTED_ECR_URI but got '${ECR_URI}'"
+  exit 1
+fi
+
+echo "--> Should use non-opt-in account when not opt-in-region"
+EXPECTED_ECR_URI="602401143452.dkr.ecr.us-east-2.amazonaws.com"
+REGION="us-east-2"
+DOMAIN="amazonaws.com"
+ECR_URI=$(/etc/eks/get-ecr-uri.sh "${REGION}" "${DOMAIN}")
+if [ ! "$ECR_URI" = "$EXPECTED_ECR_URI" ]; then
+  echo "❌ Test Failed: expected ecr-uri=$EXPECTED_ECR_URI but got '${ECR_URI}'"
+  exit 1
+fi
+
+echo "--> Should use us-west-2 account and region when opt-in-region"
+EXPECTED_ECR_URI="602401143452.dkr.ecr.us-west-2.amazonaws.com"
+REGION="eu-south-100"
+DOMAIN="amazonaws.com"
+ECR_URI=$(/etc/eks/get-ecr-uri.sh "${REGION}" "${DOMAIN}")
+if [ ! "$ECR_URI" = "$EXPECTED_ECR_URI" ]; then
+  echo "❌ Test Failed: expected ecr-uri=$EXPECTED_ECR_URI but got '${ECR_URI}'"
+  exit 1
+fi
+
+echo "--> Should default us-gov-west-1 when unknown amazonaws.com.us-gov region"
+EXPECTED_ECR_URI="013241004608.dkr.ecr.us-gov-west-1.amazonaws.com.us-gov"
+REGION="us-gov-east-100"
+DOMAIN="amazonaws.com.us-gov"
+ECR_URI=$(/etc/eks/get-ecr-uri.sh "${REGION}" "${DOMAIN}")
+if [ ! "$ECR_URI" = "$EXPECTED_ECR_URI" ]; then
+  echo "❌ Test Failed: expected ecr-uri=$EXPECTED_ECR_URI but got '${ECR_URI}'"
+  exit 1
+fi
+
+echo "--> Should default cn-northwest-1 when unknown amazonaws.com.cn region"
+EXPECTED_ECR_URI="961992271922.dkr.ecr.cn-northwest-1.amazonaws.com.cn"
+REGION="cn-north-100"
+DOMAIN="amazonaws.com.cn"
+ECR_URI=$(/etc/eks/get-ecr-uri.sh "${REGION}" "${DOMAIN}")
+if [ ! "$ECR_URI" = "$EXPECTED_ECR_URI" ]; then
+  echo "❌ Test Failed: expected ecr-uri=$EXPECTED_ECR_URI but got '${ECR_URI}'"
+  exit 1
+fi
+
+echo "--> Should default us-iso-east-1 when unknown amazonaws.com.iso region"
+EXPECTED_ECR_URI="725322719131.dkr.ecr.us-iso-east-1.amazonaws.com.iso"
+REGION="us-iso-west-100"
+DOMAIN="amazonaws.com.iso"
+ECR_URI=$(/etc/eks/get-ecr-uri.sh "${REGION}" "${DOMAIN}")
+if [ ! "$ECR_URI" = "$EXPECTED_ECR_URI" ]; then
+  echo "❌ Test Failed: expected ecr-uri=$EXPECTED_ECR_URI but got '${ECR_URI}'"
+  exit 1
+fi
+
+echo "--> Should default us-isob-east-1 when unknown amazonaws.com.isob region"
+EXPECTED_ECR_URI="187977181151.dkr.ecr.us-isob-east-1.amazonaws.com.isob"
+REGION="us-isob-west-100"
+DOMAIN="amazonaws.com.isob"
+ECR_URI=$(/etc/eks/get-ecr-uri.sh "${REGION}" "${DOMAIN}")
+if [ ! "$ECR_URI" = "$EXPECTED_ECR_URI" ]; then
+  echo "❌ Test Failed: expected ecr-uri=$EXPECTED_ECR_URI but got '${ECR_URI}'"
+  exit 1
+fi


### PR DESCRIPTION
…n unconfigured

**Issue #, if available:**
N/A

**Description of changes:**
The `get-ecr-uri/sh` script is used to get the ECR URI for the pause container in the region. I've updated that script to fall back to another region in the same partition if the region is unknown. This is necessary to automate support for new regions. Eventually, we should still add an entry for the specific region, but this will enable new regions without a change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

New unit tests added for the script. Also, I removed the entry for `eu-south-1`, which is an opt-in region, and validated that the nodes were still able to join the clusters in that region.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
