### PR TITLE
Sets docker to the latest 20.10 version

### DIFF
--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -39,7 +39,7 @@ Users have the following options for specifying their own values:
 | `cni_plugin_version` | ```v1.2.0``` |  |
 | `containerd_version` | ```1.6.*``` |  |
 | `creator` | ```{{env `USER`}}``` |  |
-| `docker_version` | ```20.10.23-1.amzn2.0.1``` |  |
+| `docker_version` | ```20.10.*``` |  |
 | `encrypted` | ```false``` |  |
 | `enable_fips` | ```false``` | Install openssl and enable fips related kernel parameters |
 | `instance_type` | *None* |  |

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -15,7 +15,7 @@
     "cni_plugin_version": "v1.2.0",
     "containerd_version": "1.6.*",
     "creator": "{{env `USER`}}",
-    "docker_version": "20.10.23-1.amzn2.0.1",
+    "docker_version": "20.10.*",
     "enable_fips": "false",
     "encrypted": "false",
     "kernel_version": "",


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
The docker version is pinned to an older version, and there are updates available, including CVE fixes like [this one](https://alas.aws.amazon.com/AL2/ALASDOCKER-2023-031.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Built a 1.23 AMI and can see that it's using the latest docker version:

```
2023-11-09T08:52:37-08:00:     amazon-ebs: Installed:
2023-11-09T08:52:37-08:00:     amazon-ebs:   docker.x86_64 0:20.10.25-1.amzn2.0.3
```
