### PR TITLE
explicitely set IMDS TTL

### DIFF
--- a/templates/al2/template.json
+++ b/templates/al2/template.json
@@ -113,7 +113,8 @@
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}",
       "metadata_options": {
-        "http_tokens": "required"
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
       }
     }
   ],

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -110,7 +110,8 @@
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}",
       "metadata_options": {
-        "http_tokens": "required"
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
       }
     }
   ],


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Specify the IMDS TTL used for AMIs to `1`. The packer defaults [here](https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/latest/components/builder/ebs#metadata-settings) mentioned the default is `1`, so there is not change other than explicitly locking this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
