### PR TITLE
decouple kubelet environment from systemd drop-in 

### DIFF
--- a/nodeadm/internal/kubelet/daemon.go
+++ b/nodeadm/internal/kubelet/daemon.go
@@ -36,7 +36,7 @@ func (k *kubelet) Configure(cfg *api.NodeConfig) error {
 	if err := writeClusterCaCert(cfg.Spec.Cluster.CertificateAuthority); err != nil {
 		return err
 	}
-	if err := k.writeKubeletServiceEnvDropIn(cfg); err != nil {
+	if err := k.writeKubeletEnvironment(cfg); err != nil {
 		return err
 	}
 	return nil

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/kubelet.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/kubelet.service
@@ -6,6 +6,7 @@ Requires=containerd.service
 
 [Service]
 Slice=runtime.slice
+EnvironmentFile=/etc/eks/kubelet/environment
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
 ExecStart=/usr/bin/kubelet $NODEADM_KUBELET_ARGS
 


### PR DESCRIPTION
**Description of changes:**

writes the kubelet environment to a file that is picked up by systemd unit rather than directly writing drop-ins

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->