### PR TITLE
[POC] attempt reading max pods from user config before computing kubeReserved

### DIFF
--- a/nodeadm/internal/kubelet/eni_max_pods.go
+++ b/nodeadm/internal/kubelet/eni_max_pods.go
@@ -49,7 +49,6 @@ func init() {
 // The behavior should align with AL2, which essentially is:
 //
 //	# of ENI * (# of IPv4 per ENI - 1) + 2
-//
 func CalcMaxPods(awsRegion string, instanceType string) int32 {
 	zap.L().Info("calculate the max pod for instance type", zap.String("instanceType", instanceType))
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(awsRegion))

--- a/nodeadm/test/e2e/cases/kubelet-user-kube-reserved/config.flag.yaml
+++ b/nodeadm/test/e2e/cases/kubelet-user-kube-reserved/config.flag.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+  kubelet:
+    flags:
+      - --max-pods=100

--- a/nodeadm/test/e2e/cases/kubelet-user-kube-reserved/config.yaml
+++ b/nodeadm/test/e2e/cases/kubelet-user-kube-reserved/config.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+  kubelet:
+    config:
+      maxPods: 100

--- a/nodeadm/test/e2e/cases/kubelet-user-kube-reserved/expected-kubelet-config.json
+++ b/nodeadm/test/e2e/cases/kubelet-user-kube-reserved/expected-kubelet-config.json
@@ -1,0 +1,67 @@
+{
+    "kind": "KubeletConfiguration",
+    "apiVersion": "kubelet.config.k8s.io/v1beta1",
+    "address": "0.0.0.0",
+    "authentication": {
+        "x509": {
+            "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+        },
+        "webhook": {
+            "enabled": true,
+            "cacheTTL": "2m0s"
+        },
+        "anonymous": {
+            "enabled": false
+        }
+    },
+    "authorization": {
+        "mode": "Webhook",
+        "webhook": {
+            "cacheAuthorizedTTL": "5m0s",
+            "cacheUnauthorizedTTL": "30s"
+        }
+    },
+    "cgroupDriver": "systemd",
+    "cgroupRoot": "/",
+    "clusterDomain": "cluster.local",
+    "containerRuntimeEndpoint": "unix:///run/containerd/containerd.sock",
+    "featureGates": {
+        "KubeletCredentialProviders": true,
+        "RotateKubeletServerCertificate": true
+    },
+    "hairpinMode": "hairpin-veth",
+    "protectKernelDefaults": true,
+    "readOnlyPort": 0,
+    "logging": {
+        "verbosity": 2
+    },
+    "serializeImagePulls": false,
+    "serverTLSBootstrap": true,
+    "tlsCipherSuites": [
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_GCM_SHA384"
+    ],
+    "clusterDNS": [
+        "10.100.0.10"
+    ],
+    "maxPods": 100,
+    "evictionHard": {
+        "memory.available": "100Mi",
+        "nodefs.available": "10%",
+        "nodefs.inodesFree": "5%"
+    },
+    "kubeReserved": {
+        "cpu": "70m",
+        "ephemeral-storage": "1Gi",
+        "memory": "1355Mi"
+    },
+    "kubeReservedCgroup": "/runtime",
+    "systemReservedCgroup": "/system",
+    "providerID": "aws:///us-west-2f/i-1234567890abcdef0"
+}

--- a/nodeadm/test/e2e/cases/kubelet-user-kube-reserved/run.sh
+++ b/nodeadm/test/e2e/cases/kubelet-user-kube-reserved/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::instance-type
+mock::imds
+mock::kubelet 1.27.0
+wait::dbus-ready
+
+for config in config.*; do
+  nodeadm init --skip run --config-source file://${config}
+  assert::json-files-equal /etc/kubernetes/kubelet/config.json expected-kubelet-config.json
+done
+
+revert::mock::instance-type

--- a/nodeadm/test/e2e/helpers.sh
+++ b/nodeadm/test/e2e/helpers.sh
@@ -112,5 +112,4 @@ function mock::instance-type() {
 
 function revert::mock::instance-type() {
   cat /etc/aemm-default-config.json | jq '.metadata.values."instance-type" = "m4.xlarge" | .dynamic.values."instance-identity-document".instanceType = "m4.xlarge"' | tee /etc/aemm-default-config.json
-
 }


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/awslabs/amazon-eks-ami/issues/1698

**Description of changes:**

initial draft of solution for https://github.com/awslabs/amazon-eks-ami/issues/1698 to take into account user-provided `maxPods` from either kubelet config or flags.

as a side effect the default for `maxPods` is ultimately set to the user provided value. This does not change any behavior but could be improved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

add unit and e2e tests

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
