### PR TITLE
Add iam instance profile support

### DIFF
--- a/doc/usage/al2.md
+++ b/doc/usage/al2.md
@@ -26,6 +26,7 @@
 | `docker_version` | Docker is not installed on Kubernetes v1.25+ |
 | `enable_fips` | Install openssl and enable fips related kernel parameters |
 | `encrypted` |  |
+| `iam_instance_profile` | The name of an IAM instance profile to launch the EC2 instance with. |
 | `instance_type` |  |
 | `kernel_version` |  |
 | `kms_key_id` |  |
@@ -40,7 +41,7 @@
 | `source_ami_filter_name` |  |
 | `source_ami_id` |  |
 | `source_ami_owners` |  |
-| `ssh_interface` |  |
+| `ssh_interface` | If using ```session_manager```, you need to specify a non-minimal ami as the minimal version does not have the SSM agent installed. |
 | `ssh_username` |  |
 | `ssm_agent_version` | Version of the SSM agent to install from the S3 bucket provided by the SSM agent project, such as ```latest```. If empty, the latest version of the SSM agent available in the Amazon Linux core repositories will be installed. |
 | `subnet_id` |  |

--- a/doc/usage/al2023.md
+++ b/doc/usage/al2023.md
@@ -23,6 +23,7 @@
 | `creator` |  |
 | `enable_fips` | Install openssl and enable fips related kernel parameters |
 | `encrypted` |  |
+| `iam_instance_profile` | The name of an IAM instance profile to launch the EC2 instance with. |
 | `instance_type` |  |
 | `kms_key_id` |  |
 | `kubernetes_build_date` |  |
@@ -35,7 +36,7 @@
 | `source_ami_filter_name` |  |
 | `source_ami_id` |  |
 | `source_ami_owners` |  |
-| `ssh_interface` |  |
+| `ssh_interface` | If using ```session_manager```, you need to specify a non-minimal ami as the minimal version does not have the SSM agent installed. |
 | `ssh_username` |  |
 | `ssm_agent_version` | Version of the SSM agent to install from the S3 bucket provided by the SSM agent project, such as ```latest```. If empty, the latest version of the SSM agent available in the Amazon Linux core repositories will be installed. |
 | `subnet_id` |  |

--- a/templates/al2/template.json
+++ b/templates/al2/template.json
@@ -22,6 +22,7 @@
     "docker_version": null,
     "enable_fips": null,
     "encrypted": null,
+    "iam_instance_profile": null,
     "instance_type": null,
     "kernel_version": null,
     "kms_key_id": null,
@@ -86,6 +87,7 @@
         "max_attempts": 90
       },
       "ami_regions": "{{user `ami_regions`}}",
+      "iam_instance_profile": "{{user `iam_instance_profile`}}",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_interface": "{{user `ssh_interface`}}",
       "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidrs`}}",

--- a/templates/al2/variables-default.json
+++ b/templates/al2/variables-default.json
@@ -20,6 +20,7 @@
     "encrypted": "false",
     "kernel_version": "",
     "kms_key_id": "",
+    "iam_instance_profile": "",
     "launch_block_device_mappings_volume_size": "4",
     "pause_container_version": "3.5",
     "pull_cni_from_github": "true",

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -19,6 +19,7 @@
     "creator": null,
     "enable_fips": null,
     "encrypted": null,
+    "iam_instance_profile": null,
     "instance_type": null,
     "kms_key_id": null,
     "kubernetes_build_date": null,

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -16,6 +16,7 @@
     "enable_fips": "false",
     "encrypted": "false",
     "kms_key_id": "",
+    "iam_instance_profile": "",
     "launch_block_device_mappings_volume_size": "20",
     "pause_container_version": "3.5",
     "remote_folder": "/tmp",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
In order to use SSM for building rather than SSH, we need to be able to configure the `iam_instance_profile`.  This change adds `iam_instance_profile` that can be used when setting `ssh_interfance` to `session_manager`.

When using `session_manager` you will need to use a non-minimal version of the source ami to ensure it has the SSM agent
available at launch. You may also need to increase the volume size from 4 depending on which source AMI you use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Successful build with `make k8s=1.29 ssh_interface=session_manager iam_instance_profile=ssm-profile aws_region=us-east-2 source_ami_filter_name="amzn2-ami-hvm-*" launch_block_device_mappings_volume_size=8`
