### PR TITLE
Add ability to specify a user data file

### DIFF
--- a/doc/usage/al2.md
+++ b/doc/usage/al2.md
@@ -45,6 +45,7 @@
 | `ssm_agent_version` | Version of the SSM agent to install from the S3 bucket provided by the SSM agent project, such as ```latest```. If empty, the latest version of the SSM agent available in the Amazon Linux core repositories will be installed. |
 | `subnet_id` |  |
 | `temporary_security_group_source_cidrs` |  |
+| `user_data_file` | Path to a file that will be used for the user data when launching the instance. |
 | `volume_type` |  |
 | `working_dir` | Directory path for ephemeral resources on the builder instance |
 <!-- template-variable-table-boundary -->

--- a/doc/usage/al2023.md
+++ b/doc/usage/al2023.md
@@ -39,6 +39,7 @@
 | `subnet_id` |  |
 | `temporary_key_pair_type` |  |
 | `temporary_security_group_source_cidrs` |  |
+| `user_data_file` | Path to a file that will be used for the user data when launching the instance. |
 | `volume_type` |  |
 | `working_dir` | Directory path for ephemeral resources on the builder instance |
 <!-- template-variable-table-boundary -->

--- a/templates/al2/template.json
+++ b/templates/al2/template.json
@@ -41,6 +41,7 @@
     "ssm_agent_version": null,
     "subnet_id": null,
     "temporary_security_group_source_cidrs": null,
+    "user_data_file": null,
     "volume_type": null,
     "working_dir": null
   },
@@ -114,7 +115,8 @@
       "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}",
       "metadata_options": {
         "http_tokens": "required"
-      }
+      },
+      "user_data_file": "{{user `user_data_file`}}"
     }
   ],
   "provisioners": [

--- a/templates/al2/variables-default.json
+++ b/templates/al2/variables-default.json
@@ -34,6 +34,7 @@
     "ssm_agent_version": "",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
+    "user_data_file": null,
     "volume_type": "gp2",
     "working_dir": "{{user `remote_folder`}}/worker"
 }

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -35,6 +35,7 @@
     "subnet_id": null,
     "temporary_key_pair_type": "ed25519",
     "temporary_security_group_source_cidrs": null,
+    "user_data_file": null,
     "volume_type": null,
     "working_dir": null
   },
@@ -106,7 +107,8 @@
       "ami_description": "{{ user `ami_description` }}, {{ user `ami_component_description` }}",
       "metadata_options": {
         "http_tokens": "required"
-      }
+      },
+      "user_data_file": "{{user `user_data_file`}}"
     }
   ],
   "provisioners": [

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -27,6 +27,7 @@
     "ssm_agent_version": "",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
+    "user_data_file": null,
     "volume_type": "gp3",
     "working_dir": "{{user `remote_folder`}}/worker"
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Sometimes we need to execute some actions on the instance along with the eks build script but currently there is not a way to inject these additional steps as part of the existing build process. This change adds the ability to specify `user_data_file` which can be passed to the build instance on startup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Built a new image with `make k8s=1.29 user_data_file=test.yaml`

The `test.yaml` contained several `bootcmd` and `runcmd` options to tweak the base image being used:
```
#cloud-config
bootcmd:
  # remove possible fips incompatible ciphers
  - sed -i -e 's/curve25519-sha256@libssh.org[,]*//' -e 's/curve25519-sha256[,]*//' /etc/ssh/sshd_config
  # remove ip_forward disabling from CIS image
  - sed -i -e '/net.ipv4.ip_forward/d' /etc/sysctl.conf
runcmd:
  # open access to kubelet
  - iptables -A INPUT -p tcp -m tcp --dport 10250 -m state --state NEW -j ACCEPT
  # open access for NodePorts
  - iptables -A INPUT -p tcp -m multiport --dports 30000:32767 -j ACCEPT
  # save updated iptables
  - bash -c "/sbin/iptables-save > /etc/sysconfig/iptables"
```

Deployed built AMI to cluster and verified pods were able to be schedule and use the node. Also verified the actions were run during the build process and the results showed up in the built AMI.
