### PR TITLE
handle pod-infra-container-image on older versions

### DIFF
--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -240,6 +240,35 @@ func (ksc *kubeletConfig) withDefaultReservedResources() {
 	ksc.KubeReservedCgroup = ptr.String("/runtime")
 }
 
+// The '--pod-infra-container-image' flags is added so that the sandbox image is
+// not garbage collected. There are several way in which we could remove this:
+//   - wait until a minimum supported version of kubernetes which implements the
+//     image pinning CRI support: https://github.com/kubernetes/kubernetes/pull/118544
+//   - update to containerd 2.0, which reworks the abstraction and no longer
+//     requires sandbox image
+func (ksc *kubeletConfig) withPodInfraContainerImage(cfg *api.NodeConfig, kubeletVersion string, flags map[string]string) error {
+	if semver.Compare(kubeletVersion, "v1.27.0") < 0 {
+		awsDomain, err := util.GetAwsDomain(context.TODO(), imds.New(imds.Options{}))
+		if err != nil {
+			return err
+		}
+		ecrUri, err := util.GetEcrUri(util.GetEcrUriRequest{
+			Region:    cfg.Status.Instance.Region,
+			Domain:    awsDomain,
+			AllowFips: true,
+		})
+		if err != nil {
+			return err
+		}
+		pauseContainerImage, err := util.GetPauseContainer(ecrUri)
+		if err != nil {
+			return err
+		}
+		flags["pod-infra-container-image"] = pauseContainerImage
+	}
+	return nil
+}
+
 func (k *kubelet) GenerateKubeletConfig(cfg *api.NodeConfig) (*kubeletConfig, error) {
 	// Get the kubelet/kubernetes version to help conditionally enable features
 	kubeletVersion, err := GetKubeletVersion()
@@ -249,6 +278,7 @@ func (k *kubelet) GenerateKubeletConfig(cfg *api.NodeConfig) (*kubeletConfig, er
 	zap.L().Info("Detected kubelet version", zap.String("version", kubeletVersion))
 
 	kubeletConfig := defaultKubeletSubConfig()
+
 	if err := kubeletConfig.withFallbackClusterDns(&cfg.Spec.Cluster); err != nil {
 		return nil, err
 	}
@@ -256,6 +286,9 @@ func (k *kubelet) GenerateKubeletConfig(cfg *api.NodeConfig) (*kubeletConfig, er
 		return nil, err
 	}
 	if err := kubeletConfig.withNodeIp(cfg, k.flags); err != nil {
+		return nil, err
+	}
+	if err := kubeletConfig.withPodInfraContainerImage(cfg, kubeletVersion, k.flags); err != nil {
 		return nil, err
 	}
 

--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -246,26 +246,24 @@ func (ksc *kubeletConfig) withDefaultReservedResources() {
 //     image pinning CRI support: https://github.com/kubernetes/kubernetes/pull/118544
 //   - update to containerd 2.0, which reworks the abstraction and no longer
 //     requires sandbox image
-func (ksc *kubeletConfig) withPodInfraContainerImage(cfg *api.NodeConfig, kubeletVersion string, flags map[string]string) error {
-	if semver.Compare(kubeletVersion, "v1.27.0") < 0 {
-		awsDomain, err := util.GetAwsDomain(context.TODO(), imds.New(imds.Options{}))
-		if err != nil {
-			return err
-		}
-		ecrUri, err := util.GetEcrUri(util.GetEcrUriRequest{
-			Region:    cfg.Status.Instance.Region,
-			Domain:    awsDomain,
-			AllowFips: true,
-		})
-		if err != nil {
-			return err
-		}
-		pauseContainerImage, err := util.GetPauseContainer(ecrUri)
-		if err != nil {
-			return err
-		}
-		flags["pod-infra-container-image"] = pauseContainerImage
+func (ksc *kubeletConfig) withPodInfraContainerImage(cfg *api.NodeConfig, flags map[string]string) error {
+	awsDomain, err := util.GetAwsDomain(context.TODO(), imds.New(imds.Options{}))
+	if err != nil {
+		return err
 	}
+	ecrUri, err := util.GetEcrUri(util.GetEcrUriRequest{
+		Region:    cfg.Status.Instance.Region,
+		Domain:    awsDomain,
+		AllowFips: true,
+	})
+	if err != nil {
+		return err
+	}
+	pauseContainerImage, err := util.GetPauseContainer(ecrUri)
+	if err != nil {
+		return err
+	}
+	flags["pod-infra-container-image"] = pauseContainerImage
 	return nil
 }
 
@@ -288,7 +286,7 @@ func (k *kubelet) GenerateKubeletConfig(cfg *api.NodeConfig) (*kubeletConfig, er
 	if err := kubeletConfig.withNodeIp(cfg, k.flags); err != nil {
 		return nil, err
 	}
-	if err := kubeletConfig.withPodInfraContainerImage(cfg, kubeletVersion, k.flags); err != nil {
+	if err := kubeletConfig.withPodInfraContainerImage(cfg, k.flags); err != nil {
 		return nil, err
 	}
 

--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -240,30 +240,35 @@ func (ksc *kubeletConfig) withDefaultReservedResources() {
 	ksc.KubeReservedCgroup = ptr.String("/runtime")
 }
 
-// The '--pod-infra-container-image' flags is added so that the sandbox image is
-// not garbage collected. There are several way in which we could remove this:
-//   - wait until a minimum supported version of kubernetes which implements the
-//     image pinning CRI support: https://github.com/kubernetes/kubernetes/pull/118544
-//   - update to containerd 2.0, which reworks the abstraction and no longer
-//     requires sandbox image
-func (ksc *kubeletConfig) withPodInfraContainerImage(cfg *api.NodeConfig, flags map[string]string) error {
-	awsDomain, err := util.GetAwsDomain(context.TODO(), imds.New(imds.Options{}))
-	if err != nil {
-		return err
+// withPodInfraContainerImage determines whether to add the
+// '--pod-infra-container-image' flag, which is used to ensure the sandbox image
+// is not garbage collected.
+//
+// TODO: revisit once the minimum supportted version catches up or the container
+// runtime is moved to containerd 2.0
+func (ksc *kubeletConfig) withPodInfraContainerImage(cfg *api.NodeConfig, kubeletVersion string, flags map[string]string) error {
+	// the flag is a noop on 1.29+, since the behavior was changed to use the
+	// CRI image pinning behavior and no longer considers the flag value.
+	// see: https://github.com/kubernetes/kubernetes/pull/118544
+	if semver.Compare(kubeletVersion, "v1.29.0") < 0 {
+		awsDomain, err := util.GetAwsDomain(context.TODO(), imds.New(imds.Options{}))
+		if err != nil {
+			return err
+		}
+		ecrUri, err := util.GetEcrUri(util.GetEcrUriRequest{
+			Region:    cfg.Status.Instance.Region,
+			Domain:    awsDomain,
+			AllowFips: true,
+		})
+		if err != nil {
+			return err
+		}
+		pauseContainerImage, err := util.GetPauseContainer(ecrUri)
+		if err != nil {
+			return err
+		}
+		flags["pod-infra-container-image"] = pauseContainerImage
 	}
-	ecrUri, err := util.GetEcrUri(util.GetEcrUriRequest{
-		Region:    cfg.Status.Instance.Region,
-		Domain:    awsDomain,
-		AllowFips: true,
-	})
-	if err != nil {
-		return err
-	}
-	pauseContainerImage, err := util.GetPauseContainer(ecrUri)
-	if err != nil {
-		return err
-	}
-	flags["pod-infra-container-image"] = pauseContainerImage
 	return nil
 }
 
@@ -286,7 +291,7 @@ func (k *kubelet) GenerateKubeletConfig(cfg *api.NodeConfig) (*kubeletConfig, er
 	if err := kubeletConfig.withNodeIp(cfg, k.flags); err != nil {
 		return nil, err
 	}
-	if err := kubeletConfig.withPodInfraContainerImage(cfg, k.flags); err != nil {
+	if err := kubeletConfig.withPodInfraContainerImage(cfg, kubeletVersion, k.flags); err != nil {
 		return nil, err
 	}
 

--- a/nodeadm/test/e2e/cases/pod-infra-container/config.yaml
+++ b/nodeadm/test/e2e/cases/pod-infra-container/config.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16

--- a/nodeadm/test/e2e/cases/pod-infra-container/run.sh
+++ b/nodeadm/test/e2e/cases/pod-infra-container/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::imds
+wait::dbus-ready
+
+mock::kubelet 1.26.0
+nodeadm init --skip run --config-source file://config.yaml
+assert::file-contains /etc/eks/kubelet/environment '--pod-infra-container-image=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5'
+
+mock::kubelet 1.27.0
+nodeadm init --skip run --config-source file://config.yaml
+assert::file-not-contains /etc/eks/kubelet/environment 'pod-infra-container-image'

--- a/nodeadm/test/e2e/cases/pod-infra-container/run.sh
+++ b/nodeadm/test/e2e/cases/pod-infra-container/run.sh
@@ -9,10 +9,6 @@ source /helpers.sh
 mock::imds
 wait::dbus-ready
 
-mock::kubelet 1.26.0
-nodeadm init --skip run --config-source file://config.yaml
-assert::file-contains /etc/eks/kubelet/environment '--pod-infra-container-image=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5'
-
 mock::kubelet 1.27.0
 nodeadm init --skip run --config-source file://config.yaml
-assert::file-not-contains /etc/eks/kubelet/environment 'pod-infra-container-image'
+assert::file-contains /etc/eks/kubelet/environment '--pod-infra-container-image=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5'

--- a/nodeadm/test/e2e/cases/pod-infra-container/run.sh
+++ b/nodeadm/test/e2e/cases/pod-infra-container/run.sh
@@ -9,6 +9,10 @@ source /helpers.sh
 mock::imds
 wait::dbus-ready
 
-mock::kubelet 1.27.0
+mock::kubelet 1.28.0
 nodeadm init --skip run --config-source file://config.yaml
 assert::file-contains /etc/eks/kubelet/environment '--pod-infra-container-image=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5'
+
+mock::kubelet 1.29.0
+nodeadm init --skip run --config-source file://config.yaml
+assert::file-not-contains /etc/eks/kubelet/environment 'pod-infra-container-image'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

some k8s versions will require the `--pod-infra-container-image` flag to avoid the sandbox image getting GC'd. [Kubelet options](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) state this will be removed in 1.27.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

e2e test cases

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
