### PR TITLE
Revert "Pull sandbox image periodically (#1601)"

### DIFF
--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -575,13 +575,10 @@ if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
   if ! cmp -s /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml; then
     sudo cp -v /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml
     sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service
-    sudo cp -v /etc/eks/containerd/sandbox-image.timer /etc/systemd/system/sandbox-image.timer
     sudo chown root:root /etc/systemd/system/sandbox-image.service
-    sudo chown root:root /etc/systemd/system/sandbox-image.timer
     systemctl daemon-reload
     systemctl enable containerd sandbox-image
     systemctl restart sandbox-image containerd
-    systemctl enable --now sandbox-image.timer
   fi
   sudo cp -v /etc/eks/containerd/kubelet-containerd.service /etc/systemd/system/kubelet.service
   sudo chown root:root /etc/systemd/system/kubelet.service

--- a/files/sandbox-image.timer
+++ b/files/sandbox-image.timer
@@ -1,9 +1,0 @@
-[Unit]
-Description=Pulls the containerd sandbox image periodically
-
-[Timer]
-OnUnitActiveSec=60
-Persistent=true
-
-[Install]
-WantedBy=timers.target

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -184,7 +184,6 @@ fi
 
 sudo mv $WORKING_DIR/kubelet-containerd.service /etc/eks/containerd/kubelet-containerd.service
 sudo mv $WORKING_DIR/sandbox-image.service /etc/eks/containerd/sandbox-image.service
-sudo mv $WORKING_DIR/sandbox-image.timer /etc/eks/containerd/sandbox-image.timer
 sudo mv $WORKING_DIR/pull-sandbox-image.sh /etc/eks/containerd/pull-sandbox-image.sh
 sudo mv $WORKING_DIR/pull-image.sh /etc/eks/containerd/pull-image.sh
 sudo chmod +x /etc/eks/containerd/pull-sandbox-image.sh
@@ -414,12 +413,10 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
   cat /etc/eks/containerd/containerd-config.toml | sed s,SANDBOX_IMAGE,$PAUSE_CONTAINER,g | sudo tee /etc/eks/containerd/containerd-cached-pause-config.toml
   sudo cp -v /etc/eks/containerd/containerd-cached-pause-config.toml /etc/containerd/config.toml
   sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service
-  sudo cp -v /etc/eks/containerd/sandbox-image.timer /etc/systemd/system/sandbox-image.timer
   sudo chown root:root /etc/systemd/system/sandbox-image.service
-  sudo chown root:root /etc/systemd/system/sandbox-image.timer
   sudo systemctl daemon-reload
   sudo systemctl start containerd
-  sudo systemctl enable containerd sandbox-image sandbox-image.timer
+  sudo systemctl enable containerd sandbox-image
 
   K8S_MINOR_VERSION=$(echo "${KUBERNETES_VERSION}" | cut -d'.' -f1-2)
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=aemm /ec2-metadata-mock /sbin/ec2-metadata-mock
 RUN mkdir -p /etc/systemd/system
 RUN mkdir -p /etc/eks/containerd
 COPY files/ /etc/eks/
-COPY files/containerd-config.toml files/kubelet-containerd.service files/pull-sandbox-image.sh files/sandbox-image.service files/sandbox-image.timer /etc/eks/containerd/
+COPY files/containerd-config.toml files/kubelet-containerd.service files/pull-sandbox-image.sh files/sandbox-image.service /etc/eks/containerd/
 COPY files/kubelet-config.json /etc/kubernetes/kubelet/kubelet-config.json
 COPY files/kubelet-kubeconfig /var/lib/kubelet/kubeconfig
 COPY files/ecr-credential-provider-config.json /etc/eks/image-credential-provider/config.json


### PR DESCRIPTION
This reverts commit 824c55ec0cb6165ae1ba6df0195ba5ea259539a8.

We're going to fast-track the release of an updated `containerd` instead of using this hack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
