### PR TITLE
fix imds mocking and update cases in nodeadm e2e tests

### DIFF
--- a/nodeadm/internal/util/ecr.go
+++ b/nodeadm/internal/util/ecr.go
@@ -140,9 +140,11 @@ func GetEcrUri(r GetEcrUriRequest) (string, error) {
 	ecrUri := buildEcrUri(r.Account, "ecr", r.Region, r.Domain)
 
 	if r.AllowFips {
-		if fipsEnabled, err := isFipsEnabled(); err != nil {
+		fipsInstalled, fipsEnabled, err := getFipsInfo()
+		if err != nil {
 			return "", err
-		} else if fipsEnabled {
+		}
+		if fipsInstalled && fipsEnabled {
 			ecrUriFips := buildEcrUri(r.Account, "ecr-fips", r.Region, r.Domain)
 			if present, err := isHostPresent(ecrUriFips); err != nil {
 				return "", err

--- a/nodeadm/test/e2e/cases/containerd-config/config.yaml
+++ b/nodeadm/test/e2e/cases/containerd-config/config.yaml
@@ -9,9 +9,3 @@ spec:
     apiServerEndpoint: https://example.com
     certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
     cidr: 10.100.0.0/16
-  containerd:
-    config:
-      mergeWithDefaults: true
-      inline: |
-        [foo]
-        bar = 'baz'

--- a/nodeadm/test/e2e/cases/containerd-config/expected-containerd-config.toml
+++ b/nodeadm/test/e2e/cases/containerd-config/expected-containerd-config.toml
@@ -1,28 +1,30 @@
-root = '/var/lib/containerd'
-state = '/run/containerd'
 version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+# Users can use the following import directory to add additional
+# configuration to containerd. The imports do not behave exactly like overrides.
+# see: https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md#format
+imports = ["/etc/containerd/config.d/*.toml"]
 
 [grpc]
-address = '/run/containerd/containerd.sock'
+address = "/run/containerd/containerd.sock"
 
-[plugins]
-[plugins.'io.containerd.grpc.v1.cri']
-sandbox_image = 'SANDBOX_IMAGE'
-
-[plugins.'io.containerd.grpc.v1.cri'.cni]
-bin_dir = '/opt/cni/bin'
-conf_dir = '/etc/cni/net.d'
-
-[plugins.'io.containerd.grpc.v1.cri'.containerd]
-default_runtime_name = 'runc'
+[plugins."io.containerd.grpc.v1.cri".containerd]
+default_runtime_name = "runc"
 discard_unpacked_layers = true
 
-[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes]
-[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.runc]
-runtime_type = 'io.containerd.runc.v2'
+[plugins."io.containerd.grpc.v1.cri"]
+sandbox_image = "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5"
 
-[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.runc.options]
+[plugins."io.containerd.grpc.v1.cri".registry]
+config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+runtime_type = "io.containerd.runc.v2"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
 SystemdCgroup = true
 
-[plugins.'io.containerd.grpc.v1.cri'.registry]
-config_path = '/etc/containerd/certs.d:/etc/docker/certs.d'
+[plugins."io.containerd.grpc.v1.cri".cni]
+bin_dir = "/opt/cni/bin"
+conf_dir = "/etc/cni/net.d"

--- a/nodeadm/test/e2e/cases/containerd-config/run.sh
+++ b/nodeadm/test/e2e/cases/containerd-config/run.sh
@@ -6,6 +6,7 @@ set -o pipefail
 
 source /helpers.sh
 
+mock::imds
 mock::kubelet 1.27.0
 wait::dbus-ready
 

--- a/nodeadm/test/e2e/cases/kubelet-config-dir/expected-kubelet-config.json
+++ b/nodeadm/test/e2e/cases/kubelet-config-dir/expected-kubelet-config.json
@@ -24,22 +24,38 @@
     "clusterDomain": "cluster.local",
     "hairpinMode": "hairpin-veth",
     "readOnlyPort": 0,
-    "cgroupDriver": "cgroupfs",
+    "cgroupDriver": "systemd",
     "cgroupRoot": "/",
     "featureGates": {
         "RotateKubeletServerCertificate": true
     },
+    "clusterDNS": [
+        "10.100.0.10"
+    ],
+    "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
+    "providerID": "aws:///us-west-2f/i-1234567890abcdef0",
+    "systemReservedCgroup": "/system",
     "protectKernelDefaults": true,
     "serializeImagePulls": false,
     "serverTLSBootstrap": true,
+    "kubeReservedCgroup": "/runtime",
+    "logging": {
+        "flushFrequency": 0,
+        "options": {
+            "json": {
+                "infoBufferSize": "0"
+            }
+        },
+        "verbosity": 2
+    },
     "tlsCipherSuites": [
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256"
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_GCM_SHA384"
     ]
 }

--- a/nodeadm/test/e2e/cases/kubelet-config-dir/run.sh
+++ b/nodeadm/test/e2e/cases/kubelet-config-dir/run.sh
@@ -6,10 +6,11 @@ set -o pipefail
 
 source /helpers.sh
 
+mock::imds
 mock::kubelet 1.28.0
 wait::dbus-ready
 
 nodeadm init --skip run --config-source file://config.yaml
 
 assert::files-equal /var/lib/kubelet/kubeconfig expected-kubeconfig.yaml
-assert::files-equal /etc/kubernetes/kubelet/config.json.d/10-defaults.conf expected-kubelet-config.json
+assert::json-files-equal /etc/kubernetes/kubelet/config.json.d/10-defaults.conf expected-kubelet-config.json

--- a/nodeadm/test/e2e/cases/kubelet-config/expected-kubelet-config.json
+++ b/nodeadm/test/e2e/cases/kubelet-config/expected-kubelet-config.json
@@ -1,16 +1,17 @@
 {
-    "address": "0.0.0.0",
+    "kind": "KubeletConfiguration",
     "apiVersion": "kubelet.config.k8s.io/v1beta1",
+    "address": "0.0.0.0",
     "authentication": {
-        "anonymous": {
-            "enabled": false
-        },
-        "webhook": {
-            "cacheTTL": "2m0s",
-            "enabled": true
-        },
         "x509": {
             "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+        },
+        "webhook": {
+            "enabled": true,
+            "cacheTTL": "2m0s"
+        },
+        "anonymous": {
+            "enabled": false
         }
     },
     "authorization": {
@@ -20,26 +21,41 @@
             "cacheUnauthorizedTTL": "30s"
         }
     },
-    "cgroupDriver": "cgroupfs",
+    "cgroupDriver": "systemd",
     "cgroupRoot": "/",
     "clusterDomain": "cluster.local",
+    "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
     "featureGates": {
         "RotateKubeletServerCertificate": true
     },
     "hairpinMode": "hairpin-veth",
-    "kind": "KubeletConfiguration",
     "protectKernelDefaults": true,
     "readOnlyPort": 0,
+    "logging": {
+        "flushFrequency": 0,
+        "verbosity": 2,
+        "options": {
+            "json": {
+                "infoBufferSize": "0"
+            }
+        }
+    },
     "serializeImagePulls": false,
     "serverTLSBootstrap": true,
     "tlsCipherSuites": [
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256"
-    ]
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_GCM_SHA384"
+    ],
+    "clusterDNS": [
+        "10.100.0.10"
+    ],
+    "systemReservedCgroup": "/system",
+    "kubeReservedCgroup": "/runtime",
+    "providerID": "aws:///us-west-2f/i-1234567890abcdef0"
 }

--- a/nodeadm/test/e2e/cases/kubelet-config/run.sh
+++ b/nodeadm/test/e2e/cases/kubelet-config/run.sh
@@ -6,10 +6,11 @@ set -o pipefail
 
 source /helpers.sh
 
+mock::imds
 mock::kubelet 1.27.0
 wait::dbus-ready
 
 nodeadm init --skip run --config-source file://config.yaml
 
 assert::files-equal /var/lib/kubelet/kubeconfig expected-kubeconfig.yaml
-assert::files-equal /etc/kubernetes/kubelet/config.json expected-kubelet-config.json
+assert::json-files-equal /etc/kubernetes/kubelet/config.json expected-kubelet-config.json

--- a/nodeadm/test/e2e/helpers.sh
+++ b/nodeadm/test/e2e/helpers.sh
@@ -17,6 +17,19 @@ function assert::files-equal() {
   fi
 }
 
+function assert::json-files-equal() {
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: assert::json-files-equal FILE1 FILE2"
+    exit 1
+  fi
+  local FILE1=$1
+  local FILE2=$2
+  if ! diff <(jq -S . $FILE1) <(jq -S . $FILE2); then
+    echo "Files $FILE1 and $FILE2 are not equal"
+    exit 1
+  fi
+}
+
 function mock::kubelet() {
   if [ "$#" -ne 1 ]; then
     echo "Usage: mock::kubelet VERSION"
@@ -47,4 +60,10 @@ function wait::path-exists() {
 
 function wait::dbus-ready() {
   wait::path-exists /run/systemd/private
+}
+
+function mock::imds() {
+  local CONFIG_PATH=${1:-/etc/aemm-default-config.json}
+  imds-mock --config-file $CONFIG_PATH &
+  export AWS_EC2_METADATA_SERVICE_ENDPOINT=http://localhost:1338
 }

--- a/nodeadm/test/e2e/infra/.dockerignore
+++ b/nodeadm/test/e2e/infra/.dockerignore
@@ -1,0 +1,1 @@
+test/e2e/cases/

--- a/nodeadm/test/e2e/infra/Dockerfile
+++ b/nodeadm/test/e2e/infra/Dockerfile
@@ -14,14 +14,13 @@ COPY . .
 RUN make build
 RUN mv _bin/nodeadm /nodeadm
 
-FROM amazonlinux:2023
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN dnf -y update && \
-    dnf -y install systemd containerd && \
+    dnf -y install systemd containerd jq && \
     dnf clean all
 COPY --from=imds-mock-build /imds-mock /usr/local/bin/imds-mock
+COPY test/e2e/infra/aemm-default-config.json /etc/aemm-default-config.json
 COPY --from=nodeadm-build /nodeadm /usr/local/bin/nodeadm
-COPY test/e2e/infra/systemd/imds-mock.service /usr/lib/systemd/system/imds-mock.service
-RUN systemctl enable imds-mock.service
 COPY test/e2e/infra/systemd/kubelet.service /usr/lib/systemd/system/kubelet.service
 COPY test/e2e/infra/systemd/containerd.service /usr/lib/systemd/system/containerd.service
 COPY test/e2e/helpers.sh /helpers.sh

--- a/nodeadm/test/e2e/infra/aemm-default-config.json
+++ b/nodeadm/test/e2e/infra/aemm-default-config.json
@@ -1,0 +1,24 @@
+{
+  "imdsv2": true,
+  "metadata": {
+    "values": {
+      "hostname": "ip-172-16-34-43.ec2.internal",
+      "instance-id": "i-1234567890abcdef0",
+      "instance-type": "m4.xlarge",
+      "local-hostname": "ip-172-16-34-43.ec2.internal",
+      "local-ipv4": "172.16.34.43",
+      "mac": "0e:49:61:0f:c3:11"
+    }
+  },
+  "dynamic": {
+    "values": {
+      "instance-identity-document": {
+        "availabilityZone": "us-west-2f",
+        "instanceId": "i-1234567890abcdef0",
+        "architecture": "x86_64",
+        "instanceType": "m4.xlarge",
+        "region": "us-west-2"
+      }
+    }
+  }
+}

--- a/nodeadm/test/e2e/infra/systemd/imds-mock.service
+++ b/nodeadm/test/e2e/infra/systemd/imds-mock.service
@@ -1,8 +1,0 @@
-[Unit]
-Description=Run the mock IMDS server
-
-[Service]
-ExecStart=imds-mock
-
-[Install]
-WantedBy=multi-user.target

--- a/nodeadm/test/e2e/run.sh
+++ b/nodeadm/test/e2e/run.sh
@@ -19,7 +19,6 @@ for CASE_DIR in $(ls -d test/e2e/cases/*); do
     -d \
     --rm \
     --privileged \
-    -v /sys/fs/cgroup:/sys/fs/cgroup \
     -v $PWD/$CASE_DIR:/test-case \
     $TEST_IMAGE)
   LOG_FILE=$(mktemp)


### PR DESCRIPTION
**Description of changes:**

* update imds mocking with custom responses 
* also return whether the fips installation is valid when checking if fips is enabled
* update content of test cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

```
cd nodeadm && make test-e2e
```