### PR TITLE
merge default metadata into drop-in kubelet config

### DIFF
--- a/nodeadm/test/e2e/cases/kubelet-config-dir/config.kubelet-config-json.yaml
+++ b/nodeadm/test/e2e/cases/kubelet-config-dir/config.kubelet-config-json.yaml
@@ -9,8 +9,6 @@ spec:
     cidr: 10.100.0.0/16
   kubelet:
     config: {
-      "kind": "KubeletConfiguration",
-      "apiVersion": "kubelet.config.k8s.io/v1beta1",
       "logging": {
         "verbosity": 5
       },

--- a/nodeadm/test/e2e/cases/kubelet-config-dir/config.kubelet-config-yaml.yaml
+++ b/nodeadm/test/e2e/cases/kubelet-config-dir/config.kubelet-config-yaml.yaml
@@ -9,8 +9,6 @@ spec:
     cidr: 10.100.0.0/16
   kubelet:
     config:
-      kind: KubeletConfiguration
-      apiVersion: kubelet.config.k8s.io/v1beta1
       logging:
         verbosity: 5
       clusterDNS:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**


When using a `KubeletConfiguration` that lacks the metadata info like `kind` and `apiVersion`, this can cause kubelet's drop-in config merging to fail on a minimal config like:

```json
{
  "maxPods": 2
}
```


```
E0202 20:46:59.510494   23792 run.go:74] "command failed" err=<
        failed to merge kubelet configs: failed to walk through kubelet dropin directory "drop-in-test/": failed to load kubelet dropin file, path: drop-in-test/test.conf, error: Object 'Kind' is missing in '{
            "maxPods": 2
        }
        '
 >
```

update the drop-in config path to merge user's data on top of default `KubeletConfiguration` metadata.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

update e2e tests to reflect the absence of `kind` and `apiVersion`

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
