### PR TITLE
Fix nodeadm build on macOS

### DIFF
--- a/nodeadm/internal/daemon/darwin_stubs.go
+++ b/nodeadm/internal/daemon/darwin_stubs.go
@@ -1,0 +1,15 @@
+//go:build darwin
+
+package daemon
+
+import "io/fs"
+
+// no-op implementations to keep the project buildable on macOS
+
+func WriteSystemdServiceUnitDropIn(serviceName, fileName, fileContent string, filePerms fs.FileMode) error {
+	return nil
+}
+
+func WriteSystemdServiceUnit(serviceName, unitContent string, filePerms fs.FileMode) error {
+	return nil
+}


### PR DESCRIPTION
**Description of changes:**

Adds no-op impl's for systemd funcs to hush the compiler on macOS.

TODO: the systemd abstraction is pretty leaky right now, the `kubelet` package is making calls like "write a systemd drop-in unit", which is weird.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Succeeds on macOS:
```
make
```