### PR TITLE
harden pull-sandbox-image script

### DIFF
--- a/files/pull-sandbox-image.sh
+++ b/files/pull-sandbox-image.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 source <(grep "sandbox_image" /etc/containerd/config.toml | tr -d ' ')
 
-### Short-circuit fetching sandbox image if its already present
-if [[ "$(sudo ctr --namespace k8s.io image ls | grep $sandbox_image)" != "" ]]; then
+### skip if we don't have a sandbox_image set in config.toml
+if [[ -z ${sandbox_image:-} ]]; then
+  echo >&2 "Skipping ... missing sandbox_image from /etc/containerd/config.toml"
   exit 0
 fi
 
-# use the region that the sandbox image comes from for the ecr authentication,
-# also mitigating the localzone isse: https://github.com/aws/aws-cli/issues/7043
-region=$(echo "${sandbox_image}" | cut -f4 -d ".")
+### Short-circuit fetching sandbox image if its already present
+if [[ -n $(sudo ctr --namespace k8s.io image ls | grep "${sandbox_image}") ]]; then
+  echo >&2 "Skipping ... sandbox_image '${sandbox_image}' is already present"
+  exit 0
+fi
+
+# if the sandbox image is provided by the bootstrap script, then the region is
+# guaranteed to come from this data source.
+# see: https://github.com/awslabs/amazon-eks-ami/blob/baef6f0860f60dbec366de30853e47418e3fb430/files/bootstrap.sh#L320-L338
+# if the image is customer provided, then this is just a sane default for the
+# region when attempting to get ecr credentials.
+region=$(imds 'latest/dynamic/instance-identity/document' | jq .region -r)
 
 MAX_RETRIES=3
 
@@ -29,9 +38,9 @@ function retry() {
   done
 }
 
-ecr_password=$(retry aws ecr get-login-password --region $region)
+# for public, non-ecr repositories even if this fails to get ECR credentials the image will pull
+ecr_password=$(retry aws ecr get-login-password --region "${region}")
 if [[ -z ${ecr_password} ]]; then
-  echo >&2 "Unable to retrieve the ECR password."
-  exit 1
+  echo >&2 "Unable to retrieve the ECR password. Image pull may not be properly authenticated."
 fi
 retry sudo crictl pull --creds "AWS:${ecr_password}" "${sandbox_image}"

--- a/files/pull-sandbox-image.sh
+++ b/files/pull-sandbox-image.sh
@@ -14,12 +14,9 @@ if [[ -n $(sudo ctr --namespace k8s.io image ls | grep "${sandbox_image}") ]]; t
   exit 0
 fi
 
-# if the sandbox image is provided by the bootstrap script, then the region is
-# guaranteed to come from this data source.
-# see: https://github.com/awslabs/amazon-eks-ami/blob/baef6f0860f60dbec366de30853e47418e3fb430/files/bootstrap.sh#L320-L338
-# if the image is customer provided, then this is just a sane default for the
-# region when attempting to get ecr credentials.
-region=$(imds 'latest/dynamic/instance-identity/document' | jq .region -r)
+# use the region that the sandbox image comes from for the ecr authentication,
+# also mitigating the localzone isse: https://github.com/aws/aws-cli/issues/7043
+region=$(echo "${sandbox_image}" | cut -f4 -d ".")
 
 MAX_RETRIES=3
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

* remove the `pipefail` so that authentication errors don't fast fail the workflow since it is ok if the ecr call fails.
* add additional bash shell hardening.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

an empty credential pull for public repositories:
```bash
$ crictl pull --creds "AWS:" registry.k8s.io/pause:3.9
Image is up to date for sha256:e6f1816883972d4be47bd48879a08919b96afcd344132622e4d444987919323c
```

in the case where a region is malformed or incorrect, this will still succeed for a public image:
```bash
$ grep sandbox_image /etc/containerd/config.toml
sandbox_image = "registry.k8s.io/pause:3.9"

$ /etc/eks/containerd/pull-sandbox-image.sh
[root@ip-192-168-5-111 bin]# /etc/eks/containerd/pull-sandbox-image.sh

Provided region_name '9' doesn't match a supported format.
Attempt 1 of 3

Provided region_name '9' doesn't match a supported format.
Attempt 2 of 3

Provided region_name '9' doesn't match a supported format.
Attempt 3 of 3

Provided region_name '9' doesn't match a supported format.
Unable to retrieve the ECR password. Image pull may not be properly authenticated.

Image is up to date for sha256:e6f1816883972d4be47bd48879a08919b96afcd344132622e4d444987919323c

# verify "caching" works
$ /etc/eks/containerd/pull-sandbox-image.sh
Skipping ... sandbox_image 'registry.k8s.io/pause:3.9' is already present
```

existing ecr uris:
```bash
$ grep sandbox_image /etc/containerd/config.toml
sandbox_image = "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5"

$ /etc/eks/containerd/pull-sandbox-image.sh
Image is up to date for sha256:6996f8da07bd405c6f82a549ef041deda57d1d658ec20a78584f9f436c9a3bb7

$ /etc/eks/containerd/pull-sandbox-image.sh
Skipping ... sandbox_image '602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5' is already present
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
