### PR TITLE
Do not prepare local disks by default

### DIFF
--- a/templates/al2023/runtime/rootfs/etc/systemd/system/setup-local-disks.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/setup-local-disks.service
@@ -4,7 +4,8 @@ Before=containerd.service kubelet.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/setup-local-disks raid0
+Environment=LOCAL_DISK_STRATEGY=none
+ExecStart=/usr/bin/setup-local-disks $LOCAL_DISK_STRATEGY
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -15,7 +15,7 @@ err_report() {
 trap 'err_report $LINENO' ERR
 
 print_help() {
-  echo "usage: $0 <raid0 | mount>"
+  echo "usage: $0 <raid0 | mount | none>"
   echo "Sets up Amazon EC2 Instance Store NVMe disks"
   echo ""
   echo "-d, --dir directory to mount the filesystem(s) (default: /mnt/k8s-disks/)"
@@ -193,9 +193,14 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 DISK_SETUP="$1"
 set -u
 
-if [[ "${DISK_SETUP}" != "raid0" && "${DISK_SETUP}" != "mount" ]]; then
-  echo "Valid disk setup options are: raid0 or mount"
+if [[ "${DISK_SETUP}" != "raid0" && "${DISK_SETUP}" != "mount" && "${DISK_SETUP}" != "none" ]]; then
+  echo "Valid disk setup options are: raid0, mount, or none"
   exit 1
+fi
+
+if [ "${DISK_SETUP}" = "none" ]; then
+  "disk setup is 'none', nothing to do!"
+  exit 0
 fi
 
 if [ ! -d /dev/disk/by-id/ ]; then


### PR DESCRIPTION
**Description of changes:**

This makes the `setup-local-disks` service unit on AL2023 a no-op by default. A followup PR will add an option to `NodeConfig` to set the local disk strategy (or otherwise configure the underlying unit).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
