### PR TITLE
default http-put-response-hop-limit to 1 for al2023

### DIFF
--- a/templates/al2/template.json
+++ b/templates/al2/template.json
@@ -113,7 +113,8 @@
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}",
       "metadata_options": {
-        "http_tokens": "required"
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
       }
     }
   ],

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -107,7 +107,8 @@
       "ami_name": "{{user `ami_name`}}",
       "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}",
       "metadata_options": {
-        "http_tokens": "required"
+        "http_tokens": "required",
+        "http_put_response_hop_limit": 1
       }
     }
   ],


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
this option is default to 2, per this [doc](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#configure-IMDS-new-instances-ami-configuration). 
And suggested by AppSec, since we supported [pod identity](https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-eks-pod-identity/), we should default it to 1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
Build 1.28 AMI and tested with kubetest2 and conformance
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
