### PR TITLE
Add support to collect Windows Events relevant to Windows Containers

### DIFF
--- a/log-collector-script/windows/eks-log-collector.ps1
+++ b/log-collector-script/windows/eks-log-collector.ps1
@@ -62,6 +62,7 @@ Function create_working_dir{
         New-Item -type directory -path $info_system\containerd_log -Force >$null
         New-Item -type directory -path $info_system\network -Force >$null
         New-Item -type directory -path $info_system\network\hns -Force >$null
+        New-Item -type directory -path $info_system\events -Force >$null
         Write-Host "OK" -ForegroundColor "green"
     }
     catch {
@@ -349,6 +350,25 @@ Function get_network_info{
     }
 }
 
+Function get_windows_events{
+    try {
+        Write-Host "Collecting Windows events"
+        Copy-Item "$env:SystemDrive\Windows\System32\Winevt\Logs\Application.evtx" -Destination $info_system\events
+        Copy-Item "$env:SystemDrive\Windows\System32\Winevt\Logs\EKS.evtx" -Destination $info_system\events
+        Copy-Item "$env:SystemDrive\Windows\System32\Winevt\Logs\System.evtx" -Destination $info_system\events
+        Copy-Item "$env:SystemDrive\Windows\System32\Winevt\Logs\\Microsoft-Windows-Containers*.evtx" -Destination $info_system\events
+        Copy-Item "$env:SystemDrive\Windows\System32\Winevt\Logs\\Microsoft-Windows-Host-Network-Service*.evtx" -Destination $info_system\events
+        Copy-Item "$env:SystemDrive\Windows\System32\Winevt\Logs\\Microsoft-Windows-Hyper-V-Compute*.evtx" -Destination $info_system\events
+
+        Write-Host "OK" -ForegroundColor "green"
+    }
+    catch {
+        Write-Error "Unable to collect Windows events"
+        Break
+    }
+
+}
+
 Function cleanup{
     Write-Host "Cleaning up directory"
     Remove-Item -Recurse -Force $basedir -ErrorAction Ignore
@@ -390,7 +410,7 @@ Function collect{
     get_containerd_logs
     get_eks_logs
     get_network_info
-
+    get_windows_events
 }
 
 #--------------------------


### PR DESCRIPTION
**Issue #, if available:**
During investigation of one of EKS Windows ticket, there was challenge during co-relation of logs. This script could be improved to collect even more logs which are relevant to Windows containers.

**Description of changes:**
Following are events which will be collected as part of this PR.
1. Application - Windows Application events
2. EKS - Events related to EKS
3. System - Windows system events
4. Microsoft-Windows-Containers - Windows containers related events
5. Microsoft-Windows-Host-Network-Service - Windows Container networking events
6. Microsoft-Windows-Hyper-V-Compute - Windows container compute service events


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
1. I tested this script on both 2019 and 2022 EKS Windows AMIs. Script collected these logs as expected.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
