### PR TITLE
Build AL2 AMI for 1.21 and 1.22 

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.6'
+          go-version: '1.21.8'
       - run: go install github.com/securego/gosec/v2/cmd/gosec@latest
       - run: gosec -exclude-generated ./...
         working-directory: nodeadm
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.21.6
+          go-version-input: 1.21.8
           work-dir: ./nodeadm
           go-version-file: nodeadm/go.mod
           cache: false

--- a/.github/workflows/update-dependency.yaml
+++ b/.github/workflows/update-dependency.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.6'
+          go-version: '1.21.8'
       - uses: actions/checkout@v4
       - name: Update Nodeadm Dependencies
         id: update_deps

--- a/templates/al2/variables-1.21.json
+++ b/templates/al2/variables-1.21.json
@@ -1,0 +1,4 @@
+{
+    "ami_component_description": "(k8s: {{ user `kubernetes_version` }}, docker: {{ user `docker_version` }}, containerd: {{ user `containerd_version` }})",
+    "docker_version": "20.10.*"
+}

--- a/templates/al2/variables-1.22.json
+++ b/templates/al2/variables-1.22.json
@@ -1,0 +1,4 @@
+{
+    "ami_component_description": "(k8s: {{ user `kubernetes_version` }}, docker: {{ user `docker_version` }}, containerd: {{ user `containerd_version` }})",
+    "docker_version": "20.10.*"
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Build AL2 AMI for 1.21 and 1.22 
- Extend CI support 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
