### PR TITLE
move gpu boost clock to gpu boostrap helper

### DIFF
--- a/templates/al2/runtime/bootstrap.sh
+++ b/templates/al2/runtime/bootstrap.sh
@@ -642,38 +642,4 @@ systemctl daemon-reload
 systemctl enable kubelet
 systemctl start kubelet
 
-# gpu boost clock
-if command -v nvidia-smi &> /dev/null; then
-  log "INFO: nvidia-smi found"
-
-  nvidia-smi -q > /tmp/nvidia-smi-check
-  if [[ "$?" == "0" ]]; then
-    sudo nvidia-smi -pm 1 # set persistence mode
-    sudo nvidia-smi --auto-boost-default=0
-
-    GPUNAME=$(nvidia-smi -L | head -n1)
-    log "INFO: GPU name: $GPUNAME"
-
-    # set application clock to maximum
-    if [[ $GPUNAME == *"A100"* ]]; then
-      nvidia-smi -ac 1215,1410
-    elif [[ $GPUNAME == *"V100"* ]]; then
-      nvidia-smi -ac 877,1530
-    elif [[ $GPUNAME == *"K80"* ]]; then
-      nvidia-smi -ac 2505,875
-    elif [[ $GPUNAME == *"T4"* ]]; then
-      nvidia-smi -ac 5001,1590
-    elif [[ $GPUNAME == *"M60"* ]]; then
-      nvidia-smi -ac 2505,1177
-    elif [[ $GPUNAME == *"H100"* ]]; then
-      nvidia-smi -ac 2619,1980
-    else
-      echo "unsupported gpu"
-    fi
-  else
-    log "ERROR: nvidia-smi check failed!"
-    cat /tmp/nvidia-smi-check
-  fi
-fi
-
 log "INFO: complete!"


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/amazon-eks-ami/issues/1826

**Description of changes:**
move nvidia-smi into the GPU bootstrap helper script to resolve Unable to satisfy 100% MinSuccessfulInstancesPercent requirement issue in #1826 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.