### PR TITLE
Add allowed-unsafe-sysctls option for bootstrap.sh

### DIFF
--- a/nodeadm/crds/node.eks.aws_nodeconfigs.yaml
+++ b/nodeadm/crds/node.eks.aws_nodeconfigs.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NodeConfig is the Schema for the nodeconfigs API
+        description: NodeConfig is the primary configuration object for `nodeadm`.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -34,42 +34,57 @@ spec:
           spec:
             properties:
               cluster:
+                description: ClusterDetails contains the coordinates of your EKS cluster.
+                  These details can be found using the [DescribeCluster API](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeCluster.html).
                 properties:
                   apiServerEndpoint:
+                    description: APIServerEndpoint is the URL of your EKS cluster's
+                      kube-apiserver.
                     type: string
                   certificateAuthority:
+                    description: CertificateAuthority is a base64-encoded string of
+                      your cluster's certificate authority chain.
                     format: byte
                     type: string
                   cidr:
+                    description: CIDR is your cluster's Pod IP CIDR. This value is
+                      used to infer your cluster's DNS address.
                     type: string
                   enableOutpost:
+                    description: EnableOutpost determines how your node is configured
+                      when running on an AWS Outpost.
                     type: boolean
                   id:
+                    description: ID is an identifier for your cluster; this is only
+                      used when your node is running on an AWS Outpost.
                     type: string
                   name:
+                    description: Name is the name of your EKS cluster
                     type: string
                 type: object
               containerd:
+                description: ContainerdOptions are additional parameters passed to
+                  `containerd`.
                 properties:
                   config:
-                    description: Config is an inline containerd config toml document
-                      that can be provided by the user to override default generated
-                      configurations https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md
+                    description: Config is inline [`containerd` configuration TOML](https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md)
+                      that will be [imported](https://github.com/containerd/containerd/blob/32169d591dbc6133ef7411329b29d0c0433f8c4d/docs/man/containerd-config.toml.5.md?plain=1#L146-L154)
+                      by the default configuration file.
                     type: string
                 type: object
               kubelet:
+                description: KubeletOptions are additional parameters passed to `kubelet`.
                 properties:
                   config:
                     additionalProperties:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                    description: Config is a kubelet config that can be provided by
-                      the user to override default generated configurations https://kubernetes.io/docs/reference/config-api/kubelet-config.v1/
+                    description: Config is a [`KubeletConfiguration`](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1/)
+                      that will be merged with the defaults.
                     type: object
                   flags:
-                    description: Flags is a list of command-line kubelet arguments.
-                      These arguments are amended to the generated defaults, and therefore
-                      will act as overrides https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
+                    description: Flags are [command-line `kubelet`` arguments](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/).
+                      that will be appended to the defaults.
                     items:
                       type: string
                     type: array

--- a/nodeadm/test/e2e/cases/kubelet-upstream-config-options/config.kubelet-config-json.yaml
+++ b/nodeadm/test/e2e/cases/kubelet-upstream-config-options/config.kubelet-config-json.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+  kubelet:
+    config: {
+      "logging": {
+        "verbosity": 5
+      },
+      "clusterDNS": [
+        "0.0.0.0",
+        "1.1.1.1"
+      ],
+      "allowedUnsafeSysctls": [
+        "kernel.msg*",
+        "net.core.somaxconn"
+      ]
+    }

--- a/nodeadm/test/e2e/cases/kubelet-upstream-config-options/config.kubelet-config-yaml.yaml
+++ b/nodeadm/test/e2e/cases/kubelet-upstream-config-options/config.kubelet-config-yaml.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+  kubelet:
+    config:
+      logging:
+        verbosity: 5
+      clusterDNS:
+        - "0.0.0.0"
+        - "1.1.1.1"
+      allowedUnsafeSysctls:
+        - "kernel.msg*"
+        - "net.core.somaxconn"
+

--- a/nodeadm/test/e2e/cases/kubelet-upstream-config-options/config.kubelet-config-yaml.yaml
+++ b/nodeadm/test/e2e/cases/kubelet-upstream-config-options/config.kubelet-config-yaml.yaml
@@ -17,4 +17,3 @@ spec:
       allowedUnsafeSysctls:
         - "kernel.msg*"
         - "net.core.somaxconn"
-

--- a/nodeadm/test/e2e/cases/kubelet-upstream-config-options/expected-kubelet-config.json
+++ b/nodeadm/test/e2e/cases/kubelet-upstream-config-options/expected-kubelet-config.json
@@ -1,0 +1,72 @@
+{
+    "kind": "KubeletConfiguration",
+    "apiVersion": "kubelet.config.k8s.io/v1beta1",
+    "address": "0.0.0.0",
+    "authentication": {
+        "x509": {
+            "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+        },
+        "webhook": {
+            "enabled": true,
+            "cacheTTL": "2m0s"
+        },
+        "anonymous": {
+            "enabled": false
+        }
+    },
+    "authorization": {
+        "mode": "Webhook",
+        "webhook": {
+            "cacheAuthorizedTTL": "5m0s",
+            "cacheUnauthorizedTTL": "30s"
+        }
+    },
+    "cgroupDriver": "systemd",
+    "cgroupRoot": "/",
+    "clusterDomain": "cluster.local",
+    "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
+    "featureGates": {
+        "KubeletCredentialProviders": true,
+        "RotateKubeletServerCertificate": true
+    },
+    "hairpinMode": "hairpin-veth",
+    "protectKernelDefaults": true,
+    "readOnlyPort": 0,
+    "logging": {
+        "verbosity": 5
+    },
+    "serializeImagePulls": false,
+    "serverTLSBootstrap": true,
+    "tlsCipherSuites": [
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_GCM_SHA384"
+    ],
+    "clusterDNS": [
+        "0.0.0.0",
+        "1.1.1.1"
+    ],
+    "allowedUnsafeSysctls": [
+        "kernel.msg*",
+        "net.core.somaxconn"
+    ],
+    "maxPods": 58,
+    "evictionHard": {
+        "memory.available": "100Mi",
+        "nodefs.available": "10%",
+        "nodefs.inodesFree": "5%"
+    },
+    "kubeReserved": {
+        "cpu": "70m",
+        "ephemeral-storage": "1Gi",
+        "memory": "893Mi"
+    },
+    "systemReservedCgroup": "/system",
+    "kubeReservedCgroup": "/runtime",
+    "providerID": "aws:///us-west-2f/i-1234567890abcdef0"
+}

--- a/nodeadm/test/e2e/cases/kubelet-upstream-config-options/run.sh
+++ b/nodeadm/test/e2e/cases/kubelet-upstream-config-options/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::imds
+mock::kubelet 1.27.0
+wait::dbus-ready
+
+for config in config.*; do
+  nodeadm init --skip run --config-source file://${config}
+  assert::json-files-equal /etc/kubernetes/kubelet/config.json expected-kubelet-config.json
+done

--- a/templates/test/cases/allowed-unsafe-sysctls.sh
+++ b/templates/test/cases/allowed-unsafe-sysctls.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "--> Should be able to set allowedUnsafeSysctls"
+exit_code=0
+export KUBELET_VERSION=v1.27.0-eks-ba74326
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  --allowed-unsafe-sysctls 'kernel.msg*,net.core.somaxconn' \
+  test || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+echo '["kernel.msg*","net.core.somaxconn"]' | jq . > expected_allowed_unsafe_sysctls.json
+jq '.allowedUnsafeSysctls' /etc/kubernetes/kubelet/kubelet-config.json > actual_allowed_unsafe_sysctls.json
+
+diffResult=$(diff expected_allowed_unsafe_sysctls.json actual_allowed_unsafe_sysctls.json)
+rm expected_allowed_unsafe_sysctls.json actual_allowed_unsafe_sysctls.json
+if [ -n "$diffResult" ]; then
+  echo "❌ Test Failed."
+  echo "$diffResult"
+  exit 1
+fi


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Seeing customer reporting issue that they cannot use some sysctls via
`kubelet --allowed-unsafe-sysctls 'net.ipv4.tcp_timestamps'`

This is due to `--allowed-unsafe-sysctls ` is deprecated 
```
Flag --allowed-unsafe-sysctls has been deprecated, This parameter should be set via the config file specified by the Kubelet's --config flag. See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.
```
Thus moving add this flag to config it in AL2. 
AL2023 has no impact, adding tests to ensure the upstream configs can be correctly pick up.

And this should also align with Karpenter, https://github.com/aws/karpenter-provider-aws/issues/1279

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
for bootstrap.sh: `make test` 
for nodeadm: `make test && make test-e2e`
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
