### PR TITLE
add sudo to avoid error out with UMASK set to 027

### DIFF
--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -16,14 +16,14 @@ OUTPUT_FILE="$1"
 sudo rpm --query --all --queryformat '\{"%{NAME}": "%{VERSION}-%{RELEASE}"\}\n' | jq --slurp --sort-keys 'add | {packages:(.)}' > "$OUTPUT_FILE"
 
 # binaries
-KUBELET_VERSION=$(kubelet --version | awk '{print $2}')
+KUBELET_VERSION=$(sudo kubelet --version | awk '{print $2}')
 if [ "$?" != 0 ]; then
   echo "unable to get kubelet version"
   exit 1
 fi
 echo $(jq ".binaries.kubelet = \"$KUBELET_VERSION\"" $OUTPUT_FILE) > $OUTPUT_FILE
 
-CLI_VERSION=$(aws --version | awk '{print $1}' | cut -d '/' -f 2)
+CLI_VERSION=$(sudo aws --version | awk '{print $1}' | cut -d '/' -f 2)
 if [ "$?" != 0 ]; then
   echo "unable to get aws cli version"
   exit 1


### PR DESCRIPTION
**Issue #, if available:**

When source_ami is using With UMASK set to 027, `kubelet` and `aws` will error out with permissions issue.

 The following is what I have for both `kubelet` and `aws`
```
amazon-ebs: -rwxr-x---. 1 root root 120671264 Nov 7 09:14 /usr/bin/kubelet
amazon-ebs: -rwxr-x---. 1 root root 6692768 Nov 13 20:11 /usr/local/aws-cli/v2/2.13.34/dist/aws
```

Errors I had: 
```
==> amazon-ebs: Provisioning with shell script: /work/amazon-eks-ami/scripts/generate-version-info.sh
    amazon-ebs: /home/ec2-user/script_5180.sh: line 19: /usr/bin/kubelet: Permission denied
==> amazon-ebs: Provisioning step had errors: Running the cleanup provisioner, if present...
```

**Description of changes:**
Add 'sudo' in front of both commands, which will avoid errors listed above

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Tested with UMASK 027 images with 'sudo', worked as expected.
Tested with vanilla AWS AL2 latest image, worked as expected. 
