### PR TITLE
Set containerd LimitNOFILE to recommended value

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -193,6 +193,12 @@ cat << EOF | sudo tee /etc/systemd/system/containerd.service.d/10-compat-symlink
 ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
 EOF
 
+cat << EOF | sudo tee /etc/systemd/system/containerd.service.d/20-limitnofile.conf
+[Service]
+# https://github.com/containerd/containerd/pull/8924
+LimitNOFILE=1024:524288
+EOF
+
 cat << EOF | sudo tee -a /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter


### PR DESCRIPTION
**Description of changes:**

The service unit in AL2 currently sets `LimitNOFILE=infinity` on `containerd`. This is known to cause issues, and the recommendation is to set it explicitly to `LimitNOFILE=1024:524288` on systems using `systemd` older that v240.

More info: https://github.com/containerd/containerd/pull/8924

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
