### PR TITLE
Add gosec

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/dependency-review-action@v4
+  gosec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: cd nodeadm
+      - uses: securego/gosec@master
+        with:
+          args: -exclude=G101,G103,G204 ./...
   govulncheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@4.0.0
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21.6'
       - run: go install github.com/securego/gosec/v2/cmd/gosec@latest

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: cd nodeadm
       - uses: securego/gosec@master
         with:
           args: -exclude=G101,G103,G204 ./...
+        working-directory: nodeadm
   govulncheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -16,9 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: securego/gosec@master
+      - uses: actions/setup-go@4.0.0
         with:
-          args: -exclude=G101,G103,G204 ./...
+          go-version: '1.21.6'
+      - run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - run: gosec -exclude=G101,G103,G204 ./...
         working-directory: nodeadm
   govulncheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-dependency.yaml
+++ b/.github/workflows/update-dependency.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/setup-go@4.0.0
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.21.6'
       - uses: actions/checkout@v4


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add gosec to dependency review. Attempted to add [this previously](https://github.com/awslabs/amazon-eks-ami/pull/1594#issuecomment-1913084855) and turns out the docker based  approach `securego/gosec@master` cannot configure the path to the nodeadm module and it cannot get all the required dependencies. 
Move to a cli way to install and run gosec to address above issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
