### PR TITLE
cleanup nerdctl after nodeadm containerized build

### DIFF
--- a/templates/al2023/provisioners/install-nodeadm.sh
+++ b/templates/al2023/provisioners/install-nodeadm.sh
@@ -13,6 +13,10 @@ sudo nerdctl run \
   public.ecr.aws/eks-distro-build-tooling/golang:1.21 \
   make build
 
+# cleanup images and networks used for nerdctl
+sudo nerdctl image prune --all --force
+sudo nerdctl network rm $(sudo nerdctl network list -q)
+
 # move the nodeadm binary into bin folder
 sudo chmod a+x $PROJECT_DIR/_bin/nodeadm
 sudo mv $PROJECT_DIR/_bin/nodeadm /usr/bin/

--- a/templates/al2023/provisioners/install-nodeadm.sh
+++ b/templates/al2023/provisioners/install-nodeadm.sh
@@ -4,18 +4,23 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
+BUILD_IMAGE=public.ecr.aws/eks-distro-build-tooling/golang:1.21
+
 sudo systemctl start containerd
 
 sudo nerdctl run \
   --rm \
+  --network host \
   --workdir /workdir \
   --volume $PROJECT_DIR:/workdir \
-  public.ecr.aws/eks-distro-build-tooling/golang:1.21 \
+  $BUILD_IMAGE \
   make build
 
-# cleanup images and networks used for nerdctl
-sudo nerdctl image prune --all --force
-sudo nerdctl network rm $(sudo nerdctl network list -q)
+# cleanup build image and snapshots
+sudo nerdctl rmi \
+  --force \
+  $BUILD_IMAGE \
+  $(sudo nerdctl images -a | grep none | awk '{ print $3 }')
 
 # move the nodeadm binary into bin folder
 sudo chmod a+x $PROJECT_DIR/_bin/nodeadm

--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -52,3 +52,12 @@ if [ ${FREE_MEBIBYTES} -lt ${REQUIRED_FREE_MEBIBYTES} ]; then
 else
   echo "Disk space requirements were met."
 fi
+
+################################
+### network ####################
+################################
+
+if sudo ip link | grep nerdctl0; then
+  echo "nerdctl0 interface should be removed."
+  exit 1
+fi


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

cleanup network and image resources used by nerdctl during the nodeadm build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

capture the following in between steps of the build:
```
sudo nerdctl network list
sudo nerdctl image list
sudo ip link
```

after build:
```
2024-01-30T00:49:40Z:     amazon-ebs: NETWORK ID    NAME    FILE
2024-01-30T00:49:40Z:     amazon-ebs:               host
2024-01-30T00:49:40Z:     amazon-ebs:               none
2024-01-30T00:49:40Z:     amazon-ebs: REPOSITORY                                        TAG       IMAGE ID        CREATED          PLATFORM       SIZE         BLOB SIZE
2024-01-30T00:49:40Z:     amazon-ebs: public.ecr.aws/eks-distro-build-tooling/golang    1.21      3072b6e1ad77    2 minutes ago    linux/amd64    469.1 MiB    149.1 MiB
2024-01-30T00:49:40Z:     amazon-ebs: <none>                                            <none>    3072b6e1ad77    2 minutes ago    linux/amd64    469.1 MiB    149.1 MiB
2024-01-30T00:49:40Z:     amazon-ebs: 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
2024-01-30T00:49:40Z:     amazon-ebs:     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2024-01-30T00:49:40Z:     amazon-ebs: 2: ens5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP mode DEFAULT group default qlen 1000
2024-01-30T00:49:40Z:     amazon-ebs:     link/ether 02:ea:1d:25:8f:eb brd ff:ff:ff:ff:ff:ff
2024-01-30T00:49:40Z:     amazon-ebs:     altname enp0s5
2024-01-30T00:49:40Z:     amazon-ebs:     altname eni-004bc029d3253c703
2024-01-30T00:49:40Z:     amazon-ebs:     altname device-number-0
```

after cleanup: (the additions in the PR)
```
2024-01-30T00:49:41Z:     amazon-ebs: NETWORK ID    NAME    FILE
2024-01-30T00:49:41Z:     amazon-ebs:               host
2024-01-30T00:49:41Z:     amazon-ebs:               none
2024-01-30T00:49:41Z:     amazon-ebs: REPOSITORY    TAG    IMAGE ID    CREATED    PLATFORM    SIZE    BLOB SIZE
2024-01-30T00:49:41Z:     amazon-ebs: 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
2024-01-30T00:49:41Z:     amazon-ebs:     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2024-01-30T00:49:41Z:     amazon-ebs: 2: ens5: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9001 qdisc mq state UP mode DEFAULT group default qlen 1000
2024-01-30T00:49:41Z:     amazon-ebs:     link/ether 02:ea:1d:25:8f:eb brd ff:ff:ff:ff:ff:ff
2024-01-30T00:49:41Z:     amazon-ebs:     altname enp0s5
2024-01-30T00:49:41Z:     amazon-ebs:     altname eni-004bc029d3253c703
2024-01-30T00:49:41Z:     amazon-ebs:     altname device-number-0
```


<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
