### PR TITLE
Skip installing amazon-ssm-agent if already present

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -503,11 +503,15 @@ fi
 ### SSM Agent ##################################################################
 ################################################################################
 
-echo "Installing amazon-ssm-agent"
-if ! [[ ${ISOLATED_REGIONS} =~ $BINARY_BUCKET_REGION ]]; then
-  sudo yum install -y https://s3.${BINARY_BUCKET_REGION}.${S3_DOMAIN}/amazon-ssm-${BINARY_BUCKET_REGION}/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm
+if yum list installed | grep amazon-ssm-agent; then
+  echo "amazon-ssm-agent already present - skipping install"
 else
-  sudo yum install -y amazon-ssm-agent
+  echo "Installing amazon-ssm-agent"
+  if ! [[ ${ISOLATED_REGIONS} =~ $BINARY_BUCKET_REGION ]]; then
+    sudo yum install -y https://s3.${BINARY_BUCKET_REGION}.${S3_DOMAIN}/amazon-ssm-${BINARY_BUCKET_REGION}/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm
+  else
+    sudo yum install -y amazon-ssm-agent
+  fi
 fi
 
 ################################################################################


### PR DESCRIPTION
**Issue #, if available:**
#1500

**Description of changes:**
This skips installation of the amazon-ssm-agent if it is already installed on base AMI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
