### PR TITLE
Add nodeadm-check-vendor PR check

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ switch_case_indent = true
 space_redirects    = true
 keep_padding       = false
 function_next_line = false
+
+[nodeadm/vendor/**]
+ignore = true

--- a/.github/workflows/ci-auto.yaml
+++ b/.github/workflows/ci-auto.yaml
@@ -28,6 +28,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: hack/nodeadm-check-generate.sh
+  nodeadm-check-vendor:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: hack/nodeadm-check-vendor.sh
   nodeadm-test:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -46,22 +46,14 @@ k8s=1.28
 build: ## Build EKS Optimized AMI, default using AL2, use os_distro=al2023 for AL2023 AMI
 	$(MAKE) k8s $(shell hack/latest-binaries.sh $(k8s))
 
-# ensure that these flags are equivalent to the rules in the .editorconfig
-SHFMT_FLAGS := --list \
---language-dialect auto \
---indent 2 \
---binary-next-line \
---case-indent \
---space-redirects
-
 .PHONY: fmt
 fmt: ## Format the source files
-	hack/shfmt $(SHFMT_FLAGS) --write $(MAKEFILE_DIR)
+	hack/shfmt --write
 
 .PHONY: lint
 lint: lint-docs ## Check the source files for syntax and format issues
-	hack/shfmt $(SHFMT_FLAGS) --diff $(MAKEFILE_DIR)
-	hack/shellcheck --format gcc --severity error $(shell find $(MAKEFILE_DIR) -type f -name '*.sh')
+	hack/shfmt --diff
+	hack/shellcheck --format gcc --severity error $(shell find $(MAKEFILE_DIR) -type f -name '*.sh' -not -path '*/nodeadm/vendor/*')
 	hack/lint-space-errors.sh
 
 .PHONY: test

--- a/hack/lint-space-errors.sh
+++ b/hack/lint-space-errors.sh
@@ -5,4 +5,4 @@ cd $(dirname $0)/..
 # `git apply|diff` can check for space errors, with the core implementation being `git diff-tree`
 # this tool compares two trees, generally used to find errors in proposed changes
 # we want to check the entire existing tree, so we compare HEAD against an empty tree
-git diff-tree --check $(git hash-object -t tree /dev/null) HEAD
+git diff-tree --check $(git hash-object -t tree /dev/null) HEAD ':!nodeadm/vendor/'

--- a/hack/nodeadm-check-vendor.sh
+++ b/hack/nodeadm-check-vendor.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+cd $(dirname $0)/../nodeadm
+
+TEMP_DIR="$(mktemp -d)"
+go mod vendor -o "${TEMP_DIR}"
+if ! DIFF="$(diff -Naupr vendor ${TEMP_DIR})"; then
+  echo "ERROR: the vendor directory is not up to date! You need to run 'go mod vendor' and commit the changes." >&2
+  exit 1
+fi

--- a/hack/shfmt
+++ b/hack/shfmt
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
-# shfmt wrapper
 
 set -o nounset
 
+# ensure these flags are equivalent to the rules in the .editorconfig
+FLAGS="--list --language-dialect auto --indent 2 --binary-next-line --case-indent --space-redirects"
+
+cd $(dirname $0)/..
 WORKDIR=$(realpath .)
+
 SHFMT_COMMAND=$(which shmft 2> /dev/null)
-if [ -z "$SHFMT_COMMAND" ]; then
-  SHFMT_COMMAND="docker run --rm -v $WORKDIR:$WORKDIR -w $WORKDIR mvdan/shfmt"
+if [ -z "${SHFMT_COMMAND}" ]; then
+  SHFMT_COMMAND="docker run --rm -v ${WORKDIR}:${WORKDIR} -w ${WORKDIR} mvdan/shfmt"
 fi
-$SHFMT_COMMAND $@
+
+FILES=$(${SHFMT_COMMAND} --find --language-dialect auto "${WORKDIR}" | grep -v "nodeadm/vendor/")
+
+${SHFMT_COMMAND} ${FLAGS} $@ ${FILES}


### PR DESCRIPTION
**Description of changes:**

Adds a PR check that ensures the `vendor` directory is kept up to date.

Also fixes the `lint` check by ignoring the `vendor` directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
