### PR TITLE
Add nodeadm PR checks

### DIFF
--- a/.github/workflows/ci-auto.yaml
+++ b/.github/workflows/ci-auto.yaml
@@ -13,8 +13,28 @@ jobs:
     - run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
     - run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
     - run: make lint
-  unit-test:
+  templates-test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - run: make test
+  nodeadm-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: cd nodeadm && make build
+  nodeadm-check-generate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: hack/nodeadm-check-generate.sh
+  nodeadm-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: cd nodeadm && make test
+  nodeadm-test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: cd nodeadm && make test-e2e

--- a/hack/nodeadm-check-generate.sh
+++ b/hack/nodeadm-check-generate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd $(dirname $0)/../nodeadm
+make generate
+if ! git diff --exit-code .; then
+  echo "ERROR: nodeadm generated code is out of date. Please run make generate and commit the changes."
+  exit 1
+fi

--- a/nodeadm/Makefile
+++ b/nodeadm/Makefile
@@ -60,8 +60,8 @@ vet: ## Run go vet against code.
 test: crds generate fmt vet ## Run go test against code.
 	go test ./...
 
-.PHONY: e2e
-e2e: build ## Run e2e tests.
+.PHONY: test-e2e
+test-e2e: build ## Run e2e tests.
 	test/e2e/run.sh
 
 ##@ Build

--- a/nodeadm/test/e2e/infra/Dockerfile
+++ b/nodeadm/test/e2e/infra/Dockerfile
@@ -10,9 +10,8 @@ COPY go.mod .
 COPY go.sum .
 RUN go mod download
 COPY Makefile .
-RUN make tools
 COPY . .
-RUN make
+RUN make build
 RUN mv _bin/nodeadm /nodeadm
 
 FROM amazonlinux:2023

--- a/nodeadm/test/e2e/run.sh
+++ b/nodeadm/test/e2e/run.sh
@@ -10,6 +10,8 @@ printf "🛠️ Building test infra image..."
 TEST_IMAGE=$(docker build -q -f test/e2e/infra/Dockerfile .)
 echo "done! Test image: $TEST_IMAGE"
 
+FAILED="false"
+
 for CASE_DIR in $(ls -d test/e2e/cases/*); do
   CASE_NAME=$(basename $CASE_DIR)
   printf "🧪 Testing $CASE_NAME..."
@@ -26,6 +28,15 @@ for CASE_DIR in $(ls -d test/e2e/cases/*); do
   else
     echo "failed! ❌"
     cat $LOG_FILE
+    FAILED="true"
   fi
   docker kill $CONTAINER_ID > /dev/null 2>&1
 done
+
+if [ "${FAILED}" = "true" ]; then
+  echo "❌ Some tests failed!"
+  exit 1
+else
+  echo "✅ All tests passed!"
+  exit 0
+fi


### PR DESCRIPTION
**Description of changes:**

Adds the `build`, `test`, and `test-e2e` make targets for `nodeadm` to the PR workflow.

Also adds a check to ensure any generated code is up-to-date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.