### PR TITLE
fix Permission denied for 99-default.link

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -93,7 +93,7 @@ if cat /etc/*release | grep "al2023" > /dev/null 2>&1; then
   if yum list installed | grep amazon-ec2-net-utils; then sudo yum remove amazon-ec2-net-utils -y -q; fi
 
   # Temporary fix for https://github.com/aws/amazon-vpc-cni-k8s/pull/2118
-  sed -i "s/^MACAddressPolicy=.*/MACAddressPolicy=none/" /usr/lib/systemd/network/99-default.link
+  sudo sed -i "s/^MACAddressPolicy=.*/MACAddressPolicy=none/" /usr/lib/systemd/network/99-default.link || true
 else
   # curl-minimal already exists in al2023 so install curl only on al2
   sudo yum install -y curl


### PR DESCRIPTION
Let's try `sudo` and also throw in `|| true` for good measure!

```
2023-11-25T04:27:26Z:     amazon-ebs: sed: couldn't open temporary file /usr/lib/systemd/network/sedelA3MU: Permission denied
2023-11-25T04:27:26Z: ==> amazon-ebs: Provisioning step had errors: Running the cleanup provisioner, if present...
```