### PR TITLE
Use 20GiB volume by default for al2023

### DIFF
--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -17,7 +17,7 @@
     "enable_fips": "false",
     "encrypted": "false",
     "kms_key_id": "",
-    "launch_block_device_mappings_volume_size": "8",
+    "launch_block_device_mappings_volume_size": "20",
     "pause_container_version": "3.5",
     "pull_cni_from_github": "true",
     "remote_folder": "/tmp",


### PR DESCRIPTION
**Description of changes:**

Bumps the snapshot size to 20GiB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
