### PR TITLE
Decompress GZIP'd user data

### DIFF
--- a/nodeadm/internal/configprovider/userdata_test.go
+++ b/nodeadm/internal/configprovider/userdata_test.go
@@ -1,131 +1,283 @@
 package configprovider
 
 import (
-	"encoding/json"
+	"bytes"
+	"compress/gzip"
 	"fmt"
-	"mime/multipart"
-	"net/mail"
-	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const boundary = "#"
-const completeNodeConfig = `---
-apiVersion: node.eks.aws/v1alpha1
-kind: NodeConfig
-spec:
-  cluster:
-    name: autofill
-    apiServerEndpoint: autofill
-    certificateAuthority: ''
-    cidr: 10.100.0.0/16
-  kubelet:
-    config:
-      port: 1010
-      maxPods: 120
-    flags:
-      - --v=2
-      - --node-labels=foo=bar,nodegroup=test
-`
+func Test_decompressIfGZIP(t *testing.T) {
+	expected := []byte("hello, world!")
+	compressed, err := compressAsGZIP(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, err := decompressIfGZIP(compressed)
+	if err != nil {
+		t.Fatalf("failed to decompress GZIP: %v", err)
+	}
+	assert.Equal(t, expected, actual)
+}
 
-const partialNodeConfig = `---
-apiVersion: node.eks.aws/v1alpha1
-kind: NodeConfig
-spec:
-  kubelet:
-    config:
-      maxPods: 150
-      podsPerCore: 20
-    flags:
-      - --v=5
-      - --node-labels=foo=baz
-`
+func mustCompressAsGZIP(t *testing.T, data []byte) []byte {
+	compressedData, err := compressAsGZIP(data)
+	if err != nil {
+		t.Errorf("failed to compress as GZIP: %v", err)
+	}
+	return compressedData
+}
 
-var completeMergedWithPartial = api.NodeConfig{
-	Spec: api.NodeConfigSpec{
-		Cluster: api.ClusterDetails{
-			Name:                 "autofill",
-			APIServerEndpoint:    "autofill",
-			CertificateAuthority: []byte{},
-			CIDR:                 "10.100.0.0/16",
-		},
-		Kubelet: api.KubeletOptions{
-			Config: api.InlineDocument{
-				"maxPods":     runtime.RawExtension{Raw: []byte("150")},
-				"podsPerCore": runtime.RawExtension{Raw: []byte("20")},
-				"port":        runtime.RawExtension{Raw: []byte("1010")},
+func compressAsGZIP(data []byte) ([]byte, error) {
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	n, err := writer.Write(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write data to GZIP writer: %v", err)
+	}
+	if n != len(data) {
+		return nil, fmt.Errorf("data written to GZIP writer doesn't match input (%d): %d", len(data), n)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("unable to close GZIP writer: %v", err)
+	}
+	return compressed.Bytes(), nil
+}
+
+type testUserDataProvider struct {
+	userData []byte
+	err      error
+}
+
+func (p *testUserDataProvider) GetUserData() ([]byte, error) {
+	return p.userData, p.err
+}
+
+func Test_Provide(t *testing.T) {
+	testCases := []struct {
+		scenario           string
+		expectedNodeConfig api.NodeConfig
+		userData           []byte
+		isErrorExpected    bool
+	}{
+		{
+			scenario: "multiple NodeConfigs in MIME multi-part should be merged",
+			userData: linesToBytes(
+				"MIME-Version: 1.0",
+				`Content-Type: multipart/mixed; boundary="BOUNDARY"`,
+				"",
+				"--BOUNDARY",
+				"Content-Type: application/node.eks.aws",
+				"",
+				"---",
+				"apiVersion: node.eks.aws/v1alpha1",
+				"kind: NodeConfig",
+				"spec:",
+				"  cluster:",
+				"    name: my-cluster",
+				"    apiServerEndpoint: https://example.com",
+				"    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=",
+				"    cidr: 10.100.0.0/16",
+				"  kubelet:",
+				"    config:",
+				"      port: 1010",
+				"      maxPods: 120",
+				"    flags:",
+				"      - --v=2",
+				"      - --node-labels=foo=bar,nodegroup=test",
+				"",
+				"--BOUNDARY",
+				"Content-Type: application/node.eks.aws",
+				"",
+				"---",
+				"apiVersion: node.eks.aws/v1alpha1",
+				"kind: NodeConfig",
+				"spec:",
+				"  kubelet:",
+				"    config:",
+				"      maxPods: 150",
+				"      podsPerCore: 20",
+				"    flags:",
+				"      - --v=5",
+				"      - --node-labels=foo=baz",
+				"",
+				"--BOUNDARY--",
+			),
+			expectedNodeConfig: api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					Cluster: api.ClusterDetails{
+						Name:                 "my-cluster",
+						APIServerEndpoint:    "https://example.com",
+						CertificateAuthority: []byte("certificateAuthority"),
+						CIDR:                 "10.100.0.0/16",
+					},
+					Kubelet: api.KubeletOptions{
+						Config: api.InlineDocument{
+							"maxPods":     runtime.RawExtension{Raw: []byte("150")},
+							"podsPerCore": runtime.RawExtension{Raw: []byte("20")},
+							"port":        runtime.RawExtension{Raw: []byte("1010")},
+						},
+						Flags: []string{
+							"--v=2",
+							"--node-labels=foo=bar,nodegroup=test",
+							"--v=5",
+							"--node-labels=foo=baz",
+						},
+					},
+				},
 			},
-			Flags: []string{
-				"--v=2",
-				"--node-labels=foo=bar,nodegroup=test",
-				"--v=5",
-				"--node-labels=foo=baz",
+		},
+		{
+			scenario: "GZIP NodeConfig",
+			userData: mustCompressAsGZIP(t,
+				linesToBytes(
+					"---",
+					"apiVersion: node.eks.aws/v1alpha1",
+					"kind: NodeConfig",
+					"spec:",
+					"  cluster:",
+					"    name: my-cluster",
+					"    apiServerEndpoint: https://example.com",
+					"    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=",
+				),
+			),
+			expectedNodeConfig: api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					Cluster: api.ClusterDetails{
+						Name:                 "my-cluster",
+						APIServerEndpoint:    "https://example.com",
+						CertificateAuthority: []byte("certificateAuthority"),
+					},
+				},
 			},
 		},
-	},
+		{
+			scenario: "GZIP multi-part MIME",
+			userData: mustCompressAsGZIP(t,
+				linesToBytes(
+					"MIME-Version: 1.0",
+					`Content-Type: multipart/mixed; boundary="BOUNDARY"`,
+					"",
+					"--BOUNDARY",
+					"Content-Type: application/node.eks.aws",
+					"",
+					"---",
+					"apiVersion: node.eks.aws/v1alpha1",
+					"kind: NodeConfig",
+					"spec:",
+					"  cluster:",
+					"    name: my-cluster",
+					"    apiServerEndpoint: https://example.com",
+					"    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=",
+					"",
+					"--BOUNDARY--",
+				),
+			),
+			expectedNodeConfig: api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					Cluster: api.ClusterDetails{
+						Name:                 "my-cluster",
+						APIServerEndpoint:    "https://example.com",
+						CertificateAuthority: []byte("certificateAuthority"),
+					},
+				},
+			},
+		},
+		{
+			scenario: "multi-part MIME with GZIP NodeConfig part",
+			userData: appendByteSlices(
+				linesToBytes(
+					"MIME-Version: 1.0",
+					`Content-Type: multipart/mixed; boundary="BOUNDARY"`,
+					"",
+					"--BOUNDARY",
+					"Content-Type: application/node.eks.aws",
+					"",
+					"",
+				),
+				mustCompressAsGZIP(t,
+					linesToBytes(
+						"---",
+						"apiVersion: node.eks.aws/v1alpha1",
+						"kind: NodeConfig",
+						"spec:",
+						"  cluster:",
+						"    name: my-cluster",
+						"    apiServerEndpoint: https://example.com",
+						"    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=",
+					),
+				),
+				linesToBytes(
+					"",
+					"--BOUNDARY--",
+				),
+			),
+			expectedNodeConfig: api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					Cluster: api.ClusterDetails{
+						Name:                 "my-cluster",
+						APIServerEndpoint:    "https://example.com",
+						CertificateAuthority: []byte("certificateAuthority"),
+					},
+				},
+			},
+		},
+		{
+			scenario: "base64 encoded, gzip compressed multi-part MIME document",
+			userData: []byte("H4sIAONcTmYAA12PT0/CQBDF7/spNty3tXpbwwGQACbUBLXKcegOdtP9l90p0m9vS4xBbjPvvfll3sI7QkfirQ8oue0M6QCRcqvPqB75wXdOQeynk+1mu5y/vJdPs91+wsZNVBiT9k7yIrtjTIjrCFv8A0MIRtdAQzx3XmGGbcrgO41ngkHQf6xrNz8VYEIDBWu1U5KXgzdwj/qLpYC1ZJzXpkuEcRw5d2DHEr34VS/iAH/FeMK4dCp47Ujyhigkmed4BhsMZrW3l2iNkfRx/BNnHTU+auol399XvVoZCx9lo1bVXH3u/OHhOah1O72tPZT5AWxxqkxSAQAA"),
+			expectedNodeConfig: api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					Cluster: api.ClusterDetails{
+						Name:                 "my-cluster",
+						APIServerEndpoint:    "https://example.com",
+						CertificateAuthority: []byte("certificateAuthority"),
+					},
+				},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("%d_%s", i, testCase.scenario), func(t *testing.T) {
+			configProvider := userDataConfigProvider{
+				userDataProvider: &testUserDataProvider{
+					userData: testCase.userData,
+				},
+			}
+			t.Logf("test case user data:\n%s", string(testCase.userData))
+			actualNodeConfig, err := configProvider.Provide()
+			if testCase.isErrorExpected {
+				assert.NotNil(t, err)
+				assert.Nil(t, actualNodeConfig)
+			} else {
+				assert.Nil(t, err)
+				if assert.NotNil(t, actualNodeConfig) {
+					assert.Equal(t, testCase.expectedNodeConfig, *actualNodeConfig)
+				}
+			}
+		})
+	}
 }
 
-func indent(in string) string {
-	var mid interface{}
-	err := json.Unmarshal([]byte(in), &mid)
-	if err != nil {
-		panic(err)
+func linesToBytes(lines ...string) []byte {
+	var buf bytes.Buffer
+	for i, line := range lines {
+		if i > 0 {
+			buf.WriteString("\n")
+		}
+		buf.WriteString(line)
 	}
-	out, err := json.MarshalIndent(&mid, "", "    ")
-	if err != nil {
-		panic(err)
-	}
-	return string(out)
+	return buf.Bytes()
 }
 
-func mimeifyNodeConfigs(configs ...string) string {
-	var mimeDocLines = []string{
-		"MIME-Version: 1.0",
-		`Content-Type: multipart/mixed; boundary="#"`,
+func appendByteSlices(slices ...[]byte) []byte {
+	var res []byte
+	for _, slice := range slices {
+		res = append(res, slice...)
 	}
-	for _, config := range configs {
-		mimeDocLines = append(mimeDocLines, fmt.Sprintf("\n--#\nContent-Type: %s\n\n%s", nodeConfigMediaType, config))
-	}
-	mimeDocLines = append(mimeDocLines, "\n--#--")
-	return strings.Join(mimeDocLines, "\n")
-}
-
-func TestParseMIMENodeConfig(t *testing.T) {
-	mimeMessage, err := mail.ReadMessage(strings.NewReader(mimeifyNodeConfigs(completeNodeConfig)))
-	if err != nil {
-		t.Fatal(err)
-	}
-	userDataReader := multipart.NewReader(mimeMessage.Body, boundary)
-	if _, err := parseMultipart(userDataReader); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestGetMIMEReader(t *testing.T) {
-	if _, err := getMIMEMultipartReader([]byte(mimeifyNodeConfigs(completeNodeConfig))); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := getMIMEMultipartReader([]byte(completeNodeConfig)); err == nil {
-		t.Fatalf("expected err for bad multipart data")
-	}
-}
-
-func TestMergeNodeConfig(t *testing.T) {
-	mimeNodeConfig := mimeifyNodeConfigs(completeNodeConfig, partialNodeConfig)
-	mimeMessage, err := mail.ReadMessage(strings.NewReader(mimeNodeConfig))
-	if err != nil {
-		t.Fatal(err)
-	}
-	userDataReader := multipart.NewReader(mimeMessage.Body, boundary)
-	config, err := parseMultipart(userDataReader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(config, &completeMergedWithPartial) {
-		t.Errorf("\nexpected: %+v\n\ngot:      %+v", &completeMergedWithPartial, config)
-	}
+	return res
 }


### PR DESCRIPTION
**Issue #, if available:**

Fixes #1734 

**Description of changes:**

Adds support for GZIP-compressed user data.

The following scenarios are supported:
1. User data that consists of a `NodeConfig` that is compressed with GZIP.
2. User data that is a multi-part MIME document that is compressed with GZIP.
3. User data that is a multi-part MIME document containing parts that are individually GZIP'd (and have the `Content-Encoding: gzip` header).
4. A combination of 2 and 3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
