### PR TITLE
fix shell variable expansion for cache images

### DIFF
--- a/templates/al2/provisioners/install-worker.sh
+++ b/templates/al2/provisioners/install-worker.sh
@@ -437,13 +437,13 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
   fi
 
   CACHE_IMGS=(
-    ${KUBE_PROXY_IMGS[@]+"${KUBE_PROXY_IMGS[@]}"}
-    ${VPC_CNI_IMGS[@]+"${VPC_CNI_IMGS[@]}"}
+    ${KUBE_PROXY_IMGS[@]:-}
+    ${VPC_CNI_IMGS[@]:-}
   )
   PULLED_IMGS=()
   REGIONS=$(aws ec2 describe-regions --all-regions --output text --query 'Regions[].[RegionName]')
 
-  for img in "${CACHE_IMGS[@]}"; do
+  for img in "${CACHE_IMGS[@]:-}"; do
     ## only kube-proxy-minimal is vended for K8s 1.24+
     if [[ "${img}" == *"kube-proxy:"* ]] && [[ "${img}" != *"-minimal-"* ]] && vercmp "${K8S_MINOR_VERSION}" gteq "1.24"; then
       continue
@@ -467,7 +467,7 @@ if [[ "$CACHE_CONTAINER_IMAGES" == "true" ]] && ! [[ ${ISOLATED_REGIONS} =~ $BIN
 
   #### Tag the pulled down image for all other regions in the partition
   for region in ${REGIONS[*]}; do
-    for img in "${PULLED_IMGS[@]}"; do
+    for img in "${PULLED_IMGS[@]:-}"; do
       region_uri=$(/etc/eks/get-ecr-uri.sh "${region}" "${AWS_DOMAIN}")
       regional_img="${img/$ECR_URI/$region_uri}"
       sudo ctr -n k8s.io image tag "${img}" "${regional_img}" || :


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

fixes an issue where missing addons causes the build to fail when caching images.

this was originally fixed in https://github.com/awslabs/amazon-eks-ami/pull/1133, but since removing the unconditional `PAUSE_CONTAINER` image, it's now possible for the entire `CACHE_IMGS` variable to be empty, resulting in

```
line 486: CACHE_IMGS[@]: unbound variable
```

added empty string as a fallback to empty or unset values of `CACHE_IMGS` and `PULLED_IMGS`, and shortened the alternative syntax `+${...}` to `:-` which avoids rewriting the same expression.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
