### PR TITLE
Use `--cloud-provider=aws` on 1.25-

### DIFF
--- a/nodeadm/doc/api.md
+++ b/nodeadm/doc/api.md
@@ -22,6 +22,15 @@ _Appears in:_
 | `enableOutpost` _boolean_ |  |
 | `id` _string_ |  |
 
+#### ContainerdOptions
+
+_Appears in:_
+- [NodeConfigSpec](#nodeconfigspec)
+
+| Field | Description |
+| --- | --- |
+| `config` _string_ | Config is an inline containerd config toml document that can be provided by the user to override default generated configurations https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md |
+
 #### KubeletOptions
 
 _Appears in:_
@@ -54,3 +63,4 @@ _Appears in:_
 | --- | --- |
 | `cluster` _[ClusterDetails](#clusterdetails)_ |  |
 | `kubelet` _[KubeletOptions](#kubeletoptions)_ |  |
+| `containerd` _[ContainerdOptions](#containerdoptions)_ |  |

--- a/nodeadm/internal/containerd/config.go
+++ b/nodeadm/internal/containerd/config.go
@@ -38,7 +38,7 @@ func writeContainerdConfig(cfg *api.NodeConfig) error {
 		return err
 	}
 	zap.L().Info("Writing containerd config to file..", zap.String("path", containerdConfigFile))
-	if err:= util.WriteFileWithDir(containerdConfigFile, containerdConfig, containerdConfigPerm); err != nil {
+	if err := util.WriteFileWithDir(containerdConfigFile, containerdConfig, containerdConfigPerm); err != nil {
 		return err
 	}
 	if len(cfg.Spec.Containerd.Config) > 0 {

--- a/nodeadm/internal/kubelet/config_test.go
+++ b/nodeadm/internal/kubelet/config_test.go
@@ -89,8 +89,8 @@ func TestProviderID(t *testing.T) {
 		kubeletVersion        string
 		expectedCloudProvider string
 	}{
-		{kubeletVersion: "v1.23.0", expectedCloudProvider: "external"},
-		{kubeletVersion: "v1.25.0", expectedCloudProvider: "external"},
+		{kubeletVersion: "v1.23.0", expectedCloudProvider: "aws"},
+		{kubeletVersion: "v1.25.0", expectedCloudProvider: "aws"},
 		{kubeletVersion: "v1.26.0", expectedCloudProvider: "external"},
 		{kubeletVersion: "v1.27.0", expectedCloudProvider: "external"},
 	}
@@ -108,10 +108,11 @@ func TestProviderID(t *testing.T) {
 	for _, test := range tests {
 		kubeletAruments := make(map[string]string)
 		kubetConfig := defaultKubeletSubConfig()
-		kubetConfig.withCloudProvider(&nodeConfig, kubeletAruments)
+		kubetConfig.withCloudProvider(test.kubeletVersion, &nodeConfig, kubeletAruments)
 		assert.Equal(t, test.expectedCloudProvider, kubeletAruments["cloud-provider"])
 		if kubeletAruments["cloud-provider"] == "external" {
 			assert.Equal(t, *kubetConfig.ProviderID, providerId)
+			// TODO assert that the --hostname-override == PrivateDnsName
 		}
 	}
 }


### PR DESCRIPTION
**Description of changes:**

Switches 1.25 and below to `--cloud-provider=aws`. We'll need to continue using `kubelet`'s in-tree cloud provider for these versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
