### PR TITLE
Allow `containerd` config imports

### DIFF
--- a/doc/usage/al2.md
+++ b/doc/usage/al2.md
@@ -132,6 +132,28 @@ $ curl -sSL "http://localhost:8001/api/v1/nodes/ip-192-168-92-220.us-east-2.comp
 
 ---
 
+## Customizing Containerd Config
+
+The EKS defaults for `containerd` will be written to `/etc/containerd/config.toml`.
+Additional configuration files placed in the `/etc/containerd/config.d/` directory will be imported and override defaults as described in the [`containerd` documentation](https://github.com/containerd/containerd/blob/release/1.7/docs/man/containerd-config.toml.5.md).
+
+> **NOTE**: If you create an additional configuration file after `containerd`
+> has already started (i.e. `bootstrap.sh` has already executed), you'll need to
+> restart `containerd` to pick up the latest configuration.
+
+> **CAUTION**: Making direct edits to the EKS default `containerd` configuration file is not recommended.
+
+**View active containerd config**
+
+To see the final configuration that is produced and consumed by containerd, you
+can use the containerd cli:
+```
+$ containerd config dump
+...
+```
+
+---
+
 ## Ephemeral Storage
 
 Some instance types launch with ephemeral NVMe instance storage (i3, i4i, c5d, c6id, etc). There are two main ways of utilizing this storage within Kubernetes: a single RAID-0 array for use by kubelet and containerd or mounting the individual disks for pod usage.

--- a/templates/al2/provisioners/install-worker.sh
+++ b/templates/al2/provisioners/install-worker.sh
@@ -151,6 +151,7 @@ sudo yum versionlock containerd-*
 # install cri-tools for crictl, needed to interact with containerd's CRI server
 sudo yum install -y cri-tools
 
+sudo mkdir -p /etc/containerd/config.d
 sudo mkdir -p /etc/eks/containerd
 if [ -f "/etc/eks/containerd/containerd-config.toml" ]; then
   ## this means we are building a gpu ami and have already placed a containerd configuration file in /etc/eks

--- a/templates/al2/runtime/bootstrap.sh
+++ b/templates/al2/runtime/bootstrap.sh
@@ -555,6 +555,7 @@ if [[ "$CONTAINER_RUNTIME" = "containerd" ]]; then
   fi
 
   sudo mkdir -p /etc/containerd
+  sudo mkdir -p /etc/containerd/config.d
   sudo mkdir -p /etc/cni/net.d
 
   if [[ -n "${CONTAINERD_CONFIG_FILE}" ]]; then

--- a/templates/al2/runtime/containerd-config.toml
+++ b/templates/al2/runtime/containerd-config.toml
@@ -1,6 +1,7 @@
 version = 2
 root = "/var/lib/containerd"
 state = "/run/containerd"
+imports = ["/etc/containerd/config.d/*.toml"]
 
 [grpc]
 address = "/run/containerd/containerd.sock"


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/amazon-eks-ami/issues/1628

**Description of changes:**

adding an import path for containerd to read for merging config tomls: https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md#complete-configuration

avoid the need for users to directly edit the containerd config toml.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
