### PR TITLE
AL2023 networking changes in install script for VPC CNI compatibility

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -86,10 +86,19 @@ fi
 # packages that need special handling
 if cat /etc/*release | grep "al2023" > /dev/null 2>&1; then
   # exists in al2023 only (needed by kubelet)
-  sudo yum install -y iptables-legacy
+  sudo yum install -y iptables-nft
 
-  # Remove the amazon-ec2-net-utils package, if it's installed. This package interferes with the route setup on the instance.
-  if yum list installed | grep amazon-ec2-net-utils; then sudo yum remove amazon-ec2-net-utils -y -q; fi
+  # Mask udev triggers installed by amazon-ec2-net-utils package
+  sudo touch /etc/udev/rules.d/99-cni-empty.rules
+
+  # Make networkd ignore foreign settings, else it may unexpectedly delete IP rules and routes added by CNI
+  sudo mkdir -p /etc/systemd/networkd.conf.d/
+  cat << EOF | sudo tee /etc/systemd/networkd.conf.d/80-release.conf
+# Do not clobber any routes or rules added by CNI.
+[Network]
+ManageForeignRoutes=no
+ManageForeignRoutingPolicyRules=no
+EOF
 
   # Temporary fix for https://github.com/aws/amazon-vpc-cni-k8s/pull/2118
   sudo sed -i "s/^MACAddressPolicy=.*/MACAddressPolicy=none/" /usr/lib/systemd/network/99-default.link || true


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This PR makes the following changes to the install script for AMI builds of AL2023 images:
1. Use `iptables-nft` by default for AL2023
2. Mask the `udev` triggers installed by `amazon-ec2-net-utils` (or others) through creation of an empty `/etc/udev/rules.d/99-vpc-policy-routes.rules`. This leaves the CNI fully responsible for configuring any new interfaces on the instance.
3. Do not remove `amazon-ec2-net-utils` package. This package is left installed so that it can properly configure the primary ENI and initial networking. Its triggers are then masked.
4. Make `networkd` ignore foreign settings. This is required to prevent `networkd` from removing IP rules and routes installed by the CNI. This setting is used on Bottlerocket (https://github.com/bottlerocket-os/bottlerocket/blob/develop/packages/release/release-systemd-networkd.conf), but it requires further investigation, specifically on whether it will impact popular 3rd party k8s plugins. Also, we should use `/etc/systemd/networkd.conf.d/80-release.conf` for the final draft for persistence reasons.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
AMI build for AL2023 images succeeds with this change. The resulting AMI can successfully join an EKS cluster, and basic VPC CNI test cases pass. More testing is to come. Manual inspection of system setup also looks good, but more is in progress. The log collector script succeeds when run on this AMI.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
