### PR TITLE
update install-worker.sh to chmod under more restrictive uname configurations

### DIFF
--- a/templates/al2/provisioners/install-worker.sh
+++ b/templates/al2/provisioners/install-worker.sh
@@ -164,8 +164,8 @@ sudo mv $WORKING_DIR/kubelet-containerd.service /etc/eks/containerd/kubelet-cont
 sudo mv $WORKING_DIR/sandbox-image.service /etc/eks/containerd/sandbox-image.service
 sudo mv $WORKING_DIR/pull-sandbox-image.sh /etc/eks/containerd/pull-sandbox-image.sh
 sudo mv $WORKING_DIR/pull-image.sh /etc/eks/containerd/pull-image.sh
-sudo chmod +x /etc/eks/containerd/pull-sandbox-image.sh
-sudo chmod +x /etc/eks/containerd/pull-image.sh
+sudo chmod 755 /etc/eks/containerd/pull-sandbox-image.sh
+sudo chmod 755 /etc/eks/containerd/pull-image.sh
 sudo mkdir -p /etc/systemd/system/containerd.service.d
 CONFIGURE_CONTAINERD_SLICE=$(vercmp "$KUBERNETES_VERSION" gteq "1.24.0" || true)
 if [ "$CONFIGURE_CONTAINERD_SLICE" == "true" ]; then
@@ -282,7 +282,7 @@ for binary in ${BINARIES[*]}; do
     sudo wget $S3_URL_BASE/$binary.sha256
   fi
   sudo sha256sum -c $binary.sha256
-  sudo chmod +x $binary
+  sudo chmod 755 $binary
   sudo mv $binary /usr/bin/
 done
 
@@ -356,12 +356,12 @@ sudo systemctl disable kubelet
 
 sudo mkdir -p /etc/eks
 sudo mv $WORKING_DIR/get-ecr-uri.sh /etc/eks/get-ecr-uri.sh
-sudo chmod +x /etc/eks/get-ecr-uri.sh
+sudo chmod 755 /etc/eks/get-ecr-uri.sh
 sudo mv $WORKING_DIR/eni-max-pods.txt /etc/eks/eni-max-pods.txt
 sudo mv $WORKING_DIR/bootstrap.sh /etc/eks/bootstrap.sh
-sudo chmod +x /etc/eks/bootstrap.sh
+sudo chmod 755 /etc/eks/bootstrap.sh
 sudo mv $WORKING_DIR/max-pods-calculator.sh /etc/eks/max-pods-calculator.sh
-sudo chmod +x /etc/eks/max-pods-calculator.sh
+sudo chmod 755 /etc/eks/max-pods-calculator.sh
 
 ################################################################################
 ### ECR CREDENTIAL PROVIDER ####################################################
@@ -374,7 +374,7 @@ else
   echo "AWS cli missing - using wget to fetch ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3. Note: This won't work for private bucket."
   sudo wget "$S3_URL_BASE/$ECR_CREDENTIAL_PROVIDER_BINARY"
 fi
-sudo chmod +x $ECR_CREDENTIAL_PROVIDER_BINARY
+sudo chmod 755 $ECR_CREDENTIAL_PROVIDER_BINARY
 sudo mkdir -p /etc/eks/image-credential-provider
 sudo mv $ECR_CREDENTIAL_PROVIDER_BINARY /etc/eks/image-credential-provider/
 sudo mv $WORKING_DIR/ecr-credential-provider-config.json /etc/eks/image-credential-provider/config.json


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

when running under a more restrictive umask, the `chmod +x` wouldn't set the r-x bits for the 'other' group (or potentially the group permissions too depending on the umask). make the chmod more explicit.

for example `chmod +x` under a more restrictive umask ends up without execute pemissions which is likely not what was intended:

```
[jo.diaz@\ ~]$ umask 0027
[jo.diaz@\ ~]$ touch testfile
[jo.diaz@\ ~]$ chmod +x testfile
[jo.diaz@\ ~]$ ls -l testfile
-rwxr-x--- 1 jo.diaz jo.diaz 0 Mar  8 11:39 testfile
```

where under a more typical umask things look more familiar:

```
[jo.diaz@\ ~]$ umask 0002
[jo.diaz@\ ~]$ touch permissive
[jo.diaz@\ ~]$ chmod +x permissive
[jo.diaz@\ ~]$ ls -l permissive
-rwxrwxr-x 1 jo.diaz jo.diaz 0 Mar  8 11:40 permissive
```

so, to accommodate using a base AMI with more a restrictive umask, update the `chmod +x`'s to be more explicit about what is intended.

without these changes, we have seen things error out during the build

```
2024-03-08T12:02:27-05:00: ==> amazon-ebs: Provisioning with shell script:
/home/jo.diaz/projects/amazon-eks-ami/templates/al2/../shared/provisioners/generate-version-info.sh
2024-03-08T12:02:28-05:00:     amazon-ebs:
/home/ec2-user/script_2147.sh: line 19: /usr/bin/kubelet: Permission
denied
2024-03-08T12:02:28-05:00: ==> amazon-ebs: Provisioning step had errors:
Running the cleanup provisioner, if present...
```


**Testing Done**

Tried a build with an AMI base image with a restrictive umask, and avoided the errors described above.

