### PR TITLE
Label cached sandbox images as pinned

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -514,6 +514,13 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
       fi
     done
   done
+
+  # exclude cached pause images from kubelet garbage collection
+  for IMAGE in $(sudo ctr -n k8s.io images ls --quiet); do
+    if [[ "${IMAGE}" == *"eks/pause"* ]]; then
+      sudo ctr -n k8s.io image label "${IMAGE}" "io.cri-containerd.pinned=pinned"
+    fi
+  done
 fi
 
 ################################################################################


### PR DESCRIPTION
**Description of changes:**

Adds the `io.cri-containerd.pinned=pinned` label to sandbox container images that are cached during the AMI build process. This will exclude all tags of the cached image layers from being garbage collected by kubelet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
