### PR TITLE
Update generate-version-info.sh

### DIFF
--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -16,14 +16,14 @@ OUTPUT_FILE="$1"
 sudo rpm --query --all --queryformat '\{"%{NAME}": "%{VERSION}-%{RELEASE}"\}\n' | jq --slurp --sort-keys 'add | {packages:(.)}' > "$OUTPUT_FILE"
 
 # binaries
-KUBELET_VERSION=$(kubelet --version | awk '{print $2}')
+KUBELET_VERSION=$(sudo kubelet --version | awk '{print $2}')
 if [ "$?" != 0 ]; then
   echo "unable to get kubelet version"
   exit 1
 fi
 echo $(jq ".binaries.kubelet = \"$KUBELET_VERSION\"" $OUTPUT_FILE) > $OUTPUT_FILE
 
-CLI_VERSION=$(aws --version | awk '{print $1}' | cut -d '/' -f 2)
+CLI_VERSION=$(sudo aws --version | awk '{print $1}' | cut -d '/' -f 2)
 if [ "$?" != 0 ]; then
   echo "unable to get aws cli version"
   exit 1


### PR DESCRIPTION


**Issue #, if available:**

It seems like install-worker makes kubelet and aws only accessible to the root user. When running this packer build as ec2-user, I get the following errors. 

```
2024-01-03T12:23:22-05:00: ==> amazon-ebs: Provisioning with shell script: /Users/varun.shivakumar/code/fedramp/ami/packer-al2/scripts/generate-version-info.sh
2024-01-03T12:23:23-05:00:     amazon-ebs: /home/ec2-user/script_9031.sh: line 19: /usr/bin/kubelet: Permission denied

2024-01-03T12:32:11-05:00: ==> amazon-ebs: Provisioning with shell script: /Users/varun.shivakumar/code/fedramp/ami/packer-al2/scripts/generate-version-info.sh
2024-01-03T12:32:13-05:00:     amazon-ebs: /home/ec2-user/script_1670.sh: line 26: aws: command not found
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
