### PR TITLE
Persist CI version-info.json as artifact

### DIFF
--- a/.github/actions/ci/build/action.yaml
+++ b/.github/actions/ci/build/action.yaml
@@ -27,3 +27,7 @@ runs:
         AMI_NAME="amazon-eks-node-${{ inputs.k8s_version }}-${{ inputs.build_id }}"
         make ${{ inputs.k8s_version }} ami_name=${AMI_NAME} ${{ inputs.additional_arguments }}
         echo "ami_id=$(jq -r .builds[0].artifact_id "${AMI_NAME}-manifest.json" | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
+    - uses: actions/upload-artifact@v3
+      with:
+        name: version-info
+        path: "*-version-info.json"


### PR DESCRIPTION
**Description of changes:**

Uploads the `version-info.json` file as an artifact of the CI build action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing done:**

Works in my fork: https://github.com/cartermckinnon/amazon-eks-ami/actions/runs/6658537660