### PR TITLE
al2023: Remove duplicate logrotate entries

### DIFF
--- a/templates/al2023/runtime/rootfs/etc/logrotate.conf
+++ b/templates/al2023/runtime/rootfs/etc/logrotate.conf
@@ -15,17 +15,3 @@ compress
 
 # RPM packages drop log rotation information into this directory
 include /etc/logrotate.d
-
-/var/log/wtmp {
-    monthly
-    create 0664 root utmp
-    minsize 1M
-    rotate 1
-}
-
-/var/log/btmp {
-    missingok
-    monthly
-    create 0600 root utmp
-    rotate 1
-}


### PR DESCRIPTION
**Description of changes:**

AL2023 includes `logrotate` dropin config files for `btmp` and `wtmp` that conflict with our defaults. This removes the entries from our config in favor of the ones provided by the base OS.

```
> cat /etc/logrotate.d/btmp 

# no packages own btmp -- we'll rotate it here
/var/log/btmp {
    missingok
    monthly
    create 0660 root utmp
    rotate 1
}

> cat /etc/logrotate.d/wtmp 

# no packages own wtmp -- we'll rotate it here
/var/log/wtmp {
    missingok
    monthly
    create 0664 root utmp
    minsize 1M
    rotate 1
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
