### PR TITLE
Specify region for local zones in sandbox image ecr auth

### DIFF
--- a/files/pull-sandbox-image.sh
+++ b/files/pull-sandbox-image.sh
@@ -8,6 +8,10 @@ if [[ "$(sudo ctr --namespace k8s.io image ls | grep $sandbox_image)" != "" ]]; 
   exit 0
 fi
 
+# use the region that the sandbox image comes from for the ecr authentication,
+# also mitigating the localzone isse: https://github.com/aws/aws-cli/issues/7043
+region=$(echo "${sandbox_image}" | cut -f4 -d ".")
+
 MAX_RETRIES=3
 
 function retry() {
@@ -25,7 +29,7 @@ function retry() {
   done
 }
 
-ecr_password=$(retry aws ecr get-login-password)
+ecr_password=$(retry aws ecr get-login-password --region $region)
 if [[ -z ${ecr_password} ]]; then
   echo >&2 "Unable to retrieve the ECR password."
   exit 1


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Fix aws cli behavior pertaining to issue https://github.com/aws/aws-cli/issues/7043 for sandbox image pulling script (https://github.com/awslabs/amazon-eks-ami/pull/1605)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
