### PR TITLE
Drop the FIPS related provisioners for al2023

### DIFF
--- a/hack/transform-al2-to-al2023.sh
+++ b/hack/transform-al2-to-al2023.sh
@@ -19,6 +19,8 @@ cat "${PACKER_TEMPLATE_FILE}" \
   | jq '._comment = "All template variables are enumerated here; and most variables have a default value defined in eks-worker-al2023-variables.json"' \
   | jq '.variables.temporary_key_pair_type = "ed25519"' \
   | jq 'del(.provisioners[5])' \
+  | jq 'del(.provisioners[5])' \
+  | jq 'del(.provisioners[5])' \
     > "${PACKER_TEMPLATE_FILE/al2/al2023}"
 
 # use newer versions of containerd and runc, do not install docker


### PR DESCRIPTION
Let's not try to enable FIPS for al2023 yet! the reboot may be cleaning up `/tmp` as well here. So just disable the 2 provisioners (script + reboot)

from https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cgroupv2-containerd-node-arm64-al2023-e2e-ec2-eks/1719129294296322048/build-log.txt
```
2023-10-30T23:28:58Z:     amazon-ebs: mv: cannot stat '/tmp/worker/configure-clocksource.service': No such file or directory
```