### PR TITLE
Install SSM agent from AL core repo by default

### DIFF
--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -58,7 +58,7 @@ Users have the following options for specifying their own values:
 | `source_ami_owners` | ```137112412989``` |  |
 | `ssh_interface` | `""` |  |
 | `ssh_username` | ```ec2-user``` |  |
-| `ssm_agent_version` | ```latest``` |  |
+| `ssm_agent_version` | `""` | Version of the SSM agent to install from the S3 bucket provided by the SSM agent project, such as ```latest```. If empty, the latest version of the SSM agent available in the Amazon Linux core repositories will be installed. |
 | `subnet_id` | `""` |  |
 | `temporary_security_group_source_cidrs` | `""` |  |
 | `volume_type` | ```gp2``` |  |

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -31,7 +31,7 @@
     "source_ami_owners": "137112412989",
     "ssh_interface": "",
     "ssh_username": "ec2-user",
-    "ssm_agent_version": "latest",
+    "ssm_agent_version": "",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
     "volume_type": "gp2",

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -32,7 +32,6 @@ validate_env_set PULL_CNI_FROM_GITHUB
 validate_env_set PAUSE_CONTAINER_VERSION
 validate_env_set CACHE_CONTAINER_IMAGES
 validate_env_set WORKING_DIR
-validate_env_set SSM_AGENT_VERSION
 
 ################################################################################
 ### Machine Architecture #######################################################
@@ -512,10 +511,11 @@ fi
 if yum list installed | grep amazon-ssm-agent; then
   echo "amazon-ssm-agent already present - skipping install"
 else
-  echo "Installing amazon-ssm-agent"
-  if ! [[ ${ISOLATED_REGIONS} =~ $BINARY_BUCKET_REGION ]]; then
+  if ! [[ -z "${SSM_AGENT_VERSION}" ]]; then
+    echo "Installing amazon-ssm-agent@${SSM_AGENT_VERSION} from S3"
     sudo yum install -y https://s3.${BINARY_BUCKET_REGION}.${S3_DOMAIN}/amazon-ssm-${BINARY_BUCKET_REGION}/${SSM_AGENT_VERSION}/linux_${ARCH}/amazon-ssm-agent.rpm
   else
+    echo "Installing amazon-ssm-agent from AL core repository"
     sudo yum install -y amazon-ssm-agent
   fi
 fi


### PR DESCRIPTION
**Description of changes:**

This changes the default installation method for `amazon-ssm-agent` back to the AL2 core repository, instead of the S3 bucket provided by the SSM agent project. This ensures that the version installed by default in the EKS AMI is compliant with any security bulletins issued by Amazon Linux.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->