### PR TITLE
e2e test kubelet version boundaries with eks suffix

### DIFF
--- a/nodeadm/test/e2e/cases/kubelet-version/config.yaml
+++ b/nodeadm/test/e2e/cases/kubelet-version/config.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+metadata:
+  name: example
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16

--- a/nodeadm/test/e2e/cases/kubelet-version/run.sh
+++ b/nodeadm/test/e2e/cases/kubelet-version/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::imds
+wait::dbus-ready
+
+mock::kubelet 1.21.0
+nodeadm init --skip run --config-source file://config.yaml
+assert::file-not-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS"'
+assert::file-not-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst"'
+
+mock::kubelet 1.22.0-eks-5e0fdde
+nodeadm init --skip run --config-source file://config.yaml
+assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS": 10'
+assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst": 20'
+
+mock::kubelet 1.22.0
+nodeadm init --skip run --config-source file://config.yaml
+assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS": 10'
+assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst": 20'
+
+mock::kubelet 1.26.0-eks-5e0fdde
+nodeadm init --skip run --config-source file://config.yaml
+assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS": 10'
+assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst": 20'
+
+mock::kubelet 1.26.0
+nodeadm init --skip run --config-source file://config.yaml
+assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS": 10'
+assert::file-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst": 20'
+
+mock::kubelet 1.27.0-eks-5e0fdde
+nodeadm init --skip run --config-source file://config.yaml
+assert::file-not-contains /etc/kubernetes/kubelet/config.json '"kubeAPIQPS"'
+assert::file-not-contains /etc/kubernetes/kubelet/config.json '"kubeAPIBurst"'

--- a/nodeadm/test/e2e/helpers.sh
+++ b/nodeadm/test/e2e/helpers.sh
@@ -32,6 +32,36 @@ function assert::json-files-equal() {
   fi
 }
 
+function assert::file-contains() {
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: assert::file-contains FILE PATTERN"
+    exit 1
+  fi
+  local FILE=$1
+  local PATTERN=$2
+  if ! grep -e "$PATTERN" $FILE; then
+    echo "File $FILE does not contain pattern '$PATTERN'"
+    cat $FILE
+    echo ""
+    exit 1
+  fi
+}
+
+function assert::file-not-contains() {
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: assert::file-not-contains FILE PATTERN"
+    exit 1
+  fi
+  local FILE=$1
+  local PATTERN=$2
+  if grep -e "$PATTERN" $FILE; then
+    echo "File $FILE contains pattern '$PATTERN'"
+    cat $FILE
+    echo ""
+    exit 1
+  fi
+}
+
 function mock::kubelet() {
   if [ "$#" -ne 1 ]; then
     echo "Usage: mock::kubelet VERSION"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Based on some version-specific values, test the behavior of the bootstrap with eks-suffixed kubelet versions to ensure that checks are not affected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

added e2e tests

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
