### PR TITLE
[WIP] Optionally require IMDS v2 on instances launched from AMI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,9 @@ lint: lint-docs ## Check the source files for syntax and format issues
 test: ## run the test-harness
 	test/test-harness.sh
 
-# include only variables which have a defined value
-PACKER_VARIABLES := $(foreach packerVar,$(AVAILABLE_PACKER_VARIABLES),$(if $($(packerVar)),$(packerVar)))
+# include only variables which have a defined value or the variable is imds_support
+PACKER_IMDS_SUPPORT_VAR := imds_support
+PACKER_VARIABLES := $(foreach packerVar,$(AVAILABLE_PACKER_VARIABLES),$(if $(or $($(packerVar)), $(filter $(packerVar),$(PACKER_IMDS_SUPPORT_VAR))),$(packerVar)))
 PACKER_VAR_FLAGS := -var-file $(PACKER_DEFAULT_VARIABLE_FILE) \
 $(if $(PACKER_VARIABLE_FILE),-var-file=$(PACKER_VARIABLE_FILE),) \
 $(foreach packerVar,$(PACKER_VARIABLES),-var $(packerVar)='$($(packerVar))')

--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,8 @@ lint: lint-docs ## Check the source files for syntax and format issues
 test: ## run the test-harness
 	test/test-harness.sh
 
-# include only variables which have a defined value or the variable is imds_support
-PACKER_IMDS_SUPPORT_VAR := imds_support
-PACKER_VARIABLES := $(foreach packerVar,$(AVAILABLE_PACKER_VARIABLES),$(if $(or $($(packerVar)), $(filter $(packerVar),$(PACKER_IMDS_SUPPORT_VAR))),$(packerVar)))
+# include only variables which have a defined value
+PACKER_VARIABLES := $(foreach packerVar,$(AVAILABLE_PACKER_VARIABLES),$(if $($(packerVar)),$(packerVar)))
 PACKER_VAR_FLAGS := -var-file $(PACKER_DEFAULT_VARIABLE_FILE) \
 $(if $(PACKER_VARIABLE_FILE),-var-file=$(PACKER_VARIABLE_FILE),) \
 $(foreach packerVar,$(PACKER_VARIABLES),-var $(packerVar)='$($(packerVar))')

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ Nodes](https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html).
 
 ## 🔢 Pre-requisites
 
-You must have [Packer](https://www.packer.io/) version 1.8.0 or later installed on your local system.
+You must have [Packer](https://www.packer.io/) version 1.8.6 or later installed on your local system.
+You must also have [Packer amazon-ebs plugin] version 1.2.7 or later installed.
+Note: The Packer team has moved away from bundling updated plugins with Packer since 1.8.x in favor of using packer plugins install for JSON users. This was called out in the [1.9.2 Packer release](https://github.com/hashicorp/packer/blob/main/CHANGELOG.md#notes-1).
+```bash
+packer plugins install "github.com/hashicorp/amazon" ">=1.2.7"
+```
 For more information, see [Installing Packer](https://www.packer.io/docs/install/index.html)
 in the Packer documentation. You must also have AWS account credentials
 configured so that Packer can make calls to AWS API operations on your behalf.

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -42,6 +42,7 @@ Users have the following options for specifying their own values:
 | `docker_version` | ```20.10.*``` |  |
 | `encrypted` | ```false``` |  |
 | `enable_fips` | ```false``` | Install openssl and enable fips related kernel parameters |
+| `imds_support` | `""` | The only valid imds_support values are "v2.0" or the empty string |
 | `instance_type` | *None* |  |
 | `kernel_version` | `""` |  |
 | `kms_key_id` | `""` |  |
@@ -63,7 +64,6 @@ Users have the following options for specifying their own values:
 | `temporary_security_group_source_cidrs` | `""` |  |
 | `volume_type` | ```gp2``` |  |
 | `working_dir` | ```{{user `remote_folder`}}/worker``` | Directory path for ephemeral resources on the builder instance |
-| `imds_support` | `""` | The only valid imds_support values are "v2.0" or the empty string |
 <!-- template-variable-table-boundary -->
 
 ---
@@ -108,14 +108,6 @@ aws s3 ls s3://amazon-eks/1.23.9/2022-07-27/bin/linux/x86_64/
 
 To build using the example binaries above:
 ```bash
-# Using IMDS v2
-make k8s \
-  kubernetes_version=1.23.9 \
-  kubernetes_build_date=2022-07-27 \
-  arch=x86_64 \
-  imds_support='v2.0'
-
-# Using IMDS v1
 make k8s \
   kubernetes_version=1.23.9 \
   kubernetes_build_date=2022-07-27 \

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -131,15 +131,6 @@ These binaries must be accessible using the credentials on the Packer builder EC
 
 2. Run the following command to start the build process to use your own Kubernetes binaries:
 ```bash
-# Using IMDS v2
-make k8s \
-  binary_bucket_name=my-custom-bucket \
-  binary_bucket_region=eu-west-1 \
-  kubernetes_version=1.14.9 \
-  kubernetes_build_date=2020-01-22 \
-  imds_support='v2.0'
-
-# Using IMDS v1
 make k8s \
   binary_bucket_name=my-custom-bucket \
   binary_bucket_region=eu-west-1 \

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -63,6 +63,7 @@ Users have the following options for specifying their own values:
 | `temporary_security_group_source_cidrs` | `""` |  |
 | `volume_type` | ```gp2``` |  |
 | `working_dir` | ```{{user `remote_folder`}}/worker``` | Directory path for ephemeral resources on the builder instance |
+| `imds_support` | `""` | The only valid imds_support values are "v2.0" or the empty string |
 <!-- template-variable-table-boundary -->
 
 ---
@@ -107,6 +108,14 @@ aws s3 ls s3://amazon-eks/1.23.9/2022-07-27/bin/linux/x86_64/
 
 To build using the example binaries above:
 ```bash
+# Using IMDS v2
+make k8s \
+  kubernetes_version=1.23.9 \
+  kubernetes_build_date=2022-07-27 \
+  arch=x86_64 \
+  imds_support='v2.0'
+
+# Using IMDS v1
 make k8s \
   kubernetes_version=1.23.9 \
   kubernetes_build_date=2022-07-27 \
@@ -130,6 +139,15 @@ These binaries must be accessible using the credentials on the Packer builder EC
 
 2. Run the following command to start the build process to use your own Kubernetes binaries:
 ```bash
+# Using IMDS v2
+make k8s \
+  binary_bucket_name=my-custom-bucket \
+  binary_bucket_region=eu-west-1 \
+  kubernetes_version=1.14.9 \
+  kubernetes_build_date=2020-01-22 \
+  imds_support='v2.0'
+
+# Using IMDS v1
 make k8s \
   binary_bucket_name=my-custom-bucket \
   binary_bucket_region=eu-west-1 \

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -35,5 +35,6 @@
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
     "volume_type": "gp2",
-    "working_dir": "{{user `remote_folder`}}/worker"
+    "working_dir": "{{user `remote_folder`}}/worker",
+    "imds_support": ""
 }

--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -18,6 +18,7 @@
     "docker_version": "20.10.*",
     "enable_fips": "false",
     "encrypted": "false",
+    "imds_support": "",
     "kernel_version": "",
     "kms_key_id": "",
     "launch_block_device_mappings_volume_size": "4",
@@ -35,6 +36,5 @@
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
     "volume_type": "gp2",
-    "working_dir": "{{user `remote_folder`}}/worker",
-    "imds_support": ""
+    "working_dir": "{{user `remote_folder`}}/worker"
 }

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -22,6 +22,7 @@
     "docker_version": null,
     "encrypted": null,
     "enable_fips": null,
+    "imds_support": null,
     "instance_type": null,
     "kernel_version": null,
     "kms_key_id": null,
@@ -42,8 +43,7 @@
     "subnet_id": null,
     "temporary_security_group_source_cidrs": null,
     "volume_type": null,
-    "working_dir": null,
-    "imds_support": null
+    "working_dir": null
   },
   "builders": [
     {

--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -42,7 +42,8 @@
     "subnet_id": null,
     "temporary_security_group_source_cidrs": null,
     "volume_type": null,
-    "working_dir": null
+    "working_dir": null,
+    "imds_support": null
   },
   "builders": [
     {
@@ -112,6 +113,7 @@
       },
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}",
+      "imds_support": "{{user `imds_support`}}",
       "metadata_options": {
         "http_tokens": "required"
       }


### PR DESCRIPTION
**Issue #, if available:**
**Description of changes:**

Enable IMDS v2

There is a bug in packer,  IMDS v2 is not enabled in the AMI produced as documented with the option of:
```
"http_tokens": "required",
```
See more details in https://github.com/hashicorp/packer-plugin-amazon/issues/357
As indicated in the issue, the solution is:
1) explicitly enable IMDS v2 with `"imds_support": "v2.0",`
2) this requires the installation of packer 1.8.6+
3) this also requires the installation of packer amazon-ebs plugin 1.2.7+ 

It is noted that the Packer team has moved away from bundling updated plugins with Packer since 1.8.x in favor of using packer plugins install for JSON users. This was called out in the [1.9.2 Packer release](https://github.com/hashicorp/packer/blob/main/CHANGELOG.md#notes-1)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
