### PR TITLE
Use crictl to pull sandbox image

### DIFF
--- a/files/pull-sandbox-image.sh
+++ b/files/pull-sandbox-image.sh
@@ -8,4 +8,26 @@ if [[ "$(sudo ctr --namespace k8s.io image ls | grep $sandbox_image)" != "" ]]; 
   exit 0
 fi
 
-/etc/eks/containerd/pull-image.sh "${sandbox_image}"
+MAX_RETRIES=3
+
+function retry() {
+  local rc=0
+  for attempt in $(seq 0 $MAX_RETRIES); do
+    rc=0
+    [[ $attempt -gt 0 ]] && echo "Attempt $attempt of $MAX_RETRIES" 1>&2
+    "$@"
+    rc=$?
+    [[ $rc -eq 0 ]] && break
+    [[ $attempt -eq $MAX_RETRIES ]] && exit $rc
+    local jitter=$((1 + RANDOM % 10))
+    local sleep_sec="$(($((5 << $((1 + $attempt)))) + $jitter))"
+    sleep $sleep_sec
+  done
+}
+
+ecr_password=$(retry aws ecr get-login-password)
+if [[ -z ${ecr_password} ]]; then
+  echo >&2 "Unable to retrieve the ECR password."
+  exit 1
+fi
+retry sudo crictl pull --creds "AWS:${ecr_password}" "${sandbox_image}"

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -174,6 +174,9 @@ sudo yum versionlock runc-*
 sudo yum install -y containerd-${CONTAINERD_VERSION}
 sudo yum versionlock containerd-*
 
+# install cri-tools for crictl, needed to interact with containerd's CRI server
+sudo yum install -y cri-tools
+
 sudo mkdir -p /etc/eks/containerd
 if [ -f "/etc/eks/containerd/containerd-config.toml" ]; then
   ## this means we are building a gpu ami and have already placed a containerd configuration file in /etc/eks


### PR DESCRIPTION
**Issue #, if available:**

Fixes #1597 on `containerd` 1.7.3+.

**Description of changes:**

The containerd CRI server will only report an image as "pinned" if it is *pulled* with the CRI server. The pinned label will not be applied if it is pulled using the bare `containerd` server with `ctr`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

On `containerd-1.7.11` with `sandbox_image = "registry.k8s.io/pause:3.9"`:
```
> sudo ctr --namespace k8s.io image pull registry.k8s.io/pause:3.9
> sudo crictl inspecti registry.k8s.io/pause:3.9 | grep pinned
    "pinned": false

> sudo crictl rmi --all
Deleted: registry.k8s.io/pause:3.9

> sudo crictl pull registry.k8s.io/pause:3.9
Image is up to date for sha256:e6f1816883972d4be47bd48879a08919b96afcd344132622e4d444987919323c
> sudo crictl inspecti registry.k8s.io/pause:3.9 | grep pinned
    "pinned": true
```