### PR TITLE
chore: fix versions script

### DIFF
--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -32,7 +32,7 @@ echo $(jq ".binaries.awscli = \"$CLI_VERSION\"" $OUTPUT_FILE) > $OUTPUT_FILE
 
 # cached images
 if systemctl is-active --quiet containerd; then
-  echo $(jq ".images = [ $(sudo ctr -n k8s.io image ls -q | grep '/' | rev |  cut -d'/' -f1 | rev | sort | uniq | grep -v 'sha256' | xargs -r printf "\"%s\"," | sed 's/,$//') ]" $OUTPUT_FILE) > $OUTPUT_FILE
+  echo $(jq ".images = [ $(sudo ctr -n k8s.io image ls -q | grep '/' | rev | cut -d'/' -f1 | rev | sort | uniq | grep -v 'sha256' | xargs -r printf "\"%s\"," | sed 's/,$//') ]" $OUTPUT_FILE) > $OUTPUT_FILE
 elif [ "${CACHE_CONTAINER_IMAGES}" = "true" ]; then
   echo "containerd must be active to generate version info for cached images"
   exit 1

--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -32,7 +32,7 @@ echo $(jq ".binaries.awscli = \"$CLI_VERSION\"" $OUTPUT_FILE) > $OUTPUT_FILE
 
 # cached images
 if systemctl is-active --quiet containerd; then
-  echo $(jq ".images = [ $(sudo ctr -n k8s.io image ls -q | cut -d'/' -f2- | sort | uniq | grep -v 'sha256' | xargs -r printf "\"%s\"," | sed 's/,$//') ]" $OUTPUT_FILE) > $OUTPUT_FILE
+  echo $(jq ".images = [ $(sudo ctr -n k8s.io image ls -q | grep '/' | rev |  cut -d'/' -f1 | rev | sort | uniq | grep -v 'sha256' | xargs -r printf "\"%s\"," | sed 's/,$//') ]" $OUTPUT_FILE) > $OUTPUT_FILE
 elif [ "${CACHE_CONTAINER_IMAGES}" = "true" ]; then
   echo "containerd must be active to generate version info for cached images"
   exit 1


### PR DESCRIPTION
**Issue #, if available:**
n/a

**Description of changes:**
 - Fix versions file for cached images

Was showing like this:
```
  "images": [
    "602401143452.dkr.ecr.ap-south-2",
    "602401143452.dkr.ecr-fips.ap-south-2",
    "602401143452.dkr.ecr.us-west-2.amazonaws.com",
    "af-south-1",
    "ap-east-1",
    "ap-northeast-1",
    "ap-northeast-2",
    "ap-northeast-3",
    "ap-south-1",
    "ap-southeast-1",
    "ap-southeast-2",
    "ap-southeast-3",
    "ap-southeast-4",
    "ca-central-1",
    "eu-central-1",
    "eu-central-2",
    "eu-north-1",
    "eu-south-1",
    "eu-south-2",
    "eu-west-1",
    "eu-west-2",
    "eu-west-3",
    "il-central-1",
    "me-central-1",
    "me-south-1",
    "sa-east-1",
    "us-east-1",
    "us-east-2.amazonaws.com",
    "us-west-1",
    "us-west-2"
  ]
```

now shows like this:

```
  "images": [
    "amazon-k8s-cni-init:v1.14.1",
    "amazon-k8s-cni-init:v1.14.1-eksbuild.1",
    "amazon-k8s-cni-init:v1.15.0-eksbuild.2",
    "amazon-k8s-cni:v1.14.1",
    "amazon-k8s-cni:v1.14.1-eksbuild.1",
    "amazon-k8s-cni:v1.15.0-eksbuild.2",
    "kube-proxy:v1.28.1-minimal",
    "kube-proxy:v1.28.1-minimal-eksbuild.1",
    "kube-proxy:v1.28.2-minimal-eksbuild.2",
    "pause:3.5"
  ]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
