### PR TITLE
Name node with Instance Id for AL2023 AMI

### DIFF
--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -205,6 +205,7 @@ func (ksc *kubeletSubConfig) withVersionToggles(kubeletVersion string, kubeletAr
 		// --container-runtime flag is gone in 1.27+
 		kubeletArguments["container-runtime"] = "remote"
 		// --container-runtime-endpoint moved to kubelet config start from 1.27
+		// https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md?plain=1#L1800-L1801
 		kubeletArguments["container-runtime-endpoint"] = "unix:///run/containerd/containerd.sock"
 	}
 

--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -201,9 +201,11 @@ func (ksc *kubeletSubConfig) withNodeIp(cfg *api.NodeConfig, kubeletArguments ma
 
 func (ksc *kubeletSubConfig) withVersionToggles(kubeletVersion string, kubeletArguments map[string]string) {
 	// TODO: remove when 1.26 is EOL
-	// --container-runtime flag is gone in 1.27+
 	if semver.Compare(kubeletVersion, "v1.27.0") < 0 {
+		// --container-runtime flag is gone in 1.27+
 		kubeletArguments["container-runtime"] = "remote"
+		// --container-runtime-endpoint moved to kubelet config start from 1.27
+		kubeletArguments["container-runtime-endpoint"] = "unix:///run/containerd/containerd.sock"
 	}
 
 	// TODO: Remove this during 1.27 EOL
@@ -220,27 +222,16 @@ func (ksc *kubeletSubConfig) withVersionToggles(kubeletVersion string, kubeletAr
 	}
 }
 
-func (ksc *kubeletSubConfig) withCloudProvider(kubeletVersion string, cfg *api.NodeConfig, kubeletArguments map[string]string) {
-	if semver.Compare(kubeletVersion, "v1.26.0") < 0 {
-		// TODO: remove when 1.25 is EOL
-		kubeletArguments["cloud-provider"] = "aws"
-	} else {
-		// ref: https://github.com/kubernetes/kubernetes/pull/121367
-		kubeletArguments["cloud-provider"] = "external"
+func (ksc *kubeletSubConfig) withCloudProvider(cfg *api.NodeConfig, kubeletArguments map[string]string) {
+	// ref: https://github.com/kubernetes/kubernetes/pull/121367
+	kubeletArguments["cloud-provider"] = "external"
 
-		// provider ID needs to be specified when the cloud provider is
-		// external. evaluate if this can be done within the cloud controller.
-		// since the values are coming from IMDS this might not be feasible
-		providerId := getProviderId(cfg.Status.Instance.AvailabilityZone, cfg.Status.Instance.ID)
-		ksc.ProviderID = &providerId
-
-		// When the external cloud provider is used, kubelet will use /etc/hostname as the name of the Node object.
-		// If the VPC has a custom `domain-name` in its DHCP options set, and the VPC has `enableDnsHostnames` set to `true`,
-		// then /etc/hostname is not the same as EC2's PrivateDnsName.
-		// The name of the Node object must be equal to EC2's PrivateDnsName for the aws-iam-authenticator to allow this kubelet to manage it.
-
-		// k.additionalArguments["hostname-override"] = cfg.Status.Instance.ID
-	}
+	// provider ID needs to be specified when the cloud provider is
+	// external. evaluate if this can be done within the cloud controller.
+	// since the values are coming from IMDS this might not be feasible
+	providerId := getProviderId(cfg.Status.Instance.AvailabilityZone, cfg.Status.Instance.ID)
+	ksc.ProviderID = &providerId
+	kubeletArguments["hostname-override"] = cfg.Status.Instance.ID
 }
 
 // When the DefaultReservedResources flag is enabled, override the kubelet
@@ -270,7 +261,7 @@ func (k *kubelet) GenerateKubeletConfig(cfg *api.NodeConfig) (*kubeletSubConfig,
 	}
 
 	kubeletConfig.withVersionToggles(kubeletVersion, k.additionalArguments)
-	kubeletConfig.withCloudProvider(kubeletVersion, cfg, k.additionalArguments)
+	kubeletConfig.withCloudProvider(cfg, k.additionalArguments)
 
 	if featuregates.DefaultTrue(featuregates.DefaultReservedResources, cfg.Spec.FeatureGates) {
 		kubeletConfig.withDefaultReservedResources()


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Name AL2023 Nodes using Instance Id


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
```
make test
```
Build AL2023 1.23 and 1.28 AMI and tested with kubetest2

Example output for 1.23 test
```
kubetest2-eksapi --kubernetes-version=1.23 --up --user-data-format=nodeadm --unmanaged-nodes --ami  ami-0265683842cb535c7 --node-name-strategy=SessionName --nodes=2

I0121 18:04:32.773468   77125 nodegroup.go:298] ASG instances are using expected AMI: ami-0265683842cb535c7
I0121 18:04:32.773501   77125 k8s.go:29] waiting up to 5m0s for 2 node(s) to be ready...
I0121 18:04:35.222935   77125 k8s.go:69] 2 node(s) are ready: map[i-04ed8f1da1c2e8496:{} i-0fb6efa3e0701f34e:{}]

k get nodes
NAME                  STATUS   ROLES    AGE   VERSION
i-04ed8f1da1c2e8496   Ready    <none>   71m   v1.23.17-eks-5e0fdde
i-0fb6efa3e0701f34e   Ready    <none>   71m   v1.23.17-eks-5e0fdde
```
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
