### PR TITLE
move image-credential-provider configuration to nodeadm

### DIFF
--- a/nodeadm/internal/containerd/config.go
+++ b/nodeadm/internal/containerd/config.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
-	"os"
-	"path"
 	"text/template"
 
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
@@ -33,10 +31,7 @@ func writeContainerdConfig(cfg *api.NodeConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(path.Dir(containerdConfigFile), containerdConfigPerm); err != nil {
-		return err
-	}
-	return os.WriteFile(containerdConfigFile, containerdConfig, containerdConfigPerm)
+	return util.WriteFileWithDir(containerdConfigFile, containerdConfig, containerdConfigPerm)
 }
 
 func generateContainerdConfig(cfg *api.NodeConfig) ([]byte, error) {

--- a/nodeadm/internal/daemon/systemd.go
+++ b/nodeadm/internal/daemon/systemd.go
@@ -6,9 +6,9 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"os"
 	"path"
 
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
 	"github.com/coreos/go-systemd/dbus"
 )
 
@@ -114,13 +114,10 @@ const servicesRoot = "/etc/systemd/system"
 
 func WriteSystemdServiceUnitDropIn(serviceName, fileName, fileContent string, filePerms fs.FileMode) error {
 	dropInPath := path.Join(servicesRoot, getServiceUnitDropInDir(serviceName), fileName)
-	if err := os.MkdirAll(path.Dir(dropInPath), filePerms); err != nil {
-		return err
-	}
-	return os.WriteFile(dropInPath, []byte(fileContent), filePerms)
+	return util.WriteFileWithDir(dropInPath, []byte(fileContent), filePerms)
 }
 
 func WriteSystemdServiceUnit(serviceName, unitContent string, filePerms fs.FileMode) error {
 	serviceUnitPath := path.Join(servicesRoot, getServiceUnitName(serviceName))
-	return os.WriteFile(serviceUnitPath, []byte(unitContent), filePerms)
+	return util.WriteFileWithDir(serviceUnitPath, []byte(unitContent), filePerms)
 }

--- a/nodeadm/internal/kubelet/cert.go
+++ b/nodeadm/internal/kubelet/cert.go
@@ -1,8 +1,7 @@
 package kubelet
 
 import (
-	"os"
-	"path"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
 )
 
 const caCertificatePath = "/etc/kubernetes/pki/ca.crt"
@@ -10,8 +9,5 @@ const caCertificatePath = "/etc/kubernetes/pki/ca.crt"
 // Write the cluster certifcate authority to the filesystem where
 // both kubelet and kubeconfig can read it
 func writeClusterCaCert(caCert []byte) error {
-	if err := os.MkdirAll(path.Dir(caCertificatePath), kubeletConfigPerm); err != nil {
-		return err
-	}
-	return os.WriteFile(caCertificatePath, caCert, kubeletConfigPerm)
+	return util.WriteFileWithDir(caCertificatePath, caCert, kubeletConfigPerm)
 }

--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
 	featuregates "github.com/awslabs/amazon-eks-ami/nodeadm/internal/feature-gates"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
 )
 
 const (
@@ -284,14 +285,10 @@ func (k *kubelet) GenerateKubeletConfig(cfg *api.NodeConfig) (*kubeletSubConfig,
 //   - kubeletConfigOverrides should be passed in the order of application
 func (k *kubelet) writeKubeletConfigToFile(kubeletConfig []byte) error {
 	configPath := path.Join(kubeletConfigRoot, kubeletConfigFile)
-	if err := os.MkdirAll(path.Dir(configPath), kubeletConfigPerm); err != nil {
-		return err
-	}
-
 	k.additionalArguments["config"] = configPath
 
 	zap.L().Info("Writing kubelet config to file..", zap.String("path", configPath))
-	return os.WriteFile(configPath, kubeletConfig, kubeletConfigPerm)
+	return util.WriteFileWithDir(configPath, kubeletConfig, kubeletConfigPerm)
 }
 
 // WriteKubeletConfigToDir writes the kubelet config to a directory for drop-in
@@ -299,10 +296,6 @@ func (k *kubelet) writeKubeletConfigToFile(kubeletConfig []byte) error {
 // see: https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/#kubelet-conf-d
 func (k *kubelet) writeKubeletConfigToDir(kubeletConfig []byte) error {
 	dirPath := path.Join(kubeletConfigRoot, kubeletConfigDir)
-	if err := os.MkdirAll(dirPath, kubeletConfigPerm); err != nil {
-		return err
-	}
-
 	k.additionalArguments["config-dir"] = dirPath
 
 	zap.L().Info("Enabling kubelet config drop-in dir..")
@@ -310,7 +303,7 @@ func (k *kubelet) writeKubeletConfigToDir(kubeletConfig []byte) error {
 
 	filePath := path.Join(dirPath, "10-defaults.conf")
 	zap.L().Info("Writing kubelet config to drop-in file..", zap.String("path", filePath))
-	return os.WriteFile(filePath, kubeletConfig, kubeletConfigPerm)
+	return util.WriteFileWithDir(filePath, kubeletConfig, kubeletConfigPerm)
 }
 
 func getProviderId(availabilityZone, instanceId string) string {

--- a/nodeadm/internal/kubelet/daemon.go
+++ b/nodeadm/internal/kubelet/daemon.go
@@ -30,6 +30,9 @@ func (k *kubelet) Configure(cfg *api.NodeConfig) error {
 	if err := k.writeKubeconfig(cfg); err != nil {
 		return err
 	}
+	if err := k.writeImageCredentialProviderConfig(cfg); err != nil {
+		return err
+	}
 	if err := writeClusterCaCert(cfg.Spec.Cluster.CertificateAuthority); err != nil {
 		return err
 	}

--- a/nodeadm/internal/kubelet/image-credential-provider.go
+++ b/nodeadm/internal/kubelet/image-credential-provider.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
 	"go.uber.org/zap"
 	"golang.org/x/mod/semver"
 )
@@ -48,10 +49,7 @@ func (k *kubelet) writeImageCredentialProviderConfig(cfg *api.NodeConfig) error 
 	k.additionalArguments["image-credential-provider-bin-dir"] = path.Dir(ecrCredentialProviderBinPath)
 	k.additionalArguments["image-credential-provider-config"] = imageCredentialProviderConfigPath
 
-	if err := os.MkdirAll(imageCredentialProviderRoot, imageCredentialProviderPerm); err != nil {
-		return err
-	}
-	return os.WriteFile(imageCredentialProviderConfigPath, config, imageCredentialProviderPerm)
+	return util.WriteFileWithDir(imageCredentialProviderConfigPath, config, imageCredentialProviderPerm)
 }
 
 type imageCredentialProviderTemplateVars struct {

--- a/nodeadm/internal/kubelet/image-credential-provider.go
+++ b/nodeadm/internal/kubelet/image-credential-provider.go
@@ -1,0 +1,90 @@
+package kubelet
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"text/template"
+
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"go.uber.org/zap"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	imageCredentialProviderRoot   = "/etc/eks/image-credential-provider"
+	imageCredentialProviderConfig = "config.json"
+	imageCredentialProviderPerm   = 0644
+
+	ecrCredentialProviderBinPathEnvironmentName = "ECR_CREDENTIAL_PROVIDER_BIN_PATH"
+)
+
+var (
+	//go:embed image-credential-provider.template.json
+	imageCredentialProviderTemplateData string
+	imageCredentialProviderTemplate     = template.Must(template.New("image-credential-provider").Parse(imageCredentialProviderTemplateData))
+	imageCredentialProviderConfigPath   = path.Join(imageCredentialProviderRoot, imageCredentialProviderConfig)
+)
+
+func (k *kubelet) writeImageCredentialProviderConfig(cfg *api.NodeConfig) error {
+	// fallback default for image credential provider binary if not overridden
+	ecrCredentialProviderBinPath := path.Join(imageCredentialProviderRoot, "ecr-credential-provider")
+	if binPath, set := os.LookupEnv(ecrCredentialProviderBinPathEnvironmentName); set {
+		zap.L().Info("picked up image credential provider binary path from environment", zap.String("bin-path", binPath))
+		ecrCredentialProviderBinPath = binPath
+	}
+	if err := ensureCredentialProviderBinaryExists(ecrCredentialProviderBinPath); err != nil {
+		return err
+	}
+
+	config, err := generateImageCredentialProviderConfig(cfg, ecrCredentialProviderBinPath)
+	if err != nil {
+		return err
+	}
+
+	k.additionalArguments["image-credential-provider-bin-dir"] = path.Dir(ecrCredentialProviderBinPath)
+	k.additionalArguments["image-credential-provider-config"] = imageCredentialProviderConfigPath
+
+	if err := os.MkdirAll(imageCredentialProviderRoot, imageCredentialProviderPerm); err != nil {
+		return err
+	}
+	return os.WriteFile(imageCredentialProviderConfigPath, config, imageCredentialProviderPerm)
+}
+
+type imageCredentialProviderTemplateVars struct {
+	ConfigApiVersion   string
+	ProviderApiVersion string
+	EcrProviderName    string
+}
+
+func generateImageCredentialProviderConfig(cfg *api.NodeConfig, ecrCredentialProviderBinPath string) ([]byte, error) {
+	templateVars := imageCredentialProviderTemplateVars{
+		EcrProviderName: filepath.Base(ecrCredentialProviderBinPath),
+	}
+	kubeletVersion, err := GetKubeletVersion()
+	if err != nil {
+		return nil, err
+	}
+	if semver.Compare(kubeletVersion, "v1.27.0") < 0 {
+		templateVars.ConfigApiVersion = "kubelet.config.k8s.io/v1alpha1"
+		templateVars.ProviderApiVersion = "credentialprovider.kubelet.k8s.io/v1alpha1"
+	} else {
+		templateVars.ConfigApiVersion = "kubelet.config.k8s.io/v1"
+		templateVars.ProviderApiVersion = "credentialprovider.kubelet.k8s.io/v1"
+	}
+	var buf bytes.Buffer
+	if err := imageCredentialProviderTemplate.Execute(&buf, templateVars); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func ensureCredentialProviderBinaryExists(binPath string) error {
+	if _, err := os.Stat(binPath); err != nil {
+		return fmt.Errorf("image credential provider binary was not found on path %s. error: %s", binPath, err)
+	}
+	return nil
+}

--- a/nodeadm/internal/kubelet/image-credential-provider.template.json
+++ b/nodeadm/internal/kubelet/image-credential-provider.template.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "{{.ConfigApiVersion}}",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "{{.EcrProviderName}}",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "{{.ProviderApiVersion}}"
+    }
+  ]
+}

--- a/nodeadm/internal/kubelet/kubeconfig.go
+++ b/nodeadm/internal/kubelet/kubeconfig.go
@@ -30,15 +30,18 @@ func (k *kubelet) writeKubeconfig(cfg *api.NodeConfig) error {
 	if err != nil {
 		return err
 	}
+	if err := os.MkdirAll(kubeconfigRoot, kubeconfigPerm); err != nil {
+		return err
+	}
 	if enabled := cfg.Spec.Cluster.EnableOutpost; enabled != nil && *enabled {
 		// kubelet bootstrap kubeconfig uses aws-iam-authenticator with cluster id to authenticate to cluster
 		//   - if "aws eks describe-cluster" is bypassed, for local outpost, the value of CLUSTER_NAME parameter will be cluster id.
 		//   - otherwise, the cluster id will use the id returned by "aws eks describe-cluster".
 		k.additionalArguments["bootstrap-kubeconfig"] = kubeconfigBootstrapPath
-		return writeConfig(kubeconfigBootstrapPath, kubeconfig)
+		return os.WriteFile(kubeconfigBootstrapPath, kubeconfig, kubeconfigPerm)
 	} else {
 		k.additionalArguments["kubeconfig"] = kubeconfigPath
-		return writeConfig(kubeconfigPath, kubeconfig)
+		return os.WriteFile(kubeconfigPath, kubeconfig, kubeconfigPerm)
 	}
 }
 
@@ -67,11 +70,4 @@ func generateKubeconfig(cfg *api.NodeConfig) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
-}
-
-func writeConfig(path string, data []byte) error {
-	if err := os.MkdirAll(kubeconfigRoot, kubeconfigPerm); err != nil {
-		return err
-	}
-	return os.WriteFile(path, data, kubeconfigPerm)
 }

--- a/nodeadm/internal/kubelet/kubeconfig.go
+++ b/nodeadm/internal/kubelet/kubeconfig.go
@@ -3,11 +3,11 @@ package kubelet
 import (
 	"bytes"
 	_ "embed"
-	"os"
 	"path"
 	"text/template"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
 )
 
 const (
@@ -30,18 +30,15 @@ func (k *kubelet) writeKubeconfig(cfg *api.NodeConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(kubeconfigRoot, kubeconfigPerm); err != nil {
-		return err
-	}
 	if enabled := cfg.Spec.Cluster.EnableOutpost; enabled != nil && *enabled {
 		// kubelet bootstrap kubeconfig uses aws-iam-authenticator with cluster id to authenticate to cluster
 		//   - if "aws eks describe-cluster" is bypassed, for local outpost, the value of CLUSTER_NAME parameter will be cluster id.
 		//   - otherwise, the cluster id will use the id returned by "aws eks describe-cluster".
 		k.additionalArguments["bootstrap-kubeconfig"] = kubeconfigBootstrapPath
-		return os.WriteFile(kubeconfigBootstrapPath, kubeconfig, kubeconfigPerm)
+		return util.WriteFileWithDir(kubeconfigBootstrapPath, kubeconfig, kubeconfigPerm)
 	} else {
 		k.additionalArguments["kubeconfig"] = kubeconfigPath
-		return os.WriteFile(kubeconfigPath, kubeconfig, kubeconfigPerm)
+		return util.WriteFileWithDir(kubeconfigPath, kubeconfig, kubeconfigPerm)
 	}
 }
 

--- a/nodeadm/internal/util/sys.go
+++ b/nodeadm/internal/util/sys.go
@@ -2,13 +2,24 @@ package util
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 )
 
 const trimChars = " \n\t"
+
+// Wraps os.WriteFile to automatically create parent directories such that the
+// caller does not need to ensure the existence of the file's directory
+func WriteFileWithDir(filePath string, data []byte, perm fs.FileMode) error {
+	if err := os.MkdirAll(path.Dir(filePath), perm); err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, data, perm)
+}
 
 func isHostPresent(host string) (bool, error) {
 	output, err := exec.Command("getent", "hosts", host).Output()

--- a/nodeadm/test/e2e/cases/image-credential-provider/config.yaml
+++ b/nodeadm/test/e2e/cases/image-credential-provider/config.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+metadata:
+  name: example
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16

--- a/nodeadm/test/e2e/cases/image-credential-provider/expected-image-credential-provider-config-126.json
+++ b/nodeadm/test/e2e/cases/image-credential-provider/expected-image-credential-provider-config-126.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "kubelet.config.k8s.io/v1alpha1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "ecr-credential-provider",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1alpha1"
+    }
+  ]
+}

--- a/nodeadm/test/e2e/cases/image-credential-provider/expected-image-credential-provider-config-127.json
+++ b/nodeadm/test/e2e/cases/image-credential-provider/expected-image-credential-provider-config-127.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "kubelet.config.k8s.io/v1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "ecr-credential-provider",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1"
+    }
+  ]
+}

--- a/nodeadm/test/e2e/cases/image-credential-provider/run.sh
+++ b/nodeadm/test/e2e/cases/image-credential-provider/run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::imds
+wait::dbus-ready
+
+mock::kubelet 1.26.0
+
+nodeadm init --skip run --config-source file://config.yaml
+
+assert::json-files-equal /etc/eks/image-credential-provider/config.json expected-image-credential-provider-config-126.json
+
+mock::kubelet 1.27.0
+
+nodeadm init --skip run --config-source file://config.yaml
+
+assert::json-files-equal /etc/eks/image-credential-provider/config.json expected-image-credential-provider-config-127.json

--- a/nodeadm/test/e2e/helpers.sh
+++ b/nodeadm/test/e2e/helpers.sh
@@ -23,7 +23,9 @@ function assert::json-files-equal() {
     exit 1
   fi
   local FILE1=$1
+  stat $FILE1
   local FILE2=$2
+  stat $FILE2
   if ! diff <(jq -S . $FILE1) <(jq -S . $FILE2); then
     echo "Files $FILE1 and $FILE2 are not equal"
     exit 1

--- a/nodeadm/test/e2e/infra/Dockerfile
+++ b/nodeadm/test/e2e/infra/Dockerfile
@@ -24,4 +24,8 @@ COPY --from=nodeadm-build /nodeadm /usr/local/bin/nodeadm
 COPY test/e2e/infra/systemd/kubelet.service /usr/lib/systemd/system/kubelet.service
 COPY test/e2e/infra/systemd/containerd.service /usr/lib/systemd/system/containerd.service
 COPY test/e2e/helpers.sh /helpers.sh
+
+RUN mkdir -p /etc/eks/image-credential-provider/
+RUN touch /etc/eks/image-credential-provider/ecr-credential-provider
+
 ENTRYPOINT ["/usr/lib/systemd/systemd","--system"]

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/kubelet.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/kubelet.service
@@ -7,10 +7,7 @@ Requires=containerd.service
 [Service]
 Slice=runtime.slice
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
-ExecStart=/usr/bin/kubelet \
-    --image-credential-provider-config /etc/eks/image-credential-provider/config.json \
-    --image-credential-provider-bin-dir /etc/eks/image-credential-provider \
-    $NODEADM_KUBELET_ARGS
+ExecStart=/usr/bin/kubelet $NODEADM_KUBELET_ARGS
 
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE


### PR DESCRIPTION
**Description of changes:**

the `image-credential-provider` related kubelet flags are currently in the worker installation script, so i moved them back into the bootstrap/nodeadm since the properties depend on kubelet version (and is considerably part of the kubelet config)

however, the install/download of the credential provider binary (`ecr-credential-provider`) still should belong in the install script, since it is a static asset.

I configured the default bin path pointers in `nodeadm` to match what is in `install-worker.sh`, and for extensibility i made this passable via an environment variable 

also, collapse some `kubeconfig.go` logic

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where 
applicable, include details steps to replicate. -->

```
make test && make test-e2e
```

also launched nodegroup with the built amis for v1.28