### PR TITLE
Fall back to previous K8s version if the latest Addons are missing

### DIFF
--- a/templates/al2/provisioners/install-worker.sh
+++ b/templates/al2/provisioners/install-worker.sh
@@ -392,7 +392,7 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
   sudo systemctl enable containerd
 
   K8S_MINOR_VERSION=$(echo "${KUBERNETES_VERSION}" | cut -d'.' -f1-2)
-  PREVIOUS_K8S_MINOR_VERSION=$(echo ${KUBERNETES_MINOR_VERSION:0:1}."$((${KUBERNETES_MINOR_VERSION:2:3} - 1))")
+  PREVIOUS_K8S_MINOR_VERSION=$(echo ${K8S_MINOR_VERSION:0:1}."$((${K8S_MINOR_VERSION:2:3} - 1))")
 
   #### Cache kube-proxy images starting with the addon default version and the latest version
   KUBE_PROXY_ADDON_VERSIONS=$(aws eks describe-addon-versions --addon-name kube-proxy --kubernetes-version=${K8S_MINOR_VERSION})


### PR DESCRIPTION
**Description of changes:**
If latest addons are not available, then we need to install the worker with the latest available.

I use the current K8s minor version to get the previous one, and after we get the Addons I check whether or not it actually got anything. If it didn't I got the prior Addons which will exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
