### PR TITLE
Retry IMDS calls on ECONNREFUSED

### DIFF
--- a/templates/al2/runtime/bin/imds
+++ b/templates/al2/runtime/bin/imds
@@ -29,6 +29,7 @@ function imdscurl() {
     --show-error \
     --output $OUTPUT_FILE \
     --write-out "%{http_code}" \
+    --retry-connrefused \
     --retry $IMDS_RETRIES \
     --retry-delay $IMDS_RETRY_DELAY_SECONDS \
     "$@" || echo "1")


### PR DESCRIPTION
**Description of changes:**

`curl` won't treat `ECONNREFUSED` as a transient error unless this flag is used.

https://curl.se/docs/manpage.html

> In addition to the other conditions, consider ECONNREFUSED as a transient error too for [--retry](https://curl.se/docs/manpage.html#--retry). This option is used together with [--retry](https://curl.se/docs/manpage.html#--retry).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
