### PR TITLE
Build nodeadm without Dockerfile

### DIFF
--- a/nodeadm/Dockerfile
+++ b/nodeadm/Dockerfile
@@ -1,3 +1,0 @@
-FROM public.ecr.aws/eks-distro-build-tooling/golang:1.21
-WORKDIR /workspace
-RUN make build

--- a/templates/al2023/provisioners/install-nodeadm.sh
+++ b/templates/al2023/provisioners/install-nodeadm.sh
@@ -4,23 +4,18 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
-# use containerd to build nodeadm containerized via kaniko + nerdctl
-# see: https://github.com/GoogleContainerTools/kaniko
-sudo systemctl enable --now containerd
+sudo systemctl start containerd
+
 sudo nerdctl run \
   --rm \
-  -v $PROJECT_DIR:/workspace \
-  $KANIKO_IMAGE \
-  --dockerfile /workspace/Dockerfile \
-  --single-snapshot \
-  --context dir:///workspace/ \
-  --no-push
-sudo systemctl disable containerd
+  --workdir /workdir \
+  --volume $PROJECT_DIR:/workdir \
+  public.ecr.aws/eks-distro-build-tooling/golang:1.21 \
+  make build
 
 # move the nodeadm binary into bin folder
 sudo chmod a+x $PROJECT_DIR/_bin/nodeadm
 sudo mv $PROJECT_DIR/_bin/nodeadm /usr/bin/
-sudo rm -rf $PROJECT_DIR/_bin
 
 # enable nodeadm bootstrap systemd units
 sudo systemctl enable nodeadm-config nodeadm-run

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -194,8 +194,7 @@
       "remote_folder": "{{ user `remote_folder`}}",
       "script": "{{template_dir}}/provisioners/install-nodeadm.sh",
       "environment_vars": [
-        "PROJECT_DIR={{user `working_dir`}}/nodeadm",
-        "KANIKO_IMAGE=gcr.io/kaniko-project/executor:latest"
+        "PROJECT_DIR={{user `working_dir`}}/nodeadm"
       ]
     },
     {
@@ -226,7 +225,7 @@
     {
       "type": "shell",
       "inline": [
-        "rm -rf {{user `working_dir`}}"
+        "sudo rm -rf {{user `working_dir`}}"
       ]
     }
   ],


### PR DESCRIPTION
**Description of changes:**

Uses the EKS-D golang image directly, instead of doing a nested build. Only downside is the `nodeadm` build steps aren't codified in a Dockerfile, but it's just `make build` anyway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

```
make os_distro=al2023 k8s=1.28
```