### PR TITLE
Fix networkd settings from #1539

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -89,11 +89,11 @@ if cat /etc/*release | grep "al2023" > /dev/null 2>&1; then
   sudo yum install -y iptables-nft
 
   # Mask udev triggers installed by amazon-ec2-net-utils package
-  sudo touch /etc/udev/rules.d/99-cni-empty.rules
+  sudo touch /etc/udev/rules.d/99-vpc-policy-routes.rules
 
   # Make networkd ignore foreign settings, else it may unexpectedly delete IP rules and routes added by CNI
-  sudo mkdir -p /etc/systemd/networkd.conf.d/
-  cat << EOF | sudo tee /etc/systemd/networkd.conf.d/80-release.conf
+  sudo mkdir -p /usr/lib/systemd/networkd.conf.d/
+  cat << EOF | sudo tee /usr/lib/systemd/networkd.conf.d/80-release.conf
 # Do not clobber any routes or rules added by CNI.
 [Network]
 ManageForeignRoutes=no


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This PR modifies the networkd settings from https://github.com/awslabs/amazon-eks-ami/pull/1539 back to the original commit, which uses the name `/etc/udev/rules.d/99-vpc-policy-routes.rules` and `/usr/lib/systemd/` instead of `/etc/systemd/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
AMI builds and VPC CNI tests pass again.
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
