### PR TITLE
fix arm64 ami build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,15 @@ AMI_VARIANT ?= amazon-eks
 AMI_VERSION ?= v$(shell date '+%Y%m%d')
 os_distro ?= al2
 arch ?= x86_64
-instance_type ?= m5.large
 
 ifeq ($(os_distro), al2023)
 	AMI_VARIANT := $(AMI_VARIANT)-al2023
 endif
 ifeq ($(arch), arm64)
-	instance_type = m6g.large
+	instance_type ?= m6g.large
 	AMI_VARIANT := $(AMI_VARIANT)-arm64
+else
+	instance_type ?= m5.large
 endif
 ifeq ($(enable_fips), true)
 	AMI_VARIANT := $(AMI_VARIANT)-fips

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifeq ($(os_distro), al2023)
 	AMI_VARIANT := $(AMI_VARIANT)-al2023
 endif
 ifeq ($(arch), arm64)
-	instance_type ?= m6g.large
+	instance_type = m6g.large
 	AMI_VARIANT := $(AMI_VARIANT)-arm64
 endif
 ifeq ($(enable_fips), true)

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -21,7 +21,7 @@
     "remote_folder": "/tmp",
     "runc_version": "*",
     "security_group_id": "",
-    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-x86_64",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1*",
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
     "ssh_interface": "",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
run into the following issue when testing arm64 ami build
```
> make 1.28 os_distro=al2023 arch=arm64 
---
The architecture 'x86_64' of the specified instance type does not match the architecture 'arm64' of the specified AMI. Specify an instance type and an AMI that have matching architectures, and try again. You can use 'describe-instance-types' or 'describe-images' to discover the architecture of the instance type or AMI.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
build arm64 ami succeed `ami-000353e26e1f56762`

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
