### PR TITLE
fix(log-collector): add `ok` to `get_modinfo` and `get_ipamd_info` func

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -483,12 +483,16 @@ get_ipamd_info() {
     echo "Ignoring IPAM introspection stats as mentioned" | tee -a "${COLLECT_DIR}"/ipamd/ipam_introspection_ignore.txt
   fi
 
+  ok
+
   if [[ "${ignore_metrics}" == "false" ]]; then
     try "collect L-IPAMD prometheus metrics"
     curl --max-time 3 --silent http://localhost:61678/metrics > "${COLLECT_DIR}"/ipamd/metrics.json 2>&1
   else
     echo "Ignoring Prometheus Metrics collection as mentioned" | tee -a "${COLLECT_DIR}"/ipamd/ipam_metrics_ignore.txt
   fi
+
+  ok
 
   try "collect L-IPAMD checkpoint"
   cp /var/run/aws-node/ipam.json "${COLLECT_DIR}"/ipamd/ipam.json

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -399,6 +399,8 @@ get_kernel_info() {
 get_modinfo() {
   try "collect modinfo"
   modinfo lustre > "${COLLECT_DIR}/modinfo/lustre"
+
+  ok
 }
 
 get_docker_logs() {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Fixed problem of no line break after `Trying to collect modinfo...` etc

```
[ec2-user@ip-xxx ~]$ sudo bash eks-log-collector.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    56  100    56    0     0  39631      0 --:--:-- --:--:-- --:--:-- 56000

	This is version 0.7.6. New versions can be found at https://github.com/awslabs/amazon-eks-ami/blob/master/log-collector-script/

Trying to collect common operating system logs... 
Trying to collect kernel logs... 
Trying to collect modinfo... Trying to collect mount points and volume information... 
Trying to collect SELinux status... 

...

Trying to collect L-IPAMD introspection information... Trying to collect L-IPAMD prometheus metrics... Trying to collect L-IPAMD checkpoint... 

...
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
