### PR TITLE
Fix build issue when using hardened AMIs as base images

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'master'
+      - 'main'
 jobs:
   mkdocs:
     permissions:

--- a/.github/workflows/sync-to-codecommit.yaml
+++ b/.github/workflows/sync-to-codecommit.yaml
@@ -27,5 +27,5 @@ jobs:
       - run: git remote add codecommit ${{ secrets.AWS_CODECOMMIT_REPO_URL }}
       - run: git checkout master
       - run: git push codecommit master
-      - run: git checkout al2023
-      - run: git push codecommit al2023
+      - run: git checkout main
+      - run: git push codecommit main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,423 @@
 
 <!--new-changelog-entry-placeholder-->
 
+# AMI Release v20240209
+<!-- Release notes generated using configuration in .github/release.yaml at baef6f0860f60dbec366de30853e47418e3fb430 -->
+
+## What's Changed
+* Specify region for local zones in sandbox image ecr auth by @ndbaker1 in https://github.com/awslabs/amazon-eks-ami/pull/1626
+* Fix CHANGELOG space errors by @cartermckinnon in https://github.com/awslabs/amazon-eks-ami/pull/1647
+
+
+**Full Changelog**: https://github.com/awslabs/amazon-eks-ami/compare/v20240202...v20240209
+
+---
+
+<h2>AMI Details</h2>
+
+
+<details>
+<summary><b>Kubernetes 1.29</b></summary>
+  <table>
+    <tr>
+      <th>AMI names</th>
+      <th>Release version</th>
+      <th>Included artifacts</th>
+    <tr>
+    <tr>
+      <td>amazon-eks-node-1.29-v20240209</td>
+      <td rowspan="3">1.29.0-20240209</td>
+      <td rowspan="3">s3://amazon-eks/1.29.0/2024-01-04/</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-gpu-node-1.29-v20240209</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-arm64-node-1.29-v20240209</td>
+    </tr>
+  </table>
+  <table>
+    <tr>
+      <th>Package</th>
+      <th>Version</th>
+    </tr>
+    <tr>
+      <td>amazon-ssm-agent</td>
+      <td>3.2.1705.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>containerd</td>
+      <td>1.7.11-1.amzn2.0.1</td>
+    </tr>
+    <tr>
+      <td>cuda</td>
+      <td>12.2.2-1</td>
+    </tr>
+    <tr>
+      <td>efa</td>
+      <td>2.6.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>kernel</td>
+      <td>5.10.209-198.812.amzn2</td>
+    </tr>
+    <tr>
+      <td>nvidia-driver-latest-dkms</td>
+      <td>535.129.03-1.el7</td>
+    </tr>
+    <tr>
+      <td>runc</td>
+      <td>1.1.11-1.amzn2</td>
+    </tr>
+  </table>
+</details>
+
+<details>
+<summary><b>Kubernetes 1.28</b></summary>
+  <table>
+    <tr>
+      <th>AMI names</th>
+      <th>Release version</th>
+      <th>Included artifacts</th>
+    <tr>
+    <tr>
+      <td>amazon-eks-node-1.28-v20240209</td>
+      <td rowspan="3">1.28.5-20240209</td>
+      <td rowspan="3">s3://amazon-eks/1.28.5/2024-01-04/</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-gpu-node-1.28-v20240209</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-arm64-node-1.28-v20240209</td>
+    </tr>
+  </table>
+  <table>
+    <tr>
+      <th>Package</th>
+      <th>Version</th>
+    </tr>
+    <tr>
+      <td>amazon-ssm-agent</td>
+      <td>3.2.1705.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>containerd</td>
+      <td>1.7.11-1.amzn2.0.1</td>
+    </tr>
+    <tr>
+      <td>cuda</td>
+      <td>12.2.2-1</td>
+    </tr>
+    <tr>
+      <td>efa</td>
+      <td>2.6.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>kernel</td>
+      <td>5.10.209-198.812.amzn2</td>
+    </tr>
+    <tr>
+      <td>nvidia-driver-latest-dkms</td>
+      <td>535.129.03-1.el7</td>
+    </tr>
+    <tr>
+      <td>runc</td>
+      <td>1.1.11-1.amzn2</td>
+    </tr>
+  </table>
+</details>
+
+<details>
+<summary><b>Kubernetes 1.27</b></summary>
+  <table>
+    <tr>
+      <th>AMI names</th>
+      <th>Release version</th>
+      <th>Included artifacts</th>
+    <tr>
+    <tr>
+      <td>amazon-eks-node-1.27-v20240209</td>
+      <td rowspan="3">1.27.9-20240209</td>
+      <td rowspan="3">s3://amazon-eks/1.27.9/2024-01-04/</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-gpu-node-1.27-v20240209</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-arm64-node-1.27-v20240209</td>
+    </tr>
+  </table>
+  <table>
+    <tr>
+      <th>Package</th>
+      <th>Version</th>
+    </tr>
+    <tr>
+      <td>amazon-ssm-agent</td>
+      <td>3.2.1705.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>containerd</td>
+      <td>1.7.11-1.amzn2.0.1</td>
+    </tr>
+    <tr>
+      <td>cuda</td>
+      <td>12.2.2-1</td>
+    </tr>
+    <tr>
+      <td>efa</td>
+      <td>2.6.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>kernel</td>
+      <td>5.10.209-198.812.amzn2</td>
+    </tr>
+    <tr>
+      <td>nvidia-driver-latest-dkms</td>
+      <td>535.129.03-1.el7</td>
+    </tr>
+    <tr>
+      <td>runc</td>
+      <td>1.1.11-1.amzn2</td>
+    </tr>
+  </table>
+</details>
+
+<details>
+<summary><b>Kubernetes 1.26</b></summary>
+  <table>
+    <tr>
+      <th>AMI names</th>
+      <th>Release version</th>
+      <th>Included artifacts</th>
+    <tr>
+    <tr>
+      <td>amazon-eks-node-1.26-v20240209</td>
+      <td rowspan="3">1.26.12-20240209</td>
+      <td rowspan="3">s3://amazon-eks/1.26.12/2024-01-04/</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-gpu-node-1.26-v20240209</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-arm64-node-1.26-v20240209</td>
+    </tr>
+  </table>
+  <table>
+    <tr>
+      <th>Package</th>
+      <th>Version</th>
+    </tr>
+    <tr>
+      <td>amazon-ssm-agent</td>
+      <td>3.2.1705.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>containerd</td>
+      <td>1.7.11-1.amzn2.0.1</td>
+    </tr>
+    <tr>
+      <td>cuda</td>
+      <td>12.2.2-1</td>
+    </tr>
+    <tr>
+      <td>efa</td>
+      <td>2.6.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>kernel</td>
+      <td>5.10.209-198.812.amzn2</td>
+    </tr>
+    <tr>
+      <td>nvidia-driver-latest-dkms</td>
+      <td>535.129.03-1.el7</td>
+    </tr>
+    <tr>
+      <td>runc</td>
+      <td>1.1.11-1.amzn2</td>
+    </tr>
+  </table>
+</details>
+
+<details>
+<summary><b>Kubernetes 1.25</b></summary>
+  <table>
+    <tr>
+      <th>AMI names</th>
+      <th>Release version</th>
+      <th>Included artifacts</th>
+    <tr>
+    <tr>
+      <td>amazon-eks-node-1.25-v20240209</td>
+      <td rowspan="3">1.25.16-20240209</td>
+      <td rowspan="3">s3://amazon-eks/1.25.16/2024-01-04/</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-gpu-node-1.25-v20240209</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-arm64-node-1.25-v20240209</td>
+    </tr>
+  </table>
+  <table>
+    <tr>
+      <th>Package</th>
+      <th>Version</th>
+    </tr>
+    <tr>
+      <td>amazon-ssm-agent</td>
+      <td>3.2.1705.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>containerd</td>
+      <td>1.7.11-1.amzn2.0.1</td>
+    </tr>
+    <tr>
+      <td>cuda</td>
+      <td>12.2.2-1</td>
+    </tr>
+    <tr>
+      <td>efa</td>
+      <td>2.6.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>kernel</td>
+      <td>5.10.209-198.812.amzn2</td>
+    </tr>
+    <tr>
+      <td>nvidia-driver-latest-dkms</td>
+      <td>535.129.03-1.el7</td>
+    </tr>
+    <tr>
+      <td>runc</td>
+      <td>1.1.11-1.amzn2</td>
+    </tr>
+  </table>
+</details>
+
+<details>
+<summary><b>Kubernetes 1.24</b></summary>
+  <table>
+    <tr>
+      <th>AMI names</th>
+      <th>Release version</th>
+      <th>Included artifacts</th>
+    <tr>
+    <tr>
+      <td>amazon-eks-node-1.24-v20240209</td>
+      <td rowspan="3">1.24.17-20240209</td>
+      <td rowspan="3">s3://amazon-eks/1.24.17/2024-01-04/</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-gpu-node-1.24-v20240209</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-arm64-node-1.24-v20240209</td>
+    </tr>
+  </table>
+  <table>
+    <tr>
+      <th>Package</th>
+      <th>Version</th>
+    </tr>
+    <tr>
+      <td>amazon-ssm-agent</td>
+      <td>3.2.1705.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>containerd</td>
+      <td>1.7.11-1.amzn2.0.1</td>
+    </tr>
+    <tr>
+      <td>cuda</td>
+      <td>11.4.0-1</td>
+    </tr>
+    <tr>
+      <td>docker</td>
+      <td>20.10.25-1.amzn2.0.4</td>
+    </tr>
+    <tr>
+      <td>kernel</td>
+      <td>5.10.209-198.812.amzn2</td>
+    </tr>
+    <tr>
+      <td>nvidia-driver-latest-dkms</td>
+      <td>470.182.03-1.el7</td>
+    </tr>
+    <tr>
+      <td>runc</td>
+      <td>1.1.11-1.amzn2</td>
+    </tr>
+  </table>
+</details>
+
+<details>
+<summary><b>Kubernetes 1.23</b></summary>
+  <table>
+    <tr>
+      <th>AMI names</th>
+      <th>Release version</th>
+      <th>Included artifacts</th>
+    <tr>
+    <tr>
+      <td>amazon-eks-node-1.23-v20240209</td>
+      <td rowspan="3">1.23.17-20240209</td>
+      <td rowspan="3">s3://amazon-eks/1.23.17/2024-01-04/</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-gpu-node-1.23-v20240209</td>
+    </tr>
+    <tr>
+      <td>amazon-eks-arm64-node-1.23-v20240209</td>
+    </tr>
+  </table>
+  <table>
+    <tr>
+      <th>Package</th>
+      <th>Version</th>
+    </tr>
+    <tr>
+      <td>amazon-ssm-agent</td>
+      <td>3.2.1705.0-1.amzn2</td>
+    </tr>
+    <tr>
+      <td>containerd</td>
+      <td>1.7.11-1.amzn2.0.1</td>
+    </tr>
+    <tr>
+      <td>cuda</td>
+      <td>11.4.0-1</td>
+    </tr>
+    <tr>
+      <td>docker</td>
+      <td>20.10.25-1.amzn2.0.4</td>
+    </tr>
+    <tr>
+      <td>kernel</td>
+      <td>5.4.268-181.368.amzn2</td>
+    </tr>
+    <tr>
+      <td>nvidia-driver-latest-dkms</td>
+      <td>470.182.03-1.el7</td>
+    </tr>
+    <tr>
+      <td>runc</td>
+      <td>1.1.11-1.amzn2</td>
+    </tr>
+  </table>
+</details>
+
+
+> **Note**
+> A recent change in the Linux kernel caused the EFA and NVIDIA drivers to be incompatible. More information is available in #1494.
+> To prevent unexpected failures, the kernel in the GPU AMI will remain at the following versions until we have determined a solution:
+> - Kubernetes 1.24 and below: `5.4.254-170.358.amzn2`
+> - Kubernetes 1.25 and above: `5.10.192-183.736.amzn2`
+
+---
+
+
 # AMI Release v20240202
 <!-- Release notes generated using configuration in .github/release.yaml at 41dfa2217582a624a3cd582e5f0a93c25f951cad -->
 

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.28)
 
 .PHONY: 1.29
-1.29: ## Build EKS Optimized AL2 AMI - K8s 1.28
+1.29: ## Build EKS Optimized AL2 AMI - K8s 1.29
 	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.29)
 
 .PHONY: lint-docs

--- a/Makefile
+++ b/Makefile
@@ -141,10 +141,6 @@ k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 1.28: ## Build EKS Optimized AL2 AMI - K8s 1.28
 	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.28)
 
-.PHONY: 1.29
-1.29: ## Build EKS Optimized AL2 AMI - K8s 1.29
-	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.29)
-
 .PHONY: lint-docs
 lint-docs: ## Lint the docs
 	hack/lint-docs.sh

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ T_YELLOW := \e[0;33m
 T_RESET := \e[0m
 
 # default to the latest supported Kubernetes version
-k8s=1.28
+k8s=1.29
 
 .PHONY: build
 build: ## Build EKS Optimized AL2 AMI
@@ -140,6 +140,10 @@ k8s: validate ## Build default K8s version of EKS Optimized AL2 AMI
 .PHONY: 1.28
 1.28: ## Build EKS Optimized AL2 AMI - K8s 1.28
 	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.28)
+
+.PHONY: 1.29
+1.29: ## Build EKS Optimized AL2 AMI - K8s 1.28
+	$(MAKE) k8s $(shell hack/latest-binaries.sh 1.29)
 
 .PHONY: lint-docs
 lint-docs: ## Lint the docs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Amazon EKS AMI Build Specification
 
+## ⚠️ The default branch of this repository is changing!
+
+Development will continue on `main`. The default branch of this repository will be changed to `main` on **February 29, 2024**. The `master` branch will be deleted on **March 30, 2024**.
+
+This change coincides with a reorganization of the project sources. You may continue using the `master` branch as you update your downstream dependencies, but you'll need to explicitly check out the `master` branch after February 29, 2024.
+
+---
+
 This repository contains resources and configuration scripts for building a
 custom Amazon EKS AMI with [HashiCorp Packer](https://www.packer.io/). This is
 the same configuration that Amazon EKS uses to create the official Amazon

--- a/scripts/generate-version-info.sh
+++ b/scripts/generate-version-info.sh
@@ -16,14 +16,14 @@ OUTPUT_FILE="$1"
 sudo rpm --query --all --queryformat '\{"%{NAME}": "%{VERSION}-%{RELEASE}"\}\n' | jq --slurp --sort-keys 'add | {packages:(.)}' > "$OUTPUT_FILE"
 
 # binaries
-KUBELET_VERSION=$(kubelet --version | awk '{print $2}')
+KUBELET_VERSION=$(sudo kubelet --version | awk '{print $2}')
 if [ "$?" != 0 ]; then
   echo "unable to get kubelet version"
   exit 1
 fi
 echo $(jq ".binaries.kubelet = \"$KUBELET_VERSION\"" $OUTPUT_FILE) > $OUTPUT_FILE
 
-CLI_VERSION=$(aws --version | awk '{print $1}' | cut -d '/' -f 2)
+CLI_VERSION=$(sudo aws --version | awk '{print $1}' | cut -d '/' -f 2)
 if [ "$?" != 0 ]; then
   echo "unable to get aws cli version"
   exit 1


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/amazon-eks-ami/issues/1554

**Description of changes:**
Two minor yet important changes:

1. I changed default version to latest 1.29 in `Makefile`;
2. I corrected `generate-version-info.sh` script so that it does not fail when Packer uses hardened AMIs. Refer to  https://github.com/awslabs/amazon-eks-ami/issues/1554 for more info.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Successfully built v1.29 EKS AMI based on hardened (CIS) version of AL2 Golden AMI.
