### PR TITLE
Read existing containerd config

### DIFF
--- a/nodeadm/internal/containerd/config.go
+++ b/nodeadm/internal/containerd/config.go
@@ -59,7 +59,7 @@ func writeContainerdConfig(cfg *api.NodeConfig) error {
 // readExistingContainerdConfig reads /etc/containerd/config.toml
 // and returns lines that are not comments
 func readExistingContainerdConfig() (string, error) {
-	zap.L().Info("Reading exisitng config file...", zap.String("path", string(containerdConfigFile)))
+	zap.L().Info("Reading existing config file...", zap.String("path", string(containerdConfigFile)))
 	file, err := os.Open(containerdConfigFile)
 	var contents strings.Builder
 	if err != nil {
@@ -70,6 +70,7 @@ func readExistingContainerdConfig() (string, error) {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
+		// skip lines with comments
 		if !strings.HasPrefix(line, "#") {
 			contents.WriteString(fmt.Sprintln(line))
 		}

--- a/nodeadm/test/e2e/cases/containerd-config/expected-containerd-config.toml
+++ b/nodeadm/test/e2e/cases/containerd-config/expected-containerd-config.toml
@@ -1,3 +1,4 @@
+default_runtime_name = 'runc'
 root = '/var/lib/containerd'
 state = '/run/containerd'
 version = 2
@@ -14,10 +15,14 @@ bin_dir = '/opt/cni/bin'
 conf_dir = '/etc/cni/net.d'
 
 [plugins.'io.containerd.grpc.v1.cri'.containerd]
-default_runtime_name = 'runc'
+default_runtime_name = 'mock-runtime'
 discard_unpacked_layers = false
 
 [plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes]
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.mock-runtime]
+[plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.mock-runtime.options]
+BinaryName = '/usr/local/bin/oci_mock_hook_wrapper.sh'
+
 [plugins.'io.containerd.grpc.v1.cri'.containerd.runtimes.runc]
 runtime_type = 'io.containerd.runc.v2'
 

--- a/nodeadm/test/e2e/infra/Dockerfile
+++ b/nodeadm/test/e2e/infra/Dockerfile
@@ -39,6 +39,7 @@ COPY test/e2e/infra/systemd/kubelet.service /usr/lib/systemd/system/kubelet.serv
 COPY test/e2e/infra/systemd/containerd.service /usr/lib/systemd/system/containerd.service
 COPY test/e2e/infra/mock/ /sys_devices_system_mock/
 COPY test/e2e/helpers.sh /helpers.sh
+COPY test/e2e/infra/containerd-config.toml /etc/containerd/config.toml
 
 RUN mkdir -p /etc/eks/image-credential-provider/
 RUN touch /etc/eks/image-credential-provider/ecr-credential-provider

--- a/nodeadm/test/e2e/infra/containerd-config.toml
+++ b/nodeadm/test/e2e/infra/containerd-config.toml
@@ -1,0 +1,37 @@
+#   Copyright 2018-2022 Docker Inc.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+#root = "/var/lib/containerd"
+#state = "/run/containerd"
+#subreaper = true
+#oom_score = 0
+
+#[grpc]
+#  address = "/run/containerd/containerd.sock"
+#  uid = 0
+#  gid = 0
+
+#[debug]
+#  address = "/run/containerd/debug.sock"
+#  uid = 0
+#  gid = 0
+#  level = "info"
+
+default_runtime_name = "runc"
+[plugins."io.containerd.grpc.v1.cri".containerd]
+default_runtime_name = "mock-runtime"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.mock-runtime]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.mock-runtime.options]
+BinaryName = "/usr/local/bin/oci_mock_hook_wrapper.sh"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Refactor `nodeadm` to read any existing containerd configuration and merge it in the final config.toml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Extended e2e test and tested manually with custom AMI.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
