### PR TITLE
Fix CHANGELOG space errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 # AMI Release v20240202
 <!-- Release notes generated using configuration in .github/release.yaml at 41dfa2217582a624a3cd582e5f0a93c25f951cad -->
 
-> [!NOTE]  
+> [!NOTE]
 > This release addresses an issue with Kubernetes 1.29 that allowed the sandbox container image used by `containerd` to be garbage-collected by `kubelet`. More information is available in #1597.
 
 ## What's Changed


### PR DESCRIPTION
**Description of changes:**

When the CHANGELOG entry is inserted after modifications to the release notes have been made in the GitHub web editor, trailing spaces seem to get added. We need to remove those in the CHANGELOG workflow, but this cleans up things that have already been added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
