### PR TITLE
make 80-ec2.network match primary eni only

### DIFF
--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -84,6 +84,7 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 
 	aspects := []system.SystemAspect{
 		system.NewLocalDiskAspect(),
+		system.NewNetworkingAspect(),
 	}
 
 	daemons := []daemon.Daemon{

--- a/nodeadm/internal/system/_assets/10-eks_primary_eni_only.conf.template
+++ b/nodeadm/internal/system/_assets/10-eks_primary_eni_only.conf.template
@@ -1,0 +1,2 @@
+[Match]
+PermanentMACAddress={{.PermanentMACAddress}}

--- a/nodeadm/internal/system/_assets/test_10-eks_primary_eni_only.conf
+++ b/nodeadm/internal/system/_assets/test_10-eks_primary_eni_only.conf
@@ -1,0 +1,2 @@
+[Match]
+PermanentMACAddress=0e:f7:72:74:2d:43

--- a/nodeadm/internal/system/networking.go
+++ b/nodeadm/internal/system/networking.go
@@ -1,0 +1,116 @@
+package system
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
+	"go.uber.org/zap"
+	"os"
+	"os/exec"
+	"text/template"
+)
+
+const (
+	networkingAspectName = "networking"
+	// The local administration network directory for systemd.network
+	administrationNetworkDir = "/etc/systemd/network"
+	// the name of ec2 network configuration setup by amazon-ec2-net-utils:
+	// https://github.com/amazonlinux/amazon-ec2-net-utils/blob/c6626fb5cd094bbfeb62c456fe088011dbab3f95/systemd/network/80-ec2.network
+	ec2NetworkConfigurationName = "80-ec2.network"
+	eksPrimaryENIOnlyConfName   = "10-eks_primary_eni_only.conf"
+	networkConfDropInDirPerms   = 0755
+	networkConfFilePerms        = 0644
+)
+
+var (
+	//go:embed _assets/10-eks_primary_eni_only.conf.template
+	eksPrimaryENIOnlyConfTemplateData string
+	eksPrimaryENIOnlyConfTemplate     = template.Must(template.New(eksPrimaryENIOnlyConfName).Parse(eksPrimaryENIOnlyConfTemplateData))
+)
+
+// NewNetworkingAspect constructs new networkingAspect.
+func NewNetworkingAspect() *networkingAspect {
+	return &networkingAspect{}
+}
+
+var _ SystemAspect = &networkingAspect{}
+
+// networkingAspect setups eks-specific networking configurations.
+type networkingAspect struct{}
+
+// Name returns the name of this aspect.
+func (a *networkingAspect) Name() string {
+	return networkingAspectName
+}
+
+// Setup executes the logic of this aspect.
+func (a *networkingAspect) Setup(cfg *api.NodeConfig) error {
+	if err := a.ensureEKSNetworkConfiguration(cfg); err != nil {
+		return fmt.Errorf("failed to ensure eks network configuration: %w", err)
+	}
+	return nil
+}
+
+// ensureEKSNetworkConfiguration will install eks specific network configuration into system.
+// NOTE: this is a temporary fix for AL2023, where the `80-ec2.network` setup by amazon-ec2-net-utils will cause systemd.network
+// to manage all ENIs on host, and that can potentially result in multiple issues including:
+//  1. systemd.network races against vpc-cni to configure secondary enis and might cause routing rules/routes setup by vpc-cni to be flushed resulting in issues with pod networking.
+//  2. routes for those secondary ENIs obtained from dhcp will appear in main route table, which is a drift from our AL2 behavior.
+//
+// To address this issue temporarily, we use drop-ins to alter configuration of `80-ec2.network` after boot to make it match against primary ENI only.
+// TODO: there are limitations on current solutions as well, and we should figure long term solution for this:
+//  1. the altNames for ENIs(a new feature in AL2023) were setup by amazon-ec2-net-utils via udev rules, but it's disabled by eks.
+func (a *networkingAspect) ensureEKSNetworkConfiguration(cfg *api.NodeConfig) error {
+	networkCfgDropInDir := fmt.Sprintf("%s/%s.d", administrationNetworkDir, ec2NetworkConfigurationName)
+	eksPrimaryENIOnlyConfPathName := fmt.Sprintf("%s/%s", networkCfgDropInDir, eksPrimaryENIOnlyConfName)
+	if exists, err := util.IsFilePathExists(eksPrimaryENIOnlyConfPathName); err != nil {
+		return fmt.Errorf("failed to check eks_primary_eni_only network configuration existance: %w", err)
+	} else if exists {
+		zap.L().Info("eks_primary_eni_only network configuration already exists, skipping configuration")
+		return nil
+	}
+
+	eksPrimaryENIOnlyConfContent, err := a.generateEKSPrimaryENIOnlyConfiguration(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to generate eks_primary_eni_only network configuration: %w", err)
+	}
+	zap.L().Info("writing eks_primary_eni_only network configuration")
+	if err := os.MkdirAll(networkCfgDropInDir, networkConfDropInDirPerms); err != nil {
+		return fmt.Errorf("failed to create network configuration drop-in directory %s: %w", networkCfgDropInDir, err)
+	}
+	if err := os.WriteFile(eksPrimaryENIOnlyConfPathName, eksPrimaryENIOnlyConfContent, networkConfFilePerms); err != nil {
+		return fmt.Errorf("failed to write eks_primary_eni_only network configuration: %w", err)
+	}
+	if err := a.reloadNetworkConfigurations(); err != nil {
+		return fmt.Errorf("failed to reload network configurations: %w", err)
+	}
+	return nil
+}
+
+// eksPrimaryENIOnlyTemplateVars holds the variables for eksPrimaryENIOnlyConfTemplate
+type eksPrimaryENIOnlyTemplateVars struct {
+	PermanentMACAddress string
+}
+
+// generateEKSPrimaryENIOnlyConfiguration generates the eks primary eni only network configuration.
+func (a *networkingAspect) generateEKSPrimaryENIOnlyConfiguration(cfg *api.NodeConfig) ([]byte, error) {
+	primaryENIMac := cfg.Status.Instance.MAC
+	templateVars := eksPrimaryENIOnlyTemplateVars{
+		PermanentMACAddress: primaryENIMac,
+	}
+
+	var buf bytes.Buffer
+	if err := eksPrimaryENIOnlyConfTemplate.Execute(&buf, templateVars); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (a *networkingAspect) reloadNetworkConfigurations() error {
+	cmd := exec.Command("networkctl", "reload")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/nodeadm/internal/system/networking_test.go
+++ b/nodeadm/internal/system/networking_test.go
@@ -1,0 +1,51 @@
+package system
+
+import (
+	_ "embed"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"reflect"
+	"testing"
+)
+
+//go:embed _assets/test_10-eks_primary_eni_only.conf
+var testEKSPrimaryENIOnlyConfTemplateData []byte
+
+func Test_networkingAspect_generateEKSPrimaryENIOnlyConfiguration(t *testing.T) {
+	type args struct {
+		cfg *api.NodeConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "mac is 0e:f7:72:74:2d:43",
+			args: args{
+				cfg: &api.NodeConfig{
+					Status: api.NodeConfigStatus{
+						Instance: api.InstanceDetails{
+							MAC: "0e:f7:72:74:2d:43",
+						},
+					},
+				},
+			},
+			want:    testEKSPrimaryENIOnlyConfTemplateData,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &networkingAspect{}
+			got, err := a.generateEKSPrimaryENIOnlyConfiguration(tt.args.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("generateEKSPrimaryENIOnlyConfiguration() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("generateEKSPrimaryENIOnlyConfiguration() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/nodeadm/internal/util/files.go
+++ b/nodeadm/internal/util/files.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"path"
@@ -13,4 +14,16 @@ func WriteFileWithDir(filePath string, data []byte, perm fs.FileMode) error {
 		return err
 	}
 	return os.WriteFile(filePath, data, perm)
+}
+
+// IsFilePathExists checks whether specific file path exists
+func IsFilePathExists(filePath string) (bool, error) {
+	_, err := os.Stat(filePath)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
 }


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Override the default `80-ec2.network` generated by amazon-ec2-net-utils to make systemd.network manage primary ENI only.
After this change, the sequence is as follows:
1. during initial boot, the `80-ec2.network` by amazon-ec2-net-utils will match all ENIs(only primary ENI at this moment), thus systemd.network will configure them properly with DHCP.
2. the `nodeadm-run` unit will execute, which will generate a `80-ec2.network` that matches the Mac of primary ENI(from ec2-metadata) only and reload the config.
3. after kubelet init and vpc-cni runs, vpc-cni will launch new secondary ENIs as pod scheduled, and those secondary ENIs will be unmanaged per `systemd.network`.

This is a temporary fix for EKS AL2023 AMI, where the `80-ec2.network` generated by amazon-ec2-net-utils will cause systemd.network managing all ENIs on host, and caused multiple issues including:
 1. systemd.network races against vpc-cni to configure secondary enis and might cause routing rules/routes from vpc-cni been flushed.
 6. routes for those secondary enis obtained from dhcp will appear in main route table, which is a drift from our AL2 behavior.

To address this issue temporarily, we override the `80-ec2.network` after boot to make it match against primary ENI only.
* the top-level `mac` from ec2 metadata is guaranteed to primary eni's mac and guaranteed to be available at boot according to [this code comment](https://github.com/amazonlinux/amazon-ec2-net-utils/blob/main/lib/lib.sh#L392) and internal code links.

TODOs after this PR: there are limitations on current solutions as well, and we should figure long term solution for this:
 1. the altNames for ENIs(a new feature in AL2023) were setup by amazon-ec2-net-utils via udev rules, but it's disabled by eks.
 2. the "unmanaged" ENI feature from vpc-cni is not supported, as those enis won't be setup by systemd.network.

Alternative solutions consider:
1. we considered to use a static file override to make `80-ec2.network` match `IFINDEX: 2`. However, after communications with ec2 networking, the primary ENI may not always be `IFINDEX: 2`.
2. completely remove `amazon-ec2-net-utils` and simply have the default `80-ec2.network`  into `/usr/lib/systemd/network/80-ec2.network` for initial setup. This should work as we have almost disabled all functionality of `amazon-ec2-net-utils` except this file. However, to keep things simple, i kept it as it is for now, and we can work on a long term solution later. (e.g. make changes to amazon-ec2-net-utils to let us optionally disable secondary eni management). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
Build an AMI in us-west-2: `ami-0caada624a580a108` and launched a node group with it.

#### After boot:
1. the primary ENI are configured correctly.
```
sudo networkctl list
IDX LINK  TYPE     OPERATIONAL SETUP
  1 lo    loopback carrier     unmanaged
  2 ens32 ether    routable    configured
```
2. the `/etc/systemd/network/80-ec2.network` contains correct content:
```
[Match]
Driver=ena ixgbevf vif
PermanentMACAddress=0e:3f:17:b2:ab:85
....
```
7. logs from ` journalctl -u nodeadm-run`
```
Mar 27 23:59:33 ip-192-168-80-181.us-west-2.compute.internal nodeadm[14386]: {"level":"info","ts":1711583973.9371097,"caller":"init/init.go:115","msg":"Setting up system aspect..","name":"networking"}
Mar 27 23:59:33 ip-192-168-80-181.us-west-2.compute.internal nodeadm[14386]: {"level":"info","ts":1711583973.9371312,"caller":"system/networking.go:77","msg":"writing eks network configuration"}
Mar 27 23:59:33 ip-192-168-80-181.us-west-2.compute.internal nodeadm[14386]: {"level":"info","ts":1711583973.9455516,"caller":"init/init.go:119","msg":"Set up system aspect","name":"networking"}
```
8. logs from `journalctl -u systemd-networkd`
```
Mar 27 23:59:29 localhost systemd[1]: Starting systemd-networkd.service - Network Configuration...
Mar 27 23:59:29 localhost systemd-networkd[13987]: lo: Link UP
Mar 27 23:59:29 localhost systemd-networkd[13987]: lo: Gained carrier
Mar 27 23:59:29 localhost systemd-networkd[13987]: Enumeration completed
Mar 27 23:59:29 localhost systemd[1]: Started systemd-networkd.service - Network Configuration.
Mar 27 23:59:29 localhost systemd-networkd[13987]: ens32: Configuring with /usr/lib/systemd/network/80-ec2.network.
Mar 27 23:59:29 localhost systemd-networkd[13987]: ens32: Link UP
Mar 27 23:59:29 localhost systemd-networkd[13987]: ens32: Gained carrier
Mar 27 23:59:29 localhost systemd-networkd[13987]: ens32: DHCPv4 address 192.168.80.181/19, gateway 192.168.64.1 acquired from 192.168.64.1
Mar 27 23:59:30 localhost systemd-networkd[13987]: ens32: Gained IPv6LL
Mar 27 23:59:33 ip-192-168-80-181.us-west-2.compute.internal systemd-networkd[13987]: ens32: Reconfiguring with /etc/systemd/network/80-ec2.network.
Mar 27 23:59:33 ip-192-168-80-181.us-west-2.compute.internal systemd-networkd[13987]: ens32: DHCP lease lost
Mar 27 23:59:34 ip-192-168-80-181.us-west-2.compute.internal systemd-networkd[13987]: ens32: DHCPv6 lease lost
Mar 27 23:59:34 ip-192-168-80-181.us-west-2.compute.internal systemd-networkd[13987]: ens32: DHCPv4 address 192.168.80.181/19, gateway 192.168.64.1 acquired from 192.168.64.1
```

#### After launching enough pods to node:
1. output from `sudo networkctl list`
```
IDX LINK           TYPE     OPERATIONAL SETUP
  1 lo             loopback carrier     unmanaged
  2 ens32          ether    routable    configured
  3 eniad135498da8 ether    degraded    unmanaged
  .........other veth pairs ...........
 27 eni753930387e9 ether    degraded    unmanaged
 28 ens33          ether    routable    unmanaged
```
2. output from `ip route show table main`
```
default via 192.168.64.1 dev ens32 proto dhcp src 192.168.80.181 metric 1024
192.168.0.2 via 192.168.64.1 dev ens32 proto dhcp src 192.168.80.181 metric 1024
192.168.64.0/19 dev ens32 proto kernel scope link src 192.168.80.181 metric 1024
192.168.64.1 dev ens32 proto dhcp scope link src 192.168.80.181 metric 1024
192.168.64.83 dev eniad11af0c6ea scope link
192.168.64.119 dev eni0240836f91e scope link
192.168.64.125 dev eni7058b07fc9b scope link
................
```
3. output from `ip route show table 2`
```
ip route show table 2
default via 192.168.64.1 dev ens33
192.168.64.1 dev ens33 scope link
```

#### After reboot
1. output from `journalctl -u systemd-networkd`
```
Mar 28 00:54:39 ip-192-168-80-181.us-west-2.compute.internal nodeadm[14691]: {"level":"info","ts":1711587279.0701544,"caller":"init/init.go:115","msg":"Setting up system aspect..","name":"networking"}
Mar 28 00:54:39 ip-192-168-80-181.us-west-2.compute.internal nodeadm[14691]: {"level":"info","ts":1711587279.0701854,"caller":"system/networking.go:69","msg":"eks network configuration already exists, skipping configuration"}
Mar 28 00:54:39 ip-192-168-80-181.us-west-2.compute.internal nodeadm[14691]: {"level":"info","ts":1711587279.0701997,"caller":"init/init.go:119","msg":"Set up system aspect","name":"networking"}
```
2. output from `sudo networkctl list`
```
[ec2-user@ip-192-168-80-181 ~]$ sudo networkctl list
IDX LINK           TYPE     OPERATIONAL SETUP
  1 lo             loopback carrier     unmanaged
  2 ens32          ether    routable    configured
  3 ens33          ether    routable    unmanaged
  4 eni22521b8ebbc ether    degraded    unmanaged
  5 enic0d6e878b13 ether    degraded    unmanaged
  6 enif535699d665 ether    degraded    unmanaged
....
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
