### PR TITLE
Use GitHub token when fetching Packer plugins

### DIFF
--- a/.github/actions/ci/build/action.yaml
+++ b/.github/actions/ci/build/action.yaml
@@ -27,7 +27,7 @@ runs:
     - id: build
       shell: bash
       run: |
-        packer plugins install github.com/hashicorp/amazon
+        PACKER_GITHUB_API_TOKEN="${{ github.token }}" packer plugins install github.com/hashicorp/amazon
         AMI_NAME="amazon-eks-node-${{ inputs.os_distro }}-${{ inputs.k8s_version }}-${{ inputs.build_id }}"
         make k8s=${{ inputs.k8s_version }} os_distro=${{ inputs.os_distro }} ami_name=${AMI_NAME} ${{ inputs.additional_arguments }}
         echo "ami_id=$(jq -r .builds[0].artifact_id "${AMI_NAME}-manifest.json" | cut -d ':' -f 2)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Description of changes:**

Should fix flakes like this: https://github.com/awslabs/amazon-eks-ami/actions/runs/8619723697/job/23625050672

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
