### PR TITLE
Add bootstrap helper for GPU AMI

### DIFF
--- a/templates/al2/runtime/bootstrap.sh
+++ b/templates/al2/runtime/bootstrap.sh
@@ -629,6 +629,15 @@ Environment='KUBELET_EXTRA_ARGS=$KUBELET_EXTRA_ARGS'
 EOF
 fi
 
+# WARNING: this implementation detail is subject to change!
+# Do not use this as a way to inject behavior into this script
+BOOTSTRAP_GPU_HELPER=/etc/eks/bootstrap-gpu.sh
+if [ -x "${BOOTSTRAP_GPU_HELPER}" ]; then
+  log "INFO: starting GPU bootstrap helper..."
+  "${BOOTSTRAP_GPU_HELPER}"
+  log "INFO: completed GPU bootstrap helper!"
+fi
+
 systemctl daemon-reload
 systemctl enable kubelet
 systemctl start kubelet


### PR DESCRIPTION
**Issue #, if available:**

This is part of the fix for a race-condition occurring in the GPU, referenced in: #1744.

**Description of changes:**

We need a way to explicitly synchronize some background processes that configure GPU instances in the GPU AMI. This will run a helper script if it's present, which will perform GPU-AMI-specific actions. The helper script will only be present on GPU AMI's.

**As the code comment states, this is not intended to be a way for users to inject arbitrary logic into the bootstrap script! Don't do that.**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
