### PR TITLE
Adjusted install-worker to redirect GovCloud

### DIFF
--- a/hack/latest-binaries.sh
+++ b/hack/latest-binaries.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -o errexit
 set -o pipefail
 set -o nounset
@@ -13,8 +12,9 @@ MINOR_VERSION="${1}"
 
 # retrieve the available "VERSION/BUILD_DATE" prefixes (e.g. "1.28.1/2023-09-14")
 # from the binary object keys, sorted in descending semver order, and pick the first one
-LATEST_BINARIES=$(aws s3api list-objects-v2 --bucket amazon-eks --prefix "${MINOR_VERSION}" --query 'Contents[*].[Key]' --output text | cut -d'/' -f-2 | sort -Vru | head -n1)
-
+# If s3api fails; use curl to pull the list. For some reason, reversing order returns nothing, so I dropped that from the sort command
+LATEST_BINARIES=$(aws s3api list-objects-v2 --bucket amazon-eks --prefix "${MINOR_VERSION}" --query 'Contents[*].[Key]' --output text | cut -d'/' -f-2 | sort -Vru | head -n1 || curl -s  "https://amazon-eks.s3.amazonaws.com/?prefix=${MINOR_VERSION}" | xmllint --format  --nocdata - | grep -E  "<Key>${MINOR_VERSION}.*" | sed "s/^.*<Key>//g" | sort -Vu | tail -n 1)
+	
 if [ "${LATEST_BINARIES}" == "None" ]; then
   echo >&2 "No binaries available for minor version: ${MINOR_VERSION}"
   exit 1

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -276,6 +276,12 @@ elif [ "$BINARY_BUCKET_REGION" = "us-iso-east-1" ] || [ "$BINARY_BUCKET_REGION" 
   S3_DOMAIN="c2s.ic.gov"
 elif [ "$BINARY_BUCKET_REGION" = "us-isob-east-1" ]; then
   S3_DOMAIN="sc2s.sgov.gov"
+# Updating binary_bucket_region variable to redirect from us-gov-west-1 and us-gov-east-1 to us-west-2 and us-east-2 respectively, as the buckets in GovCloud regions is returning Access Denieds
+# https://github.com/awslabs/amazon-eks-ami/issues/1536
+elif [ "$BINARY_BUCKET_REGION" = "us-gov-west-1" ]; then
+  BINARY_BUCKET_REGION="us-west-2"
+elif [ "$BINARY_BUCKET_REGION" = "us-gov-east-1" ]; then
+  BINARY_BUCKET_REGION="us-east-2"
 fi
 S3_URL_BASE="https://$BINARY_BUCKET_NAME.s3.$BINARY_BUCKET_REGION.$S3_DOMAIN/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
 S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
@@ -295,7 +301,7 @@ for binary in ${BINARIES[*]}; do
     sudo wget $S3_URL_BASE/$binary.sha256
   fi
   sudo sha256sum -c $binary.sha256
-  sudo chmod +x $binary
+  sudo chmod 755 $binary
   sudo mv $binary /usr/bin/
 done
 


### PR DESCRIPTION
**Issue #, if available:**
[1536](https://github.com/awslabs/amazon-eks-ami/issues/1536)

**Description of changes:**

Currently, the S3 bucket for the kubelet binary in us-gov-west-1 (and us-gov-east-1) returns an 403 - `Access Denied` HTTP Code when attempting to download it, when the `binary_bucket_region` variable is set to `us-gov-west-1` or `us-gov-east-1` instead of the default `us-west-2`. 

I added a redirect from `us-gov-west-1` and `us-gov-east-1` to `us-west-2` and `us-east-2` repectively. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

Step 1 - Adjusted file as noted above and in the diff (line numbers included)
```
279 # Updating binary_bucket_region variable to redirect from us-gov-west-1 and us-gov-east-1 to us-west-2 and us-east-2 respectively, as the buckets in GovCloud regions is returning Access Denieds
280 # https://github.com/awslabs/amazon-eks-ami/issues/1536
281 elif [ "$BINARY_BUCKET_REGION" = "us-gov-west-1" ]; then
282   BINARY_BUCKET_REGION="us-west-2"
283 elif [ "$BINARY_BUCKET_REGION" = "us-gov-east-1" ]; then
284   BINARY_BUCKET_REGION="us-east-2"
```
Without Line Numbers:
```
# Updating binary_bucket_region variable to redirect from us-gov-west-1 and us-gov-east-1 to us-west-2 and us-east-2 respectively, as the buckets in GovCloud regions is returning Access Denieds
# https://github.com/awslabs/amazon-eks-ami/issues/1536
elif [ "$BINARY_BUCKET_REGION" = "us-gov-west-1" ]; then
  BINARY_BUCKET_REGION="us-west-2"
elif [ "$BINARY_BUCKET_REGION" = "us-gov-east-1" ]; then
  BINARY_BUCKET_REGION="us-east-2"
fi
```
Step 2 - Change the `bucket_binary_region` variable in `eks-worker-al2-variables.json` (example provided assuming that the `amazon-eks-ami` the current working directory)
```
sed -i 's/\"binary_bucket_region\": \"us-west-2\"/\"binary_bucket_region\": \"us-gov-west-1\"/g' eks-worker-al2-variables.json 
```

Step 3 - Built an AMI using packer as noted here: https://aws.amazon.com/blogs/containers/building-amazon-linux-2-cis-benchmark-amis-for-amazon-eks/
Example command:
```
 make 1.27 aws_region=$AWS_REGION source_ami_id=$AMI_ID source_ami_owners=$AMI_OWNER_ACCOUNT_ID source_ami_filter_name="$AMI_NAME" subnet_id="$SUBNET_ID"
```

Note: In addition to the variables in the above, you also need to set the `kubernetes_version` and `kubernetes_build_date` as the `hack/latest-binaries.sh` also throws an error in GovCloud. Here are the variables I used:
```
kubernetes_build_date=2023-11-14
kubernetes_version=1.27.7
```
 
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
