### PR TITLE
Remove sandbox image from build-time cache

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -412,14 +412,9 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
   AWS_DOMAIN=$(imds 'latest/meta-data/services/domain')
   ECR_URI=$(/etc/eks/get-ecr-uri.sh "${BINARY_BUCKET_REGION}" "${AWS_DOMAIN}")
 
-  PAUSE_CONTAINER="${ECR_URI}/eks/pause:${PAUSE_CONTAINER_VERSION}"
-  cat /etc/eks/containerd/containerd-config.toml | sed s,SANDBOX_IMAGE,$PAUSE_CONTAINER,g | sudo tee /etc/eks/containerd/containerd-cached-pause-config.toml
-  sudo cp -v /etc/eks/containerd/containerd-cached-pause-config.toml /etc/containerd/config.toml
-  sudo cp -v /etc/eks/containerd/sandbox-image.service /etc/systemd/system/sandbox-image.service
-  sudo chown root:root /etc/systemd/system/sandbox-image.service
   sudo systemctl daemon-reload
   sudo systemctl start containerd
-  sudo systemctl enable containerd sandbox-image
+  sudo systemctl enable containerd
 
   K8S_MINOR_VERSION=$(echo "${KUBERNETES_VERSION}" | cut -d'.' -f1-2)
 
@@ -467,7 +462,6 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
   fi
 
   CACHE_IMGS=(
-    "${PAUSE_CONTAINER}"
     ${KUBE_PROXY_IMGS[@]+"${KUBE_PROXY_IMGS[@]}"}
     ${VPC_CNI_IMGS[@]+"${VPC_CNI_IMGS[@]}"}
   )


### PR DESCRIPTION
**Description of changes:**

This removes the sandbox image from the build-time cache. This image needs to be pulled via the CRI gRPC server of containerd in order to be properly labeled as "pinned" in order to be excluded from kubelet's image garbage collection. The multi-regional tagging behavior of the image cache is not amenable to this, and the sandbox image is very small -- it is not expensive to pull at runtime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.