### PR TITLE
Stop pulling aws-iam-authenticator binary

### DIFF
--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -170,7 +170,6 @@ S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin
 
 BINARIES=(
   kubelet
-  aws-iam-authenticator
 )
 for binary in ${BINARIES[*]}; do
   if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
@@ -186,16 +185,6 @@ for binary in ${BINARIES[*]}; do
   sudo chmod +x $binary
   sudo mv $binary /usr/bin/
 done
-
-# Verify that the aws-iam-authenticator is at last v0.5.9 or greater. Otherwise, nodes will be
-# unable to join clusters due to upgrading to client.authentication.k8s.io/v1beta1
-iam_auth_version=$(sudo /usr/bin/aws-iam-authenticator version | jq -r .Version)
-if vercmp "$iam_auth_version" lt "v0.5.9"; then
-  # To resolve this issue, you need to update the aws-iam-authenticator binary. Using binaries distributed by EKS
-  # with kubernetes_build_date 2022-10-31 or later include v0.5.10 or greater.
-  echo "❌ The aws-iam-authenticator should be on version v0.5.9 or later. Found $iam_auth_version"
-  exit 1
-fi
 
 # Since CNI 0.7.0, all releases are done in the plugins repo.
 CNI_PLUGIN_FILENAME="cni-plugins-linux-${ARCH}-${CNI_PLUGIN_VERSION}"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

we are using `aws eks get-token` over `aws-iam-authenticator` since the `aws` cli version in [AL2023 packages](https://docs.aws.amazon.com/linux/al2023/release-notes/all-packages-AL2023.3.html) supports this feature generally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

WIP testing successfully nodegroup launch

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
