### PR TITLE
sync max pods to main branch

### DIFF
--- a/.github/workflows/sync-eni-max-pods.yaml
+++ b/.github/workflows/sync-eni-max-pods.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: awslabs/amazon-eks-ami
-          ref: refs/heads/master
+          ref: refs/heads/main
           path: amazon-eks-ami/
       - uses: actions/checkout@v3
         with:
@@ -39,6 +39,7 @@ jobs:
         with:
           branch: update-eni-max-pods
           path: amazon-eks-ami/
+          base: main
           add-paths: |
             templates/shared/runtime/eni-max-pods.txt
             nodeadm/internal/kubelet/eni-max-pods.txt


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

point eni max pods sync cron job to `main` branch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

ref action docs: https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#update-changelog

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
