### PR TITLE
Use go-version defined in nodeadm/go.mod

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.8'
+          go-version-file: 'nodeadm/go.mod'
       - run: go install github.com/securego/gosec/v2/cmd/gosec@latest
       - run: gosec -exclude-generated ./...
         working-directory: nodeadm
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.21.8
           work-dir: ./nodeadm
           go-version-file: nodeadm/go.mod
           cache: false


### PR DESCRIPTION
**Description of changes:**

Removes the hard-coded go versions from our dependency checks, in favor of using whatever is defined in `nodeadm/go.mod`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
