### PR TITLE
Allow more flexible kernel_version

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -52,6 +52,13 @@ fi
 ### Packages ###################################################################
 ################################################################################
 
+sudo yum install -y \
+  yum-utils \
+  yum-plugin-versionlock
+
+# lock the version of the kernel and associated packages before we yum update
+sudo yum versionlock kernel-$(uname -r) kernel-headers-$(uname -r) kernel-devel-$(uname -r)
+
 # Update the OS to begin with to catch up to the latest packages.
 sudo yum update -y
 
@@ -68,8 +75,6 @@ sudo yum install -y \
   socat \
   unzip \
   wget \
-  yum-utils \
-  yum-plugin-versionlock \
   mdadm \
   pigz
 
@@ -87,8 +92,6 @@ else
   # curl-minimal already exists in al2023 so install curl only on al2
   sudo yum install -y curl
 fi
-
-sudo yum versionlock kernel-$(uname -r) kernel-headers-$(uname -r) kernel-devel-$(uname -r)
 
 # Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
 if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi

--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -13,13 +13,15 @@ if [[ -z "$KERNEL_VERSION" ]]; then
   echo "kernel_version is unset. Setting to $KERNEL_VERSION based on Kubernetes version $KUBERNETES_VERSION."
 fi
 
-if [[ $KERNEL_VERSION == "4.14" ]]; then
-  sudo yum update -y kernel
+if [[ $KERNEL_VERSION == 4.14* ]]; then
+  sudo yum install -y "kernel-${KERNEL_VERSION}*"
 else
-  sudo amazon-linux-extras install -y "kernel-${KERNEL_VERSION}"
+  KERNEL_MINOR_VERSION=$(echo ${KERNEL_VERSION} | cut -d. -f-2)
+  sudo amazon-linux-extras enable "kernel-${KERNEL_MINOR_VERSION}"
+  sudo yum install -y "kernel-${KERNEL_VERSION}*"
 fi
 
-sudo yum install -y kernel-headers kernel-devel
+sudo yum install -y "kernel-headers-${KERNEL_VERSION}*" "kernel-devel-${KERNEL_VERSION}*"
 
 # enable pressure stall information
 sudo grubby \


### PR DESCRIPTION
**Description of changes:**

Makes the `kernel_version` template variable more flexible. Today, you can only use a "minor version" such as `4.14`, `5.4`, or `5.10`. This change allows us to specify a fully-formed kernel version as well, such as `5.10.192-183.736`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

This succeeds, and installs the latest 5.10 kernel as expected.
```
make 1.28
```

This succeeds, and installs the specified kernel version as expected:
```
make 1.28 kernel_version=5.10.192-183.736
```