### PR TITLE
support os_distro and version for CI job

### DIFF
--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -25,9 +25,18 @@ on:
         options:
           - "build"
           - "test"
+      os_distro:
+        description: 'Operating System Distributions (comma-separated, e.g., al2,al2023)'
+        required: false
+        type: string
+      kubernetes_versions:
+        description: 'Kubernetes Versions (comma-separated, e.g., 1.21,1.22)'
+        required: false
+        type: string
       build_arguments:
         required: false
         type: string
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -37,17 +46,16 @@ jobs:
       kubernetes_versions: ${{ steps.variables.outputs.kubernetes_versions }}
       build_id: ${{ steps.variables.outputs.build_id }}
       ci_step_name_prefix: ${{ steps.variables.outputs.ci_step_name_prefix }}
+      os_distro: ${{ steps.variables.outputs.os_distro }}
     steps:
     - id: variables
       run: |
         echo "git_sha_short=$(echo ${{ inputs.git_sha }} | rev | cut -c-7 | rev)" >> $GITHUB_OUTPUT
         echo "workflow_run_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
-        # grab supported versions directly from eksctl
-        wget --no-verbose -O eksctl.tar.gz "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz"
-        tar xzf eksctl.tar.gz && chmod +x ./eksctl
-        echo "kubernetes_versions=$(./eksctl version --output json | jq -c .EKSServerSupportedVersions)" >> $GITHUB_OUTPUT
         echo "build_id=ci-${{ inputs.pr_number }}-${{ needs.setup.outputs.git_sha_short }}-${{ inputs.uuid }}" >> $GITHUB_OUTPUT
         echo 'ci_step_name_prefix=CI:' >> $GITHUB_OUTPUT
+        echo "kubernetes_versions=$(jq -Rn --arg input '${{ inputs.kubernetes_versions }}' '($input | split(","))' | jq -c .)" >> $GITHUB_OUTPUT
+        echo "os_distro=$(jq -Rn --arg input '${{ inputs.os_distro }}' '($input | split(","))' | jq -c .)" >> $GITHUB_OUTPUT
 
   notify-start:
     runs-on: ubuntu-latest
@@ -77,7 +85,12 @@ jobs:
       fail-fast: false
       matrix:
         k8s_version: ${{ fromJson(needs.setup.outputs.kubernetes_versions) }}
-        os_distro: [al2, al2023]
+        os_distro: ${{ fromJson(needs.setup.outputs.os_distro) }}
+        exclude:
+          - os_distro: al2023
+            k8s_version: 1.21
+          - os_distro: al2023
+            k8s_version: 1.22
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -25,12 +25,14 @@ on:
         options:
           - "build"
           - "test"
-      os_distro:
+      os_distros:
         description: 'Operating System Distributions (comma-separated, e.g., al2,al2023)'
+        default: "al2,al2023"
         required: false
         type: string
-      kubernetes_versions:
+      k8s_versions:
         description: 'Kubernetes Versions (comma-separated, e.g., 1.21,1.22)'
+        default: "1.21,1.22,1.23,1.24,1.25,1.26,1.27,1.28,1.29"
         required: false
         type: string
       build_arguments:
@@ -46,7 +48,7 @@ jobs:
       kubernetes_versions: ${{ steps.variables.outputs.kubernetes_versions }}
       build_id: ${{ steps.variables.outputs.build_id }}
       ci_step_name_prefix: ${{ steps.variables.outputs.ci_step_name_prefix }}
-      os_distro: ${{ steps.variables.outputs.os_distro }}
+      os_distros: ${{ steps.variables.outputs.os_distros }}
     steps:
     - id: variables
       run: |
@@ -54,8 +56,8 @@ jobs:
         echo "workflow_run_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
         echo "build_id=ci-${{ inputs.pr_number }}-${{ needs.setup.outputs.git_sha_short }}-${{ inputs.uuid }}" >> $GITHUB_OUTPUT
         echo 'ci_step_name_prefix=CI:' >> $GITHUB_OUTPUT
-        echo "kubernetes_versions=$(jq -Rn --arg input '${{ inputs.kubernetes_versions }}' '($input | split(","))' | jq -c .)" >> $GITHUB_OUTPUT
-        echo "os_distro=$(jq -Rn --arg input '${{ inputs.os_distro }}' '($input | split(","))' | jq -c .)" >> $GITHUB_OUTPUT
+        echo "kubernetes_versions=$(jq -Rn --arg input '${{ inputs.k8s_versions }}' '($input | split(","))' | jq -c .)" >> $GITHUB_OUTPUT
+        echo "os_distros=$(jq -Rn --arg input '${{ inputs.os_distros }}' '($input | split(","))' | jq -c .)" >> $GITHUB_OUTPUT
 
   notify-start:
     runs-on: ubuntu-latest
@@ -85,7 +87,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s_version: ${{ fromJson(needs.setup.outputs.kubernetes_versions) }}
-        os_distro: ${{ fromJson(needs.setup.outputs.os_distro) }}
+        os_distro: ${{ fromJson(needs.setup.outputs.os_distros) }}
+        # al2023 is not supporting 1.22 and below, exclude them from CI
         exclude:
           - os_distro: al2023
             k8s_version: 1.21


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Extend the CI job to accept os_distro and version to be frugal 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Tested in my folk https://github.com/Issacwww/amazon-eks-ami/pull/3

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
