### PR TITLE
Add nodeadm examples

### DIFF
--- a/doc/nodeadm/doc/examples.md
+++ b/doc/nodeadm/doc/examples.md
@@ -1,0 +1,1 @@
+../../../nodeadm/doc/examples.md

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -19,7 +19,7 @@ nav:
     - 'API':
       - 'Concepts': nodeadm/doc/api-concepts.md
       - 'Reference': nodeadm/doc/api.md
-
+    - 'Examples': nodeadm/doc/examples.md
 theme:
   name: material
   palette:

--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -1,0 +1,83 @@
+# Examples
+
+---
+
+## Merging multiple configuration objects
+
+When using the IMDS configuration source (`--config-source=imds://user-data`),
+`nodeadm` will merge any configuration objects it discovers before configuring your node.
+
+With the following user data:
+```
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+--BOUNDARY
+Content-Type: application/node.eks.aws
+
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+
+--BOUNDARY--
+Content-Type: application/node.eks.aws
+
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  kubelet:
+    config:
+      shutdownGracePeriod: 30s
+      featureGates:
+        DisableKubeletCloudCredentialProviders: true
+
+--BOUNDARY--
+```
+
+The configuration `nodeadm` will use is:
+```
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+  kubelet:
+    config:
+      shutdownGracePeriod: 30s
+      featureGates:
+        DisableKubeletCloudCredentialProviders: true
+```
+
+The configuration objects will be merged in the order they appear in the MIME multi-part document, meaning the value in the lattermost configuration object will take precedence.
+
+---
+
+## Configuring `containerd`
+
+Additional `containerd` configuration can be supplied in your `NodeConfig`. The values in your inline TOML document will overwrite any default value set by `nodeadm`.
+
+The following configuration object:
+```
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster: ...
+  containerd:
+    config: |
+      [plugins."io.containerd.grpc.v1.cri".containerd]
+      discard_unpacked_layers = false
+```
+
+Can be used to disable deletion of unpacked image layers in the `containerd` content store.


### PR DESCRIPTION
**Description of changes:**

Adds some basic examples for `nodeadm` user data configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
