### PR TITLE
make kubelet config generation composable to improve testability

### DIFF
--- a/nodeadm/internal/kubelet/config_test.go
+++ b/nodeadm/internal/kubelet/config_test.go
@@ -1,0 +1,108 @@
+package kubelet
+
+import (
+	"testing"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKubeletCredentialProvidersFeatureFlag(t *testing.T) {
+	var tests = []struct {
+		kubeletVersion string
+		expectedValue  *bool
+	}{
+		{kubeletVersion: "v1.23.0", expectedValue: ptr.Bool(true)},
+		{kubeletVersion: "v1.27.0", expectedValue: ptr.Bool(true)},
+		{kubeletVersion: "v1.28.0", expectedValue: nil},
+	}
+
+	for _, test := range tests {
+		kubetConfig := defaultKubeletSubConfig()
+		kubetConfig.withVersionToggles(test.kubeletVersion, make(map[string]string))
+		kubeletCredentialProviders, present := kubetConfig.FeatureGates["KubeletCredentialProviders"]
+		if test.expectedValue == nil && present {
+			t.Errorf("KubeletCredentialProviders shouldn't be set for versions %s", test.kubeletVersion)
+		} else if test.expectedValue != nil && *test.expectedValue != kubeletCredentialProviders {
+			t.Errorf("expected %v but got %v for KubeletCredentialProviders feature gate", *test.expectedValue, kubeletCredentialProviders)
+		}
+	}
+}
+
+func TestContainerRuntime(t *testing.T) {
+	var tests = []struct {
+		kubeletVersion string
+		expectedValue  *string
+	}{
+		{kubeletVersion: "v1.26.0", expectedValue: ptr.String("remote")},
+		{kubeletVersion: "v1.27.0", expectedValue: nil},
+		{kubeletVersion: "v1.28.0", expectedValue: nil},
+	}
+
+	for _, test := range tests {
+		kubeletAruments := make(map[string]string)
+		kubetConfig := defaultKubeletSubConfig()
+		kubetConfig.withVersionToggles(test.kubeletVersion, kubeletAruments)
+		containerRuntime, present := kubeletAruments["container-runtime"]
+		if test.expectedValue == nil && present {
+			t.Errorf("container-runtime shouldn't be set for versions %s", test.kubeletVersion)
+		} else if test.expectedValue != nil && *test.expectedValue != containerRuntime {
+			t.Errorf("expected %v but got %s for container-runtime", *test.expectedValue, containerRuntime)
+		}
+	}
+}
+
+func TestKubeAPILimits(t *testing.T) {
+	var tests = []struct {
+		kubeletVersion       string
+		expectedKubeAPIQS    *int
+		expectedKubeAPIBurst *int
+	}{
+		{kubeletVersion: "v1.21.0", expectedKubeAPIQS: nil, expectedKubeAPIBurst: nil},
+		{kubeletVersion: "v1.22.0", expectedKubeAPIQS: ptr.Int(10), expectedKubeAPIBurst: ptr.Int(20)},
+		{kubeletVersion: "v1.23.0", expectedKubeAPIQS: ptr.Int(10), expectedKubeAPIBurst: ptr.Int(20)},
+		{kubeletVersion: "v1.26.0", expectedKubeAPIQS: ptr.Int(10), expectedKubeAPIBurst: ptr.Int(20)},
+		{kubeletVersion: "v1.27.0", expectedKubeAPIQS: nil, expectedKubeAPIBurst: nil},
+		{kubeletVersion: "v1.28.0", expectedKubeAPIQS: nil, expectedKubeAPIBurst: nil},
+	}
+
+	for _, test := range tests {
+		kubetConfig := defaultKubeletSubConfig()
+		kubetConfig.withVersionToggles(test.kubeletVersion, make(map[string]string))
+		assert.Equal(t, test.expectedKubeAPIQS, kubetConfig.KubeAPIQPS)
+		assert.Equal(t, test.expectedKubeAPIBurst, kubetConfig.KubeAPIBurst)
+	}
+}
+
+func TestProviderID(t *testing.T) {
+	var tests = []struct {
+		kubeletVersion        string
+		expectedCloudProvider string
+	}{
+		{kubeletVersion: "v1.23.0", expectedCloudProvider: "aws"},
+		{kubeletVersion: "v1.25.0", expectedCloudProvider: "aws"},
+		{kubeletVersion: "v1.26.0", expectedCloudProvider: "external"},
+		{kubeletVersion: "v1.27.0", expectedCloudProvider: "external"},
+	}
+
+	nodeConfig := api.NodeConfig{
+		Status: api.NodeConfigStatus{
+			Instance: api.InstanceDetails{
+				AvailabilityZone: "us-west-2f",
+				ID:               "i-123456789000",
+			},
+		},
+	}
+	providerId := getProviderId(nodeConfig.Status.Instance.AvailabilityZone, nodeConfig.Status.Instance.ID)
+
+	for _, test := range tests {
+		kubeletAruments := make(map[string]string)
+		kubetConfig := defaultKubeletSubConfig()
+		kubetConfig.withCloudProvider(test.kubeletVersion, &nodeConfig, kubeletAruments)
+		assert.Equal(t, test.expectedCloudProvider, kubeletAruments["cloud-provider"])
+		if kubeletAruments["cloud-provider"] == "external" {
+			assert.Equal(t, *kubetConfig.ProviderID, providerId)
+		}
+	}
+}

--- a/nodeadm/test/e2e/cases/kubelet-config/expected-kubelet-config.json
+++ b/nodeadm/test/e2e/cases/kubelet-config/expected-kubelet-config.json
@@ -26,6 +26,7 @@
     "clusterDomain": "cluster.local",
     "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
     "featureGates": {
+        "KubeletCredentialProviders": true,
         "RotateKubeletServerCertificate": true
     },
     "hairpinMode": "hairpin-veth",


### PR DESCRIPTION
**Description of changes:**

suggestion for a way to structure the config generation as a sequence of transformations functions to make unit testing single functionality simpler and avoid coming up with a solution to mock network-dependent setup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

```
make test && make test-e2e
```
