### PR TITLE
account for the possibility of there being no aws cli binary

### DIFF
--- a/templates/shared/provisioners/generate-version-info.sh
+++ b/templates/shared/provisioners/generate-version-info.sh
@@ -23,12 +23,14 @@ if [ "$?" != 0 ]; then
 fi
 echo $(jq ".binaries.kubelet = \"$KUBELET_VERSION\"" $OUTPUT_FILE) > $OUTPUT_FILE
 
-CLI_VERSION=$(aws --version | awk '{print $1}' | cut -d '/' -f 2)
+CLI_VERSION=$(aws --version | awk '{print $1}' | cut -d '/' -f 2 || echo "unknown")
 if [ "$?" != 0 ]; then
   echo "unable to get aws cli version"
   exit 1
 fi
-echo $(jq ".binaries.awscli = \"$CLI_VERSION\"" $OUTPUT_FILE) > $OUTPUT_FILE
+if [ "$CLI_VERSION" != "unknown" ]; then
+  echo $(jq ".binaries.awscli = \"$CLI_VERSION\"" $OUTPUT_FILE) > $OUTPUT_FILE
+fi
 
 # cached images
 if systemctl is-active --quiet containerd; then


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

the generate-version-info.sh script presently assumes that the aws binary will be present. but this isn't always the case depending on the base AMI being used. allow for the possibility that we will not have an aws binary so the script doesn't error out.

otherwise we end up with errors like so:

2024-03-08T13:48:36-05:00: ==> amazon-ebs: Provisioning with shell script:
/home/jo.diaz/projects/amazon-eks-ami/templates/al2/../shared/provisioners/generate-version-info.sh
2024-03-08T13:48:37-05:00:     amazon-ebs:
/home/ec2-user/script_1364.sh: line 26: aws: command not found
2024-03-08T13:48:37-05:00: ==> amazon-ebs: Provisioning step had errors:
Running the cleanup provisioner, if present...
2024-03-08T13:48:37-05:00: ==> amazon-ebs: Terminating the source AWS
instance...

**Testing Done**

Ran a build with a base AMI that didn't include the aws CLI w/o running into this issue.