### PR TITLE
Pull sandbox image periodically

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -575,10 +575,13 @@ if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
   if ! cmp -s /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml; then
     sudo cp -v /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml
     sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service
+    sudo cp -v /etc/eks/containerd/sandbox-image.timer /etc/systemd/system/sandbox-image.timer
     sudo chown root:root /etc/systemd/system/sandbox-image.service
+    sudo chown root:root /etc/systemd/system/sandbox-image.timer
     systemctl daemon-reload
     systemctl enable containerd sandbox-image
     systemctl restart sandbox-image containerd
+    systemctl enable --now sandbox-image.timer
   fi
   sudo cp -v /etc/eks/containerd/kubelet-containerd.service /etc/systemd/system/kubelet.service
   sudo chown root:root /etc/systemd/system/kubelet.service

--- a/files/sandbox-image.timer
+++ b/files/sandbox-image.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Pulls the containerd sandbox image periodically
+
+[Timer]
+OnUnitActiveSec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -184,6 +184,7 @@ fi
 
 sudo mv $WORKING_DIR/kubelet-containerd.service /etc/eks/containerd/kubelet-containerd.service
 sudo mv $WORKING_DIR/sandbox-image.service /etc/eks/containerd/sandbox-image.service
+sudo mv $WORKING_DIR/sandbox-image.timer /etc/eks/containerd/sandbox-image.timer
 sudo mv $WORKING_DIR/pull-sandbox-image.sh /etc/eks/containerd/pull-sandbox-image.sh
 sudo mv $WORKING_DIR/pull-image.sh /etc/eks/containerd/pull-image.sh
 sudo chmod +x /etc/eks/containerd/pull-sandbox-image.sh
@@ -413,10 +414,12 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
   cat /etc/eks/containerd/containerd-config.toml | sed s,SANDBOX_IMAGE,$PAUSE_CONTAINER,g | sudo tee /etc/eks/containerd/containerd-cached-pause-config.toml
   sudo cp -v /etc/eks/containerd/containerd-cached-pause-config.toml /etc/containerd/config.toml
   sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service
+  sudo cp -v /etc/eks/containerd/sandbox-image.timer /etc/systemd/system/sandbox-image.timer
   sudo chown root:root /etc/systemd/system/sandbox-image.service
+  sudo chown root:root /etc/systemd/system/sandbox-image.timer
   sudo systemctl daemon-reload
   sudo systemctl start containerd
-  sudo systemctl enable containerd sandbox-image
+  sudo systemctl enable containerd sandbox-image sandbox-image.timer
 
   K8S_MINOR_VERSION=$(echo "${KUBERNETES_VERSION}" | cut -d'.' -f1-2)
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=aemm /ec2-metadata-mock /sbin/ec2-metadata-mock
 RUN mkdir -p /etc/systemd/system
 RUN mkdir -p /etc/eks/containerd
 COPY files/ /etc/eks/
-COPY files/containerd-config.toml files/kubelet-containerd.service files/pull-sandbox-image.sh files/sandbox-image.service /etc/eks/containerd/
+COPY files/containerd-config.toml files/kubelet-containerd.service files/pull-sandbox-image.sh files/sandbox-image.service files/sandbox-image.timer /etc/eks/containerd/
 COPY files/kubelet-config.json /etc/kubernetes/kubelet/kubelet-config.json
 COPY files/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
 COPY files/ecr-credential-provider-config.json /etc/eks/image-credential-provider/config.json


### PR DESCRIPTION
**Issue #, if available:**

Helps workaround #1597, proper fix will be an updated `containerd` from Amazon Linux.

**Description of changes:**

As a hotfix for accidental garbage collections of the sandbox container image, we'll check every minute and re-pull it if necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

Tested live on a node, the timer has the desired effect:
```
[ec2-user@ip-172-31-37-28 ~]$ sudo journalctl -u sandbox-image -f
...
Jan 30 20:22:37 ip-172-31-37-28.us-west-2.compute.internal systemd[1]: Starting pull sandbox image defined in containerd config.toml...
Jan 30 20:22:37 ip-172-31-37-28.us-west-2.compute.internal sudo[12946]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/ctr#040--namespace#040k8s.io#040image#040ls
Jan 30 20:22:37 ip-172-31-37-28.us-west-2.compute.internal systemd[1]: Started pull sandbox image defined in containerd config.toml.
Jan 30 20:24:37 ip-172-31-37-28.us-west-2.compute.internal systemd[1]: Starting pull sandbox image defined in containerd config.toml...
Jan 30 20:24:37 ip-172-31-37-28.us-west-2.compute.internal sudo[12961]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/ctr#040--namespace#040k8s.io#040image#040ls
Jan 30 20:24:37 ip-172-31-37-28.us-west-2.compute.internal systemd[1]: Started pull sandbox image defined in containerd config.toml.
Jan 30 20:26:17 ip-172-31-37-28.us-west-2.compute.internal systemd[1]: Starting pull sandbox image defined in containerd config.toml...
Jan 30 20:26:17 ip-172-31-37-28.us-west-2.compute.internal sudo[13007]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/ctr#040--namespace#040k8s.io#040image#040ls
Jan 30 20:26:17 ip-172-31-37-28.us-west-2.compute.internal systemd[1]: Started pull sandbox image defined in containerd config.toml.
Jan 30 20:27:37 ip-172-31-37-28.us-west-2.compute.internal systemd[1]: Starting pull sandbox image defined in containerd config.toml...
Jan 30 20:27:37 ip-172-31-37-28.us-west-2.compute.internal sudo[13034]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/bin/ctr#040--namespace#040k8s.io#040image#040ls
Jan 30 20:27:37 ip-172-31-37-28.us-west-2.compute.internal systemd[1]: Started pull sandbox image defined in containerd config.toml.
```