### PR TITLE
Group working directory scripts after reboot

### DIFF
--- a/templates/al2/template.json
+++ b/templates/al2/template.json
@@ -125,40 +125,9 @@
     {
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
-      "inline": [
-        "mkdir -p {{user `working_dir`}}",
-        "mkdir -p {{user `working_dir`}}/log-collector-script"
-      ]
-    },
-    {
-      "type": "shell",
-      "remote_folder": "{{ user `remote_folder`}}",
       "script": "{{template_dir}}/provisioners/install-additional-repos.sh",
       "environment_vars": [
         "ADDITIONAL_YUM_REPOS={{user `additional_yum_repos`}}"
-      ]
-    },
-    {
-      "type": "file",
-      "source": "{{template_dir}}/../shared/runtime/",
-      "destination": "{{user `working_dir`}}"
-    },
-    {
-      "type": "file",
-      "source": "{{template_dir}}/runtime/",
-      "destination": "{{user `working_dir`}}"
-    },
-    {
-      "type": "file",
-      "source": "{{template_dir}}/../../log-collector-script/linux/",
-      "destination": "{{user `working_dir`}}/log-collector-script/"
-    },
-    {
-      "type": "shell",
-      "remote_folder": "{{ user `remote_folder`}}",
-      "inline": [
-        "sudo chmod -R a+x {{user `working_dir`}}/bin/",
-        "sudo mv {{user `working_dir`}}/bin/* /usr/bin/"
       ]
     },
     {
@@ -184,6 +153,37 @@
       "inline": ["sudo reboot"],
       "expect_disconnect": true,
       "pause_after": "90s"
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "inline": [
+        "mkdir -p {{user `working_dir`}}",
+        "mkdir -p {{user `working_dir`}}/log-collector-script"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "{{template_dir}}/../shared/runtime/",
+      "destination": "{{user `working_dir`}}"
+    },
+    {
+      "type": "file",
+      "source": "{{template_dir}}/runtime/",
+      "destination": "{{user `working_dir`}}"
+    },
+    {
+      "type": "file",
+      "source": "{{template_dir}}/../../log-collector-script/linux/",
+      "destination": "{{user `working_dir`}}/log-collector-script/"
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "inline": [
+        "sudo chmod -R a+x {{user `working_dir`}}/bin/",
+        "sudo mv {{user `working_dir`}}/bin/* /usr/bin/"
+      ]
     },
     {
       "type": "shell",


### PR DESCRIPTION
**Issue #, if available:** #1765

**Description of changes:**


Group the file working directory file provisioning and scripts after reboot in case the files are not there after a restart. 

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Building on a hardened image without this threw and error in the linked issue. After the changes the build process moved passed the issue. Then hits the issue with permissions of kubelet and awscli which has two pull requests #1513 and #1717. 

