### PR TITLE
Add support for disabling Bind Mounting of kubelet, containerd and var-log-pods to setup-local-disk

### DIFF
--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -5,24 +5,24 @@ set -o pipefail
 set -o nounset
 
 if [ "$(id --user)" -ne 0 ]; then
-  echo "Must be run as root"
-  exit 1
+	echo "Must be run as root"
+	exit 1
 fi
 
 err_report() {
-  echo "Exited with error on line $1"
+	echo "Exited with error on line $1"
 }
 trap 'err_report $LINENO' ERR
 
 print_help() {
-  echo "usage: $0 <raid0 | mount | none>"
-  echo "Sets up Amazon EC2 Instance Store NVMe disks"
-  echo ""
-  echo "-d, --dir directory to mount the filesystem(s) (default: /mnt/k8s-disks/)"
-  echo "--no-bind-kubelet disable bind mounting kubelet dir onto MD raid device"
-  echo "--no-bind-containerd disable bind mounting containerd dir onto MD raid device"
-  echo "--no-bind-pod-logs disable bind mounting /var/log/pods onto MD raid device"
-  echo "-h, --help print this help"
+	echo "usage: $0 <raid0 | mount | none>"
+	echo "Sets up Amazon EC2 Instance Store NVMe disks"
+	echo ""
+	echo "-d, --dir directory to mount the filesystem(s) (default: /mnt/k8s-disks/)"
+	echo "--no-bind-kubelet disable bind mounting kubelet dir onto MD raid device"
+	echo "--no-bind-containerd disable bind mounting containerd dir onto MD raid device"
+	echo "--no-bind-pods-logs disable bind mounting /var/log/pods onto MD raid device"
+	echo "-h, --help print this help"
 }
 
 # Sets up a RAID-0 of NVMe instance storage disks, moves
@@ -30,47 +30,47 @@ print_help() {
 # to the new mounted RAID, and bind mounts the kubelet and
 # containerd state directories.
 maybe_raid0() {
-  local md_name="kubernetes"
-  local md_device="/dev/md/${md_name}"
-  local md_config="/.aws/mdadm.conf"
-  local array_mount_point="${MNT_DIR}/0"
-  mkdir -p "$(dirname "${md_config}")"
+	local md_name="kubernetes"
+	local md_device="/dev/md/${md_name}"
+	local md_config="/.aws/mdadm.conf"
+	local array_mount_point="${MNT_DIR}/0"
+	mkdir -p "$(dirname "${md_config}")"
 
-  if [[ ! -s "${md_config}" ]]; then
-    mdadm --create --force --verbose \
-      "${md_device}" \
-      --level=0 \
-      --name="${md_name}" \
-      --raid-devices="${#EPHEMERAL_DISKS[@]}" \
-      "${EPHEMERAL_DISKS[@]}"
-    while [ -n "$(mdadm --detail "${md_device}" | grep -ioE 'State :.*resyncing')" ]; do
-      echo "Raid is resyncing..."
-      sleep 1
-    done
-    mdadm --detail --scan > "${md_config}"
-  fi
+	if [[ ! -s "${md_config}" ]]; then
+		mdadm --create --force --verbose \
+			"${md_device}" \
+			--level=0 \
+			--name="${md_name}" \
+			--raid-devices="${#EPHEMERAL_DISKS[@]}" \
+			"${EPHEMERAL_DISKS[@]}"
+		while [ -n "$(mdadm --detail "${md_device}" | grep -ioE 'State :.*resyncing')" ]; do
+			echo "Raid is resyncing..."
+			sleep 1
+		done
+		mdadm --detail --scan >"${md_config}"
+	fi
 
-  ## Check if the device symlink has changed on reboot to include a homehost identifier
-  local current_md_device=$(find /dev/md/ -type l -regex ".*/${md_name}_?[0-9a-z]*$" | tail -n1)
-  if [[ ! -z ${current_md_device} ]]; then
-    md_device="${current_md_device}"
-  fi
+	## Check if the device symlink has changed on reboot to include a homehost identifier
+	local current_md_device=$(find /dev/md/ -type l -regex ".*/${md_name}_?[0-9a-z]*$" | tail -n1)
+	if [[ ! -z ${current_md_device} ]]; then
+		md_device="${current_md_device}"
+	fi
 
-  # Format the array if not already formatted.
-  if [[ -z "$(lsblk "${md_device}" -o fstype --noheadings)" ]]; then
-    ## By default, mkfs tries to use the stripe unit of the array (512k),
-    ## for the log stripe unit, but the max log stripe unit is 256k.
-    ## So instead, we use 32k (8 blocks) to avoid a warning of breaching the max.
-    ## mkfs.xfs defaults to 32k after logging the warning since the default log buffer size is 32k.
-    mkfs.xfs -l su=8b "${md_device}"
-  fi
+	# Format the array if not already formatted.
+	if [[ -z "$(lsblk "${md_device}" -o fstype --noheadings)" ]]; then
+		## By default, mkfs tries to use the stripe unit of the array (512k),
+		## for the log stripe unit, but the max log stripe unit is 256k.
+		## So instead, we use 32k (8 blocks) to avoid a warning of breaching the max.
+		## mkfs.xfs defaults to 32k after logging the warning since the default log buffer size is 32k.
+		mkfs.xfs -l su=8b "${md_device}"
+	fi
 
-  ## Create the mount directory
-  mkdir -p "${array_mount_point}"
+	## Create the mount directory
+	mkdir -p "${array_mount_point}"
 
-  local dev_uuid=$(blkid -s UUID -o value "${md_device}")
-  local mount_unit_name="$(systemd-escape --path --suffix=mount "${array_mount_point}")"
-  cat > "/etc/systemd/system/${mount_unit_name}" << EOF
+	local dev_uuid=$(blkid -s UUID -o value "${md_device}")
+	local mount_unit_name="$(systemd-escape --path --suffix=mount "${array_mount_point}")"
+	cat >"/etc/systemd/system/${mount_unit_name}" <<EOF
   [Unit]
   Description=Mount EC2 Instance Store NVMe disk RAID0
   [Mount]
@@ -81,56 +81,56 @@ maybe_raid0() {
   [Install]
   WantedBy=multi-user.target
 EOF
-  systemd-analyze verify "${mount_unit_name}"
-  systemctl enable "${mount_unit_name}" --now
+	systemd-analyze verify "${mount_unit_name}"
+	systemctl enable "${mount_unit_name}" --now
 
-  prev_running=""
-  needs_linked=""
+	prev_running=""
+	needs_linked=""
 
-  BIND_MOUNTS=()                                                                                                                                                                                                                      
-                                                                                                                                                                                                                                      
-  if [ "${BIND_KUBELET}" = true ]; then                                                                                                                                                                                               
-      BIND_MOUNTS+=("kubelet")                                                                                                                                                                                                        
-  fi                                                                                                                                                                                                                                  
-                                                                                                                                                                                                                                      
-  if [ "${BIND_CONTAINERD}" = true ]; then                                                                                                                                                                                            
-      BIND_MOUNTS+=("containerd")                                                                                                                                                                                                     
-  fi  
+	BIND_MOUNTS=()
 
-  for unit in "kubelet" "${BIND_MOUNTS[@]}"; do
-    ## Check if the bind mount from the RAID already exists
-    if [[ "$(systemctl is-active var-lib-${unit}.mount)" != "active" ]]; then
-      # Check if components that depend on the RAID are running and, if so, stop them
-      if systemctl is-active "${unit}" > /dev/null 2>&1; then
-        prev_running+=" ${unit}"
-      fi
-      needs_linked+=" /var/lib/${unit}"
-    fi
-  done
+	if [ "${BIND_KUBELET}" = true ]; then
+		BIND_MOUNTS+=("kubelet")
+	fi
 
-  ## Check if /var/log/pods has been bind mounted and make sure kubelet is stopped
-  if [[ "${BIND_VAR_LOG_PODS}" = true ]]; then
-    if [[ "$(systemctl is-active var-log-pods.mount)" != "active" ]]; then
-      if systemctl is-active "kubelet" > /dev/null 2>&1; then
-        prev_running+=" ${unit}"
-      fi
-      needs_linked+=" /var/log/pods"
-    fi
-  fi
+	if [ "${BIND_CONTAINERD}" = true ]; then
+		BIND_MOUNTS+=("containerd")
+	fi
 
-  if [[ ! -z "${prev_running}" ]]; then
-    systemctl stop ${prev_running}
-  fi
+	for unit in "kubelet" "${BIND_MOUNTS[@]}"; do
+		## Check if the bind mount from the RAID already exists
+		if [[ "$(systemctl is-active var-lib-${unit}.mount)" != "active" ]]; then
+			# Check if components that depend on the RAID are running and, if so, stop them
+			if systemctl is-active "${unit}" >/dev/null 2>&1; then
+				prev_running+=" ${unit}"
+			fi
+			needs_linked+=" /var/lib/${unit}"
+		fi
+	done
 
-  # Transfer state directories to the array, if they exist.
-  for mount_point in ${needs_linked}; do
-    local unit="$(basename "${mount_point}")"
-    local array_mount_point_unit="${array_mount_point}/${unit}"
-    mkdir -p "${mount_point}"
-    echo "Copying ${mount_point}/ to ${array_mount_point_unit}/"
-    cp -a "${mount_point}/" "${array_mount_point_unit}/"
-    local mount_unit_name="$(systemd-escape --path --suffix=mount "${mount_point}")"
-    cat > "/etc/systemd/system/${mount_unit_name}" << EOF
+	## Check if /var/log/pods has been bind mounted and make sure kubelet is stopped
+	if [[ "${BIND_VAR_LOG_PODS}" = true ]]; then
+		if [[ "$(systemctl is-active var-log-pods.mount)" != "active" ]]; then
+			if systemctl is-active "kubelet" >/dev/null 2>&1; then
+				prev_running+=" ${unit}"
+			fi
+			needs_linked+=" /var/log/pods"
+		fi
+	fi
+
+	if [[ ! -z "${prev_running}" ]]; then
+		systemctl stop ${prev_running}
+	fi
+
+	# Transfer state directories to the array, if they exist.
+	for mount_point in ${needs_linked}; do
+		local unit="$(basename "${mount_point}")"
+		local array_mount_point_unit="${array_mount_point}/${unit}"
+		mkdir -p "${mount_point}"
+		echo "Copying ${mount_point}/ to ${array_mount_point_unit}/"
+		cp -a "${mount_point}/" "${array_mount_point_unit}/"
+		local mount_unit_name="$(systemd-escape --path --suffix=mount "${mount_point}")"
+		cat >"/etc/systemd/system/${mount_unit_name}" <<EOF
       [Unit]
       Description=Mount ${unit} on EC2 Instance Store NVMe RAID0
       [Mount]
@@ -141,31 +141,31 @@ EOF
       [Install]
       WantedBy=multi-user.target
 EOF
-    systemd-analyze verify "${mount_unit_name}"
-    systemctl enable "${mount_unit_name}" --now
-  done
+		systemd-analyze verify "${mount_unit_name}"
+		systemctl enable "${mount_unit_name}" --now
+	done
 
-  if [[ ! -z "${prev_running}" ]]; then
-    systemctl start ${prev_running}
-  fi
+	if [[ ! -z "${prev_running}" ]]; then
+		systemctl start ${prev_running}
+	fi
 }
 
 # Mounts and creates xfs file systems on all EC2 instance store NVMe disks
 # without existing file systems. Mounts in /mnt/k8s-disks/{1..} by default
 maybe_mount() {
-  idx=1
-  for dev in "${EPHEMERAL_DISKS[@]}"; do
-    if [[ -z "$(lsblk "${dev}" -o fstype --noheadings)" ]]; then
-      mkfs.xfs -l su=8b "${dev}"
-    fi
-    if [[ ! -z "$(lsblk "${dev}" -o MOUNTPOINT --noheadings)" ]]; then
-      echo "${dev} is already mounted."
-      continue
-    fi
-    local mount_point="${MNT_DIR}/${idx}"
-    local mount_unit_name="$(systemd-escape --path --suffix=mount "${mount_point}")"
-    mkdir -p "${mount_point}"
-    cat > "/etc/systemd/system/${mount_unit_name}" << EOF
+	idx=1
+	for dev in "${EPHEMERAL_DISKS[@]}"; do
+		if [[ -z "$(lsblk "${dev}" -o fstype --noheadings)" ]]; then
+			mkfs.xfs -l su=8b "${dev}"
+		fi
+		if [[ ! -z "$(lsblk "${dev}" -o MOUNTPOINT --noheadings)" ]]; then
+			echo "${dev} is already mounted."
+			continue
+		fi
+		local mount_point="${MNT_DIR}/${idx}"
+		local mount_unit_name="$(systemd-escape --path --suffix=mount "${mount_point}")"
+		mkdir -p "${mount_point}"
+		cat >"/etc/systemd/system/${mount_unit_name}" <<EOF
     [Unit]
     Description=Mount EC2 Instance Store NVMe disk ${idx}
     [Mount]
@@ -176,47 +176,47 @@ maybe_mount() {
     [Install]
     WantedBy=multi-user.target
 EOF
-    systemd-analyze verify "${mount_unit_name}"
-    systemctl enable "${mount_unit_name}" --now
-    idx=$((idx + 1))
-  done
+		systemd-analyze verify "${mount_unit_name}"
+		systemctl enable "${mount_unit_name}" --now
+		idx=$((idx + 1))
+	done
 }
 
 ## Main logic
 MNT_DIR="/mnt/k8s-disks"
-BIND_KUBELET=true                                                                                                                                                                                                                       
-BIND_CONTAINERD=true                                                                                                                                                                                                                    
-BIND_VAR_LOG_PODS=true  
+BIND_KUBELET=true
+BIND_CONTAINERD=true
+BIND_VAR_LOG_PODS=true
 
 while [[ $# -gt 0 ]]; do
-  key="$1"
-  case $key in
-    -h | --help)
-      print_help
-      exit 0
-      ;;
-    -d | --dir)
-      MNT_DIR="$2"
-      shift
-      shift
-      ;;
-    --no-bind-kubelet)                                                                                                                                                                                                                  
-        BIND_KUBELET=false                                                                                                                                                                                                              
-        shift                                                                                                                                                                                                                           
-        ;;                                                                                                                                                                                                                              
-    --no-bind-containerd)                                                                                                                                                                                                               
-        BIND_CONTAINERD=false                                                                                                                                                                                                           
-        shift                                                                                                                                                                                                                           
-        ;;                                                                                                                                                                                                                              
-    --no-bind-pods-logs)                                                                                                                                                                                                                
-        BIND_VAR_LOG_PODS=false                                                                                                                                                                                                         
-        shift                                                                                                                                                                                                                           
-        ;; 
-    *)                   # unknown option
-      POSITIONAL+=("$1") # save it in an array for later
-      shift              # past argument
-      ;;
-  esac
+	key="$1"
+	case $key in
+	-h | --help)
+		print_help
+		exit 0
+		;;
+	-d | --dir)
+		MNT_DIR="$2"
+		shift
+		shift
+		;;
+	--no-bind-kubelet)
+		BIND_KUBELET=false
+		shift
+		;;
+	--no-bind-containerd)
+		BIND_CONTAINERD=false
+		shift
+		;;
+	--no-bind-pods-logs)
+		BIND_VAR_LOG_PODS=false
+		shift
+		;;
+	*)                  # unknown option
+		POSITIONAL+=("$1") # save it in an array for later
+		shift              # past argument
+		;;
+	esac
 done
 
 set +u
@@ -225,37 +225,37 @@ DISK_SETUP="$1"
 set -u
 
 if [[ "${DISK_SETUP}" != "raid0" && "${DISK_SETUP}" != "mount" && "${DISK_SETUP}" != "none" ]]; then
-  echo "Valid disk setup options are: raid0, mount, or none"
-  exit 1
+	echo "Valid disk setup options are: raid0, mount, or none"
+	exit 1
 fi
 
 if [ "${DISK_SETUP}" = "none" ]; then
-  "disk setup is 'none', nothing to do!"
-  exit 0
+	"disk setup is 'none', nothing to do!"
+	exit 0
 fi
 
 if [ ! -d /dev/disk/by-id/ ]; then
-  echo "no ephemeral disks found!"
-  exit 0
+	echo "no ephemeral disks found!"
+	exit 0
 fi
 
 disks=($(find -L /dev/disk/by-id/ -xtype l -name '*NVMe_Instance_Storage_*'))
 ## Bail early if there are no ephemeral disks to setup
 if [[ "${#disks[@]}" -eq 0 ]]; then
-  echo "no NVMe instance storage disks found!"
-  exit 0
+	echo "no NVMe instance storage disks found!"
+	exit 0
 fi
 
 ## Get devices of NVMe instance storage ephemeral disks
 EPHEMERAL_DISKS=($(realpath "${disks[@]}" | sort -u))
 
 case "${DISK_SETUP}" in
-  "raid0")
-    maybe_raid0
-    echo "Successfully setup RAID-0 consisting of ${EPHEMERAL_DISKS[@]}"
-    ;;
-  "mount")
-    maybe_mount
-    echo "Successfully setup disk mounts consisting of ${EPHEMERAL_DISKS[@]}"
-    ;;
+"raid0")
+	maybe_raid0
+	echo "Successfully setup RAID-0 consisting of ${EPHEMERAL_DISKS[@]}"
+	;;
+"mount")
+	maybe_mount
+	echo "Successfully setup disk mounts consisting of ${EPHEMERAL_DISKS[@]}"
+	;;
 esac

--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -90,11 +90,11 @@ EOF
 
   BIND_MOUNTS=()
 
-  if [ "${BIND_KUBELET}" = true ]; then
+  if [[ "${BIND_KUBELET}" == "true" ]]; then
     BIND_MOUNTS+=("kubelet")
   fi
 
-  if [ "${BIND_CONTAINERD}" = true ]; then
+  if [[ "${BIND_CONTAINERD}" == "true" ]]; then
     BIND_MOUNTS+=("containerd")
   fi
 
@@ -110,7 +110,7 @@ EOF
   done
 
   ## Check if /var/log/pods has been bind mounted and make sure kubelet is stopped
-  if [[ "${BIND_VAR_LOG_PODS}" = true ]]; then
+  if [[ "${BIND_VAR_LOG_PODS}" == "true" ]]; then
     if [[ "$(systemctl is-active var-log-pods.mount)" != "active" ]]; then
       if systemctl is-active "kubelet" > /dev/null 2>&1; then
         prev_running+=" ${unit}"
@@ -185,9 +185,9 @@ EOF
 
 ## Main logic
 MNT_DIR="/mnt/k8s-disks"
-BIND_KUBELET=true
-BIND_CONTAINERD=true
-BIND_VAR_LOG_PODS=true
+BIND_KUBELET="true"
+BIND_CONTAINERD="true"
+BIND_VAR_LOG_PODS="true"
 
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -202,21 +202,21 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --no-bind-kubelet)
-      BIND_KUBELET=false
+      BIND_KUBELET="false"
       shift
       ;;
     --no-bind-containerd)
-      BIND_CONTAINERD=false
+      BIND_CONTAINERD="false"
       shift
       ;;
     --no-bind-pods-logs)
-      BIND_VAR_LOG_PODS=false
+      BIND_VAR_LOG_PODS="false"
       shift
       ;;
     --no-bind-mounts)
-      BIND_KUBELET=false
-      BIND_CONTAINERD=false
-      BIND_VAR_LOG_PODS=false
+      BIND_KUBELET="false"
+      BIND_CONTAINERD="false"
+      BIND_VAR_LOG_PODS="false"
       shift
       ;;
     *)                   # unknown option

--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -97,7 +97,7 @@ EOF
     BIND_MOUNTS+=("containerd")
   fi
 
-  for unit in "kubelet" "${BIND_MOUNTS[@]}"; do
+  for unit in "${BIND_MOUNTS[@]}"; do
     ## Check if the bind mount from the RAID already exists
     if [[ "$(systemctl is-active var-lib-${unit}.mount)" != "active" ]]; then
       # Check if components that depend on the RAID are running and, if so, stop them

--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -19,6 +19,9 @@ print_help() {
   echo "Sets up Amazon EC2 Instance Store NVMe disks"
   echo ""
   echo "-d, --dir directory to mount the filesystem(s) (default: /mnt/k8s-disks/)"
+  echo "--no-bind-kubelet disable bind mounting kubelet dir onto MD raid device"
+  echo "--no-bind-containerd disable bind mounting containerd dir onto MD raid device"
+  echo "--no-bind-pod-logs disable bind mounting /var/log/pods onto MD raid device"
   echo "-h, --help print this help"
 }
 
@@ -83,7 +86,18 @@ EOF
 
   prev_running=""
   needs_linked=""
-  for unit in "kubelet" "containerd"; do
+
+  BIND_MOUNTS=()                                                                                                                                                                                                                      
+                                                                                                                                                                                                                                      
+  if [ "${BIND_KUBELET}" = true ]; then                                                                                                                                                                                               
+      BIND_MOUNTS+=("kubelet")                                                                                                                                                                                                        
+  fi                                                                                                                                                                                                                                  
+                                                                                                                                                                                                                                      
+  if [ "${BIND_CONTAINERD}" = true ]; then                                                                                                                                                                                            
+      BIND_MOUNTS+=("containerd")                                                                                                                                                                                                     
+  fi  
+
+  for unit in "kubelet" "${BIND_MOUNTS[@]}"; do
     ## Check if the bind mount from the RAID already exists
     if [[ "$(systemctl is-active var-lib-${unit}.mount)" != "active" ]]; then
       # Check if components that depend on the RAID are running and, if so, stop them
@@ -95,11 +109,13 @@ EOF
   done
 
   ## Check if /var/log/pods has been bind mounted and make sure kubelet is stopped
-  if [[ "$(systemctl is-active var-log-pods.mount)" != "active" ]]; then
-    if systemctl is-active "kubelet" > /dev/null 2>&1; then
-      prev_running+=" ${unit}"
+  if [[ "${BIND_VAR_LOG_PODS}" = true ]]; then
+    if [[ "$(systemctl is-active var-log-pods.mount)" != "active" ]]; then
+      if systemctl is-active "kubelet" > /dev/null 2>&1; then
+        prev_running+=" ${unit}"
+      fi
+      needs_linked+=" /var/log/pods"
     fi
-    needs_linked+=" /var/log/pods"
   fi
 
   if [[ ! -z "${prev_running}" ]]; then
@@ -168,6 +184,9 @@ EOF
 
 ## Main logic
 MNT_DIR="/mnt/k8s-disks"
+BIND_KUBELET=true                                                                                                                                                                                                                       
+BIND_CONTAINERD=true                                                                                                                                                                                                                    
+BIND_VAR_LOG_PODS=true  
 
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -181,6 +200,18 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    --no-bind-kubelet)                                                                                                                                                                                                                  
+        BIND_KUBELET=false                                                                                                                                                                                                              
+        shift                                                                                                                                                                                                                           
+        ;;                                                                                                                                                                                                                              
+    --no-bind-containerd)                                                                                                                                                                                                               
+        BIND_CONTAINERD=false                                                                                                                                                                                                           
+        shift                                                                                                                                                                                                                           
+        ;;                                                                                                                                                                                                                              
+    --no-bind-pods-logs)                                                                                                                                                                                                                
+        BIND_VAR_LOG_PODS=false                                                                                                                                                                                                         
+        shift                                                                                                                                                                                                                           
+        ;; 
     *)                   # unknown option
       POSITIONAL+=("$1") # save it in an array for later
       shift              # past argument

--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -113,7 +113,7 @@ EOF
   if [[ "${BIND_VAR_LOG_PODS}" == "true" ]]; then
     if [[ "$(systemctl is-active var-log-pods.mount)" != "active" ]]; then
       if systemctl is-active "kubelet" > /dev/null 2>&1; then
-        prev_running+=" ${unit}"
+        prev_running+=" kubelet"
       fi
       needs_linked+=" /var/log/pods"
     fi

--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -5,24 +5,24 @@ set -o pipefail
 set -o nounset
 
 if [ "$(id --user)" -ne 0 ]; then
-	echo "Must be run as root"
-	exit 1
+  echo "Must be run as root"
+  exit 1
 fi
 
 err_report() {
-	echo "Exited with error on line $1"
+  echo "Exited with error on line $1"
 }
 trap 'err_report $LINENO' ERR
 
 print_help() {
-	echo "usage: $0 <raid0 | mount | none>"
-	echo "Sets up Amazon EC2 Instance Store NVMe disks"
-	echo ""
-	echo "-d, --dir directory to mount the filesystem(s) (default: /mnt/k8s-disks/)"
-	echo "--no-bind-kubelet disable bind mounting kubelet dir onto MD raid device"
-	echo "--no-bind-containerd disable bind mounting containerd dir onto MD raid device"
-	echo "--no-bind-pods-logs disable bind mounting /var/log/pods onto MD raid device"
-	echo "-h, --help print this help"
+  echo "usage: $0 <raid0 | mount | none>"
+  echo "Sets up Amazon EC2 Instance Store NVMe disks"
+  echo ""
+  echo "-d, --dir directory to mount the filesystem(s) (default: /mnt/k8s-disks/)"
+  echo "--no-bind-kubelet disable bind mounting kubelet dir onto MD raid device"
+  echo "--no-bind-containerd disable bind mounting containerd dir onto MD raid device"
+  echo "--no-bind-pods-logs disable bind mounting /var/log/pods onto MD raid device"
+  echo "-h, --help print this help"
 }
 
 # Sets up a RAID-0 of NVMe instance storage disks, moves
@@ -30,47 +30,47 @@ print_help() {
 # to the new mounted RAID, and bind mounts the kubelet and
 # containerd state directories.
 maybe_raid0() {
-	local md_name="kubernetes"
-	local md_device="/dev/md/${md_name}"
-	local md_config="/.aws/mdadm.conf"
-	local array_mount_point="${MNT_DIR}/0"
-	mkdir -p "$(dirname "${md_config}")"
+  local md_name="kubernetes"
+  local md_device="/dev/md/${md_name}"
+  local md_config="/.aws/mdadm.conf"
+  local array_mount_point="${MNT_DIR}/0"
+  mkdir -p "$(dirname "${md_config}")"
 
-	if [[ ! -s "${md_config}" ]]; then
-		mdadm --create --force --verbose \
-			"${md_device}" \
-			--level=0 \
-			--name="${md_name}" \
-			--raid-devices="${#EPHEMERAL_DISKS[@]}" \
-			"${EPHEMERAL_DISKS[@]}"
-		while [ -n "$(mdadm --detail "${md_device}" | grep -ioE 'State :.*resyncing')" ]; do
-			echo "Raid is resyncing..."
-			sleep 1
-		done
-		mdadm --detail --scan >"${md_config}"
-	fi
+  if [[ ! -s "${md_config}" ]]; then
+    mdadm --create --force --verbose \
+      "${md_device}" \
+      --level=0 \
+      --name="${md_name}" \
+      --raid-devices="${#EPHEMERAL_DISKS[@]}" \
+      "${EPHEMERAL_DISKS[@]}"
+    while [ -n "$(mdadm --detail "${md_device}" | grep -ioE 'State :.*resyncing')" ]; do
+      echo "Raid is resyncing..."
+      sleep 1
+    done
+    mdadm --detail --scan > "${md_config}"
+  fi
 
-	## Check if the device symlink has changed on reboot to include a homehost identifier
-	local current_md_device=$(find /dev/md/ -type l -regex ".*/${md_name}_?[0-9a-z]*$" | tail -n1)
-	if [[ ! -z ${current_md_device} ]]; then
-		md_device="${current_md_device}"
-	fi
+  ## Check if the device symlink has changed on reboot to include a homehost identifier
+  local current_md_device=$(find /dev/md/ -type l -regex ".*/${md_name}_?[0-9a-z]*$" | tail -n1)
+  if [[ ! -z ${current_md_device} ]]; then
+    md_device="${current_md_device}"
+  fi
 
-	# Format the array if not already formatted.
-	if [[ -z "$(lsblk "${md_device}" -o fstype --noheadings)" ]]; then
-		## By default, mkfs tries to use the stripe unit of the array (512k),
-		## for the log stripe unit, but the max log stripe unit is 256k.
-		## So instead, we use 32k (8 blocks) to avoid a warning of breaching the max.
-		## mkfs.xfs defaults to 32k after logging the warning since the default log buffer size is 32k.
-		mkfs.xfs -l su=8b "${md_device}"
-	fi
+  # Format the array if not already formatted.
+  if [[ -z "$(lsblk "${md_device}" -o fstype --noheadings)" ]]; then
+    ## By default, mkfs tries to use the stripe unit of the array (512k),
+    ## for the log stripe unit, but the max log stripe unit is 256k.
+    ## So instead, we use 32k (8 blocks) to avoid a warning of breaching the max.
+    ## mkfs.xfs defaults to 32k after logging the warning since the default log buffer size is 32k.
+    mkfs.xfs -l su=8b "${md_device}"
+  fi
 
-	## Create the mount directory
-	mkdir -p "${array_mount_point}"
+  ## Create the mount directory
+  mkdir -p "${array_mount_point}"
 
-	local dev_uuid=$(blkid -s UUID -o value "${md_device}")
-	local mount_unit_name="$(systemd-escape --path --suffix=mount "${array_mount_point}")"
-	cat >"/etc/systemd/system/${mount_unit_name}" <<EOF
+  local dev_uuid=$(blkid -s UUID -o value "${md_device}")
+  local mount_unit_name="$(systemd-escape --path --suffix=mount "${array_mount_point}")"
+  cat > "/etc/systemd/system/${mount_unit_name}" << EOF
   [Unit]
   Description=Mount EC2 Instance Store NVMe disk RAID0
   [Mount]
@@ -81,56 +81,56 @@ maybe_raid0() {
   [Install]
   WantedBy=multi-user.target
 EOF
-	systemd-analyze verify "${mount_unit_name}"
-	systemctl enable "${mount_unit_name}" --now
+  systemd-analyze verify "${mount_unit_name}"
+  systemctl enable "${mount_unit_name}" --now
 
-	prev_running=""
-	needs_linked=""
+  prev_running=""
+  needs_linked=""
 
-	BIND_MOUNTS=()
+  BIND_MOUNTS=()
 
-	if [ "${BIND_KUBELET}" = true ]; then
-		BIND_MOUNTS+=("kubelet")
-	fi
+  if [ "${BIND_KUBELET}" = true ]; then
+    BIND_MOUNTS+=("kubelet")
+  fi
 
-	if [ "${BIND_CONTAINERD}" = true ]; then
-		BIND_MOUNTS+=("containerd")
-	fi
+  if [ "${BIND_CONTAINERD}" = true ]; then
+    BIND_MOUNTS+=("containerd")
+  fi
 
-	for unit in "kubelet" "${BIND_MOUNTS[@]}"; do
-		## Check if the bind mount from the RAID already exists
-		if [[ "$(systemctl is-active var-lib-${unit}.mount)" != "active" ]]; then
-			# Check if components that depend on the RAID are running and, if so, stop them
-			if systemctl is-active "${unit}" >/dev/null 2>&1; then
-				prev_running+=" ${unit}"
-			fi
-			needs_linked+=" /var/lib/${unit}"
-		fi
-	done
+  for unit in "kubelet" "${BIND_MOUNTS[@]}"; do
+    ## Check if the bind mount from the RAID already exists
+    if [[ "$(systemctl is-active var-lib-${unit}.mount)" != "active" ]]; then
+      # Check if components that depend on the RAID are running and, if so, stop them
+      if systemctl is-active "${unit}" > /dev/null 2>&1; then
+        prev_running+=" ${unit}"
+      fi
+      needs_linked+=" /var/lib/${unit}"
+    fi
+  done
 
-	## Check if /var/log/pods has been bind mounted and make sure kubelet is stopped
-	if [[ "${BIND_VAR_LOG_PODS}" = true ]]; then
-		if [[ "$(systemctl is-active var-log-pods.mount)" != "active" ]]; then
-			if systemctl is-active "kubelet" >/dev/null 2>&1; then
-				prev_running+=" ${unit}"
-			fi
-			needs_linked+=" /var/log/pods"
-		fi
-	fi
+  ## Check if /var/log/pods has been bind mounted and make sure kubelet is stopped
+  if [[ "${BIND_VAR_LOG_PODS}" = true ]]; then
+    if [[ "$(systemctl is-active var-log-pods.mount)" != "active" ]]; then
+      if systemctl is-active "kubelet" > /dev/null 2>&1; then
+        prev_running+=" ${unit}"
+      fi
+      needs_linked+=" /var/log/pods"
+    fi
+  fi
 
-	if [[ ! -z "${prev_running}" ]]; then
-		systemctl stop ${prev_running}
-	fi
+  if [[ ! -z "${prev_running}" ]]; then
+    systemctl stop ${prev_running}
+  fi
 
-	# Transfer state directories to the array, if they exist.
-	for mount_point in ${needs_linked}; do
-		local unit="$(basename "${mount_point}")"
-		local array_mount_point_unit="${array_mount_point}/${unit}"
-		mkdir -p "${mount_point}"
-		echo "Copying ${mount_point}/ to ${array_mount_point_unit}/"
-		cp -a "${mount_point}/" "${array_mount_point_unit}/"
-		local mount_unit_name="$(systemd-escape --path --suffix=mount "${mount_point}")"
-		cat >"/etc/systemd/system/${mount_unit_name}" <<EOF
+  # Transfer state directories to the array, if they exist.
+  for mount_point in ${needs_linked}; do
+    local unit="$(basename "${mount_point}")"
+    local array_mount_point_unit="${array_mount_point}/${unit}"
+    mkdir -p "${mount_point}"
+    echo "Copying ${mount_point}/ to ${array_mount_point_unit}/"
+    cp -a "${mount_point}/" "${array_mount_point_unit}/"
+    local mount_unit_name="$(systemd-escape --path --suffix=mount "${mount_point}")"
+    cat > "/etc/systemd/system/${mount_unit_name}" << EOF
       [Unit]
       Description=Mount ${unit} on EC2 Instance Store NVMe RAID0
       [Mount]
@@ -141,31 +141,31 @@ EOF
       [Install]
       WantedBy=multi-user.target
 EOF
-		systemd-analyze verify "${mount_unit_name}"
-		systemctl enable "${mount_unit_name}" --now
-	done
+    systemd-analyze verify "${mount_unit_name}"
+    systemctl enable "${mount_unit_name}" --now
+  done
 
-	if [[ ! -z "${prev_running}" ]]; then
-		systemctl start ${prev_running}
-	fi
+  if [[ ! -z "${prev_running}" ]]; then
+    systemctl start ${prev_running}
+  fi
 }
 
 # Mounts and creates xfs file systems on all EC2 instance store NVMe disks
 # without existing file systems. Mounts in /mnt/k8s-disks/{1..} by default
 maybe_mount() {
-	idx=1
-	for dev in "${EPHEMERAL_DISKS[@]}"; do
-		if [[ -z "$(lsblk "${dev}" -o fstype --noheadings)" ]]; then
-			mkfs.xfs -l su=8b "${dev}"
-		fi
-		if [[ ! -z "$(lsblk "${dev}" -o MOUNTPOINT --noheadings)" ]]; then
-			echo "${dev} is already mounted."
-			continue
-		fi
-		local mount_point="${MNT_DIR}/${idx}"
-		local mount_unit_name="$(systemd-escape --path --suffix=mount "${mount_point}")"
-		mkdir -p "${mount_point}"
-		cat >"/etc/systemd/system/${mount_unit_name}" <<EOF
+  idx=1
+  for dev in "${EPHEMERAL_DISKS[@]}"; do
+    if [[ -z "$(lsblk "${dev}" -o fstype --noheadings)" ]]; then
+      mkfs.xfs -l su=8b "${dev}"
+    fi
+    if [[ ! -z "$(lsblk "${dev}" -o MOUNTPOINT --noheadings)" ]]; then
+      echo "${dev} is already mounted."
+      continue
+    fi
+    local mount_point="${MNT_DIR}/${idx}"
+    local mount_unit_name="$(systemd-escape --path --suffix=mount "${mount_point}")"
+    mkdir -p "${mount_point}"
+    cat > "/etc/systemd/system/${mount_unit_name}" << EOF
     [Unit]
     Description=Mount EC2 Instance Store NVMe disk ${idx}
     [Mount]
@@ -176,10 +176,10 @@ maybe_mount() {
     [Install]
     WantedBy=multi-user.target
 EOF
-		systemd-analyze verify "${mount_unit_name}"
-		systemctl enable "${mount_unit_name}" --now
-		idx=$((idx + 1))
-	done
+    systemd-analyze verify "${mount_unit_name}"
+    systemctl enable "${mount_unit_name}" --now
+    idx=$((idx + 1))
+  done
 }
 
 ## Main logic
@@ -189,34 +189,34 @@ BIND_CONTAINERD=true
 BIND_VAR_LOG_PODS=true
 
 while [[ $# -gt 0 ]]; do
-	key="$1"
-	case $key in
-	-h | --help)
-		print_help
-		exit 0
-		;;
-	-d | --dir)
-		MNT_DIR="$2"
-		shift
-		shift
-		;;
-	--no-bind-kubelet)
-		BIND_KUBELET=false
-		shift
-		;;
-	--no-bind-containerd)
-		BIND_CONTAINERD=false
-		shift
-		;;
-	--no-bind-pods-logs)
-		BIND_VAR_LOG_PODS=false
-		shift
-		;;
-	*)                  # unknown option
-		POSITIONAL+=("$1") # save it in an array for later
-		shift              # past argument
-		;;
-	esac
+  key="$1"
+  case $key in
+    -h | --help)
+      print_help
+      exit 0
+      ;;
+    -d | --dir)
+      MNT_DIR="$2"
+      shift
+      shift
+      ;;
+    --no-bind-kubelet)
+      BIND_KUBELET=false
+      shift
+      ;;
+    --no-bind-containerd)
+      BIND_CONTAINERD=false
+      shift
+      ;;
+    --no-bind-pods-logs)
+      BIND_VAR_LOG_PODS=false
+      shift
+      ;;
+    *)                   # unknown option
+      POSITIONAL+=("$1") # save it in an array for later
+      shift              # past argument
+      ;;
+  esac
 done
 
 set +u
@@ -225,37 +225,37 @@ DISK_SETUP="$1"
 set -u
 
 if [[ "${DISK_SETUP}" != "raid0" && "${DISK_SETUP}" != "mount" && "${DISK_SETUP}" != "none" ]]; then
-	echo "Valid disk setup options are: raid0, mount, or none"
-	exit 1
+  echo "Valid disk setup options are: raid0, mount, or none"
+  exit 1
 fi
 
 if [ "${DISK_SETUP}" = "none" ]; then
-	"disk setup is 'none', nothing to do!"
-	exit 0
+  "disk setup is 'none', nothing to do!"
+  exit 0
 fi
 
 if [ ! -d /dev/disk/by-id/ ]; then
-	echo "no ephemeral disks found!"
-	exit 0
+  echo "no ephemeral disks found!"
+  exit 0
 fi
 
 disks=($(find -L /dev/disk/by-id/ -xtype l -name '*NVMe_Instance_Storage_*'))
 ## Bail early if there are no ephemeral disks to setup
 if [[ "${#disks[@]}" -eq 0 ]]; then
-	echo "no NVMe instance storage disks found!"
-	exit 0
+  echo "no NVMe instance storage disks found!"
+  exit 0
 fi
 
 ## Get devices of NVMe instance storage ephemeral disks
 EPHEMERAL_DISKS=($(realpath "${disks[@]}" | sort -u))
 
 case "${DISK_SETUP}" in
-"raid0")
-	maybe_raid0
-	echo "Successfully setup RAID-0 consisting of ${EPHEMERAL_DISKS[@]}"
-	;;
-"mount")
-	maybe_mount
-	echo "Successfully setup disk mounts consisting of ${EPHEMERAL_DISKS[@]}"
-	;;
+  "raid0")
+    maybe_raid0
+    echo "Successfully setup RAID-0 consisting of ${EPHEMERAL_DISKS[@]}"
+    ;;
+  "mount")
+    maybe_mount
+    echo "Successfully setup disk mounts consisting of ${EPHEMERAL_DISKS[@]}"
+    ;;
 esac

--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -22,6 +22,7 @@ print_help() {
   echo "--no-bind-kubelet disable bind mounting kubelet dir onto MD raid device"
   echo "--no-bind-containerd disable bind mounting containerd dir onto MD raid device"
   echo "--no-bind-pods-logs disable bind mounting /var/log/pods onto MD raid device"
+  echo "--no-bind-mounts disable all bind mounting onto MD raid device, only create and mount MD device"
   echo "-h, --help print this help"
 }
 
@@ -209,6 +210,12 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --no-bind-pods-logs)
+      BIND_VAR_LOG_PODS=false
+      shift
+      ;;
+    --no-bind-mounts)
+      BIND_KUBELET=false
+      BIND_CONTAINERD=false
       BIND_VAR_LOG_PODS=false
       shift
       ;;


### PR DESCRIPTION
**Issue #, if available:** #1706

**Description of changes:**

Add flags to the setup-local-disks script so that bind mounting of individual components onto the MD raid device can be disabled 

```
--no-bind-kubelet disable bind mounting kubelet dir onto MD raid device
--no-bind-containerd disable bind mounting containerd dir onto MD raid device
--no-bind-pods-logs disable bind mounting /var/log/pods onto MD raid device
--no-bind-mounts disable all bind mounting 
```

* Keep default behaviour same as now, all are bind mounted 
* Allow disabling all or only some of the bind mounts


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Details in https://github.com/awslabs/amazon-eks-ami/pull/1723#issuecomment-1999475547 

In order to test without creating an AMI i added the script from this PR as `userData` to a karpenter `ec2nodeclass` and run it with the multiple options 

The only part that was not tested is the `cli parsing of the flags` 

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
