### PR TITLE
Miscellaneous fixes from AL2023 testing

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -407,7 +407,7 @@ fi
 
 log "INFO: Using IP family: ${IP_FAMILY}"
 
-echo $B64_CLUSTER_CA | base64 -d > $CA_CERTIFICATE_FILE_PATH
+echo "$B64_CLUSTER_CA" | base64 -d > $CA_CERTIFICATE_FILE_PATH
 
 sed -i s,MASTER_ENDPOINT,$APISERVER_ENDPOINT,g /var/lib/kubelet/kubeconfig
 sed -i s,AWS_REGION,$AWS_DEFAULT_REGION,g /var/lib/kubelet/kubeconfig

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -88,13 +88,19 @@ fi
 if cat /etc/*release | grep "al2023" > /dev/null 2>&1; then
   # exists in al2023 only (needed by kubelet)
   sudo yum install -y iptables-legacy
+
+  # Remove the amazon-ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
+  if yum list installed | grep amazon-ec2-net-utils; then sudo yum remove amazon-ec2-net-utils -y -q; fi
+
+  # Temporary fix for https://github.com/aws/amazon-vpc-cni-k8s/pull/2118
+  sed -i "s/^MACAddressPolicy=.*/MACAddressPolicy=none/" /usr/lib/systemd/network/99-default.link
 else
   # curl-minimal already exists in al2023 so install curl only on al2
   sudo yum install -y curl
-fi
 
-# Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
-if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi
+  # Remove the ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
+  if yum list installed | grep ec2-net-utils; then sudo yum remove ec2-net-utils -y -q; fi
+fi
 
 sudo mkdir -p /etc/eks/
 


### PR DESCRIPTION
- Add `"` around `B64_CLUSTER_CA` so a multi-line value can be saved correctly into the file
- In AL2 we had `ec2-net-utils` which is now named `amazon-ec2-net-utils` so handle them separately/explicitly (so it's obvious!)
-  Patch `MACAddressPolicy` which defaults to `persistent` in AL2023 and [causes issues](https://github.com/aws/amazon-vpc-cni-k8s/pull/2118)