### PR TITLE
Add Kubernetes 1.30 to CI

### DIFF
--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -32,7 +32,7 @@ on:
         type: string
       k8s_versions:
         description: 'Kubernetes Versions (comma-separated, e.g., 1.21,1.22)'
-        default: "1.21,1.22,1.23,1.24,1.25,1.26,1.27,1.28,1.29"
+        default: "1.21,1.22,1.23,1.24,1.25,1.26,1.27,1.28,1.29,1.30"
         required: false
         type: string
       build_arguments:


### PR DESCRIPTION
**Description of changes:**

Adds 1.30 to the default k8s versions in the CI workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
