### PR TITLE
Sync `main` branch to CodeCommit

### DIFF
--- a/.github/workflows/sync-to-codecommit.yaml
+++ b/.github/workflows/sync-to-codecommit.yaml
@@ -27,5 +27,5 @@ jobs:
       - run: git remote add codecommit ${{ secrets.AWS_CODECOMMIT_REPO_URL }}
       - run: git checkout master
       - run: git push codecommit master
-      - run: git checkout al2023
-      - run: git push codecommit al2023
+      - run: git checkout main
+      - run: git push codecommit main


### PR DESCRIPTION
**Description of changes:**

Replaces `al2023` in the sync config with `main`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.