### PR TITLE
Revert "Set containerd LimitNOFILE to recommended value (#1535)"

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -202,12 +202,6 @@ cat << EOF | sudo tee /etc/systemd/system/containerd.service.d/10-compat-symlink
 ExecStartPre=/bin/ln -sf /run/containerd/containerd.sock /run/dockershim.sock
 EOF
 
-cat << EOF | sudo tee /etc/systemd/system/containerd.service.d/20-limitnofile.conf
-[Service]
-# https://github.com/containerd/containerd/pull/8924
-LimitNOFILE=1024:524288
-EOF
-
 cat << EOF | sudo tee -a /etc/modules-load.d/containerd.conf
 overlay
 br_netfilter


### PR DESCRIPTION
This reverts commit e0989539612fd6c56a32c129a185c988d790d16e.

**Issue #, if available:**
#1551
**Description of changes:**
Customers are reporting hitting ulimits after upgrading to the latest AMI due to this change. Rolling back.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
None
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
