### PR TITLE
Wait for network-online to configure clocksource

### DIFF
--- a/templates/shared/runtime/configure-clocksource.service
+++ b/templates/shared/runtime/configure-clocksource.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=Configure kernel clocksource
+# the script needs to use IMDS, so wait for the network to be up
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/usr/bin/configure-clocksource


### PR DESCRIPTION
**Description of changes:**

The script that configures the clocksource needs to query the hypervisor info from IMDS. We have retries in place, but this should add some more stability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
