### PR TITLE
Collect IPv6 Networking Information in Log Collector Script

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -333,10 +333,15 @@ get_iptables_info() {
   else
     try "collect iptables information"
     iptables --wait 1 --numeric --verbose --list --table mangle | tee "${COLLECT_DIR}"/networking/iptables-mangle.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-mangle.txt
+    ip6tables --wait 1 --numeric --verbose --list --table mangle | tee "${COLLECT_DIR}"/networking/ip6tables-mangle.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/ip6tables-mangle.txt
     iptables --wait 1 --numeric --verbose --list --table filter | tee "${COLLECT_DIR}"/networking/iptables-filter.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-filter.txt
+    ip6tables --wait 1 --numeric --verbose --list --table filter | tee "${COLLECT_DIR}"/networking/ip6tables-filter.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/ip6tables-filter.txt
     iptables --wait 1 --numeric --verbose --list --table nat | tee "${COLLECT_DIR}"/networking/iptables-nat.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables-nat.txt
+    ip6tables --wait 1 --numeric --verbose --list --table nat | tee "${COLLECT_DIR}"/networking/ip6tables-nat.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/ip6tables-nat.txt
     iptables --wait 1 --numeric --verbose --list | tee "${COLLECT_DIR}"/networking/iptables.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/iptables.txt
+    ip6tables --wait 1 --numeric --verbose --list | tee "${COLLECT_DIR}"/networking/ip6tables.txt | sed '/^num\|^$\|^Chain\|^\ pkts.*.destination/d' | echo -e "=======\nTotal Number of Rules: $(wc -l)" >> "${COLLECT_DIR}"/networking/ip6tables.txt
     iptables-save > "${COLLECT_DIR}"/networking/iptables-save.txt
+    ip6tables-save > "${COLLECT_DIR}"/networking/ip6tables-save.txt
   fi
 
   ok
@@ -539,13 +544,19 @@ get_networking_info() {
   timeout 75 conntrack -S >> "${COLLECT_DIR}"/networking/conntrack.txt
   echo "*** Output of conntrack -L ***" >> "${COLLECT_DIR}"/networking/conntrack.txt
   timeout 75 conntrack -L >> "${COLLECT_DIR}"/networking/conntrack.txt
+  echo "*** Output of conntrack -L -f ipv6 ***" >> "${COLLECT_DIR}"/networking/conntrack6.txt
+  timeout 75 conntrack -L -f ipv6 >> "${COLLECT_DIR}"/networking/conntrack6.txt
 
   # ifconfig
   timeout 75 ifconfig > "${COLLECT_DIR}"/networking/ifconfig.txt
 
   # ip rule show
   timeout 75 ip rule show > "${COLLECT_DIR}"/networking/iprule.txt
+  timeout 75 ip -6 rule show > "${COLLECT_DIR}"/networking/ip6rule.txt
+
+  # ip route show
   timeout 75 ip route show table all >> "${COLLECT_DIR}"/networking/iproute.txt
+  timeout 75 ip -6 route show table all >> "${COLLECT_DIR}"/networking/ip6route.txt
 
   # configure-multicard-interfaces
   timeout 75 journalctl -u configure-multicard-interfaces > "${COLLECT_DIR}"/networking/configure-multicard-interfaces.txt || echo -e "\tTimed out, ignoring \"configure-multicard-interfaces unit output \" "


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/amazon-eks-ami/issues/1474

**Description of changes:**
This PR updates the log collector script for Linux nodes to collect IPv6 networking information that will assist in debugging. The following commands are run on IPv4 and IPv6 nodes:
1. `ip6tables --wait 1 --numeric --verbose --list --table mangle`
2. `ip6tables --wait 1 --numeric --verbose --list --table filter`
3. `ip6tables --wait 1 --numeric --verbose --list --table nat`
4. `ip6tables --wait 1 --numeric --verbose --list`
5. `ip6tables-save`
6. `timeout 75 conntrack -L -f ipv6`
7. `timeout 75 ip -6 rule show`
8. `timeout 75 ip -6 route show table all`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
I ran the updated script against IPv4 and IPv6 Linux nodes and validated that the expected information was collected.
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
