### PR TITLE
[WIP] Use `kernel-5.15` on Kubernetes 1.29+

### DIFF
--- a/scripts/upgrade_kernel.sh
+++ b/scripts/upgrade_kernel.sh
@@ -5,7 +5,9 @@ set -o nounset
 set -o errexit
 
 if [[ -z "$KERNEL_VERSION" ]]; then
-  if vercmp "$KUBERNETES_VERSION" gteq "1.24.0"; then
+  if vercmp "$KUBERNETES_VERSION" gteq "1.29.0"; then
+    KERNEL_VERSION=5.15
+  elif vercmp "$KUBERNETES_VERSION" gteq "1.24.0"; then
     KERNEL_VERSION=5.10
   else
     KERNEL_VERSION=5.4


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Use the 5.15 kernel for AMI's with Kubernetes 1.29 and above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
 
*Blocked until 1.29 initial release in k/k*