### PR TITLE
Update CI to use k8s arg to make command

### DIFF
--- a/.github/actions/ci/build/action.yaml
+++ b/.github/actions/ci/build/action.yaml
@@ -26,7 +26,7 @@ runs:
       run: |
         packer plugins install github.com/hashicorp/amazon
         AMI_NAME="amazon-eks-node-${{ inputs.k8s_version }}-${{ inputs.build_id }}"
-        make ${{ inputs.k8s_version }} ami_name=${AMI_NAME} ${{ inputs.additional_arguments }}
+        make k8s=${{ inputs.k8s_version }} ami_name=${AMI_NAME} ${{ inputs.additional_arguments }}
         echo "ami_id=$(jq -r .builds[0].artifact_id "${AMI_NAME}-manifest.json" | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
**Description of changes:**

Instead of using the k8s version stub targets, use the `k8s` make variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
