### PR TITLE
Support building for Gov.cloud only accounts

### DIFF
--- a/hack/latest-binaries.sh
+++ b/hack/latest-binaries.sh
@@ -13,7 +13,7 @@ MINOR_VERSION="${1}"
 
 # retrieve the available "VERSION/BUILD_DATE" prefixes (e.g. "1.28.1/2023-09-14")
 # from the binary object keys, sorted in descending semver order, and pick the first one
-LATEST_BINARIES=$(aws s3api list-objects-v2 --bucket amazon-eks --prefix "${MINOR_VERSION}" --query 'Contents[*].[Key]' --output text | cut -d'/' -f-2 | sort -Vru | head -n1)
+LATEST_BINARIES=$(aws s3api list-objects-v2 --bucket amazon-eks --no-sign-request --region us-west-2 --prefix "${MINOR_VERSION}" --query 'Contents[*].[Key]' --output text | cut -d'/' -f-2 | sort -Vru | head -n1)
 
 if [ "${LATEST_BINARIES}" == "None" ]; then
   echo >&2 "No binaries available for minor version: ${MINOR_VERSION}"


### PR DESCRIPTION
Fixes #1536, #1482 
obsoletes #1537

**Description of changes:**

if a user only has access to an AWS account in GovCloud then obtaining the binary versions from S3 will fail.

As this bucket is public we do not need any authentication so add --no-sign-request  and hardcode the region (which would not be the default region for any govCloud).

chose `us-west-2` as the region to use as this appears to be the
canonical location.   As it is just metdata using a region on the other
side of the world should not matter too much when the overhead of the
packer build is taken into account


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

ran ` make k8s=1.25 enable_fips=true source_ami_owners=045324592363 aws_region=us-gov-east-1` and verified make completed without error (and the previous error about kubernetes versions being unavailable was no longer present).

in order to repo the original change you need `aws`  cli setup with **only** an account in gov.cloud.


prior to this change

```
jnord@pc-jnord:/mnt/d/source/github/awslabs/amazon-eks-ami$ make k8s=1.25 enable_fips=true source_ami_owners=045324592363 aws_region=us-gov-east-1

An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied
make k8s
make[1]: Entering directory '/mnt/d/source/github/awslabs/amazon-eks-ami'
packer validate -var-file /mnt/d/source/github/awslabs/amazon-eks-ami/eks-worker-al2-variables.json  -var aws_region='us-gov-east-1' -var source_ami_owners='045324592363' -var ami_component_description='(k8s: {{ user `kubernetes_version` }}, containerd: {{ user `containerd_version` }})' -var arch='x86_64' -var enable_fips='true' -var instance_type='m5.large' -var ami_name='amazon-eks-fips-node-.-v20240208' -var docker_version='none' /mnt/d/source/github/awslabs/amazon-eks-ami/eks-worker-al2.json
Error:

2 errors occurred:
        * required variable not set: kubernetes_version
        * required variable not set: kubernetes_build_date




make[1]: *** [Makefile:113: validate] Error 1
make[1]: Leaving directory '/mnt/d/source/github/awslabs/amazon-eks-ami'
make: *** [Makefile:64: build] Error 2
```

after this change

```
jnord@pc-jnord:/mnt/d/source/github/awslabs/amazon-eks-ami$ make k8s=1.25 enable_fips=true source_ami_owners=045324592363 aws_region=us-gov-east-1
make k8s kubernetes_version=1.25.16 kubernetes_build_date=2024-01-04
make[1]: Entering directory '/mnt/d/source/github/awslabs/amazon-eks-ami'
packer validate -var-file /mnt/d/source/github/awslabs/amazon-eks-ami/eks-worker-al2-variables.json  -var aws_region='us-gov-east-1' -var arch='x86_64' -var ami_component_description='(k8s: {{ user `kubernetes_version` }}, containerd: {{ user `containerd_version` }})' -var docker_version='none' -var source_ami_owners='045324592363' -var instance_type='m5.large' -var kubernetes_version='1.25.16' -var ami_name='amazon-eks-fips-node-1.25-v20240208' -var kubernetes_build_date='2024-01-04' -var enable_fips='true' /mnt/d/source/github/awslabs/amazon-eks-ami/eks-worker-al2.json
The configuration is valid.
Building AMI for version 1.25.16 on x86_64
packer build -timestamp-ui -color=false -var-file /mnt/d/source/github/awslabs/amazon-eks-ami/eks-worker-al2-variables.json  -var aws_region='us-gov-east-1' -var arch='x86_64' -var ami_component_description='(k8s: {{ user `kubernetes_version` }}, containerd: {{ user `containerd_version` }})' -var docker_version='none' -var source_ami_owners='045324592363' -var instance_type='m5.large' -var kubernetes_version='1.25.16' -var ami_name='amazon-eks-fips-node-1.25-v20240208' -var kubernetes_build_date='2024-01-04' -var enable_fips='true' /mnt/d/source/github/awslabs/amazon-eks-ami/eks-worker-al2.json
2024-02-08T10:43:40Z: ==> amazon-ebs: Prevalidating any provided VPC information
....
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs: AMIs were created:
us-gov-east-1: ami-0a74ad3614fbfea23

--> amazon-ebs: AMIs were created:
us-gov-east-1: ami-0a74ad3614fbfea23

--> amazon-ebs: AMIs were created:
us-gov-east-1: ami-0a74ad3614fbfea23
make[1]: Leaving directory '/mnt/d/source/github/awslabs/amazon-eks-ami'
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
