### PR TITLE
Add checks, vendoring to dependency update PRs

### DIFF
--- a/.github/workflows/update-dependency.yaml
+++ b/.github/workflows/update-dependency.yaml
@@ -35,8 +35,8 @@ jobs:
         with:
           title: 'Update dependencies'
           commit-message: Update dependencies
-          committer: github-actions <actions@github.com>
-          author: github-actions <actions@github.com>
+          committer: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+          author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
           branch: dependencies/update
           branch-suffix: timestamp
           base: main

--- a/nodeadm/Makefile
+++ b/nodeadm/Makefile
@@ -136,4 +136,4 @@ $(CRD_REF_DOCS): $(LOCALBIN)
 
 .PHONY: update-deps
 update-deps:
-	go get $(shell go list -f '{{if not (or .Main .Indirect)}}{{.Path}}{{end}}' -mod=mod -m all) && go mod tidy
+	go get $(shell go list -f '{{if not (or .Main .Indirect)}}{{.Path}}{{end}}' -mod=mod -m all) && go mod tidy && go mod vendor


### PR DESCRIPTION
**Description of changes:**

GitHub doesn't allow the `github-actions` author to trigger PR checks, to prevent infinite loops. That's a problem for our dependency update workflow, because we have no idea if the project still builds + passes tests after the changes. This PR changes the author and committer to `dependabot` for those PRs, because that works as expected.

it also makes sure that the vendor directory is updated after any dependency updates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
