### PR TITLE
bump kernel in AL2 to 5.10 for rest of k8s versions

### DIFF
--- a/templates/al2/provisioners/upgrade-kernel.sh
+++ b/templates/al2/provisioners/upgrade-kernel.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o errexit
 
 if [[ -z "$KERNEL_VERSION" ]]; then
-  if vercmp "$KUBERNETES_VERSION" gteq "1.24.0"; then
+  if vercmp "$KUBERNETES_VERSION" gteq "1.23.0"; then
     KERNEL_VERSION=5.10
   else
     KERNEL_VERSION=5.4

--- a/templates/al2/provisioners/upgrade-kernel.sh
+++ b/templates/al2/provisioners/upgrade-kernel.sh
@@ -5,11 +5,7 @@ set -o nounset
 set -o errexit
 
 if [[ -z "$KERNEL_VERSION" ]]; then
-  if vercmp "$KUBERNETES_VERSION" gteq "1.23.0"; then
-    KERNEL_VERSION=5.10
-  else
-    KERNEL_VERSION=5.4
-  fi
+  KERNEL_VERSION=5.10
   echo "kernel_version is unset. Setting to $KERNEL_VERSION based on Kubernetes version $KUBERNETES_VERSION."
 fi
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Bumping the kernel version to 5.10 across the board. newer kernel versions have already been released in GPU variants even on 1.23, so there is little foreseeable risk here

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
