### PR TITLE
Handle existing `nerdctl` installations

### DIFF
--- a/templates/al2/provisioners/install-worker.sh
+++ b/templates/al2/provisioners/install-worker.sh
@@ -196,7 +196,7 @@ EOF
 ###############################################################################
 
 sudo yum install -y nerdctl
-sudo -p mkdir /etc/nerdctl
+sudo mkdir -p /etc/nerdctl
 cat << EOF | sudo tee -a /etc/nerdctl/nerdctl.toml
 namespace = "k8s.io"
 EOF

--- a/templates/al2/provisioners/install-worker.sh
+++ b/templates/al2/provisioners/install-worker.sh
@@ -196,7 +196,9 @@ EOF
 ###############################################################################
 
 sudo yum install -y nerdctl
-sudo mkdir /etc/nerdctl
+if [ ! -d "/etc/nerdctl" ]; then
+    sudo mkdir /etc/nerdctl
+fi
 cat << EOF | sudo tee -a /etc/nerdctl/nerdctl.toml
 namespace = "k8s.io"
 EOF

--- a/templates/al2/provisioners/install-worker.sh
+++ b/templates/al2/provisioners/install-worker.sh
@@ -196,9 +196,7 @@ EOF
 ###############################################################################
 
 sudo yum install -y nerdctl
-if [ ! -d "/etc/nerdctl" ]; then
-    sudo mkdir /etc/nerdctl
-fi
+sudo -p mkdir /etc/nerdctl
 cat << EOF | sudo tee -a /etc/nerdctl/nerdctl.toml
 namespace = "k8s.io"
 EOF


### PR DESCRIPTION
mkdir creation fails when package nerdctl is already present in the ami.

**Issue #, if available:**

**Description of changes:**
Just add an if so it does not try to create it if it already exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
After this change, I could create my ami.  

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
