### PR TITLE
Tag AMI's with ena_support

### DIFF
--- a/templates/al2/template.json
+++ b/templates/al2/template.json
@@ -118,7 +118,8 @@
       "metadata_options": {
         "http_tokens": "required"
       },
-      "user_data_file": "{{user `user_data_file`}}"
+      "user_data_file": "{{user `user_data_file`}}",
+      "ena_support": true
     }
   ],
   "provisioners": [

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -109,7 +109,8 @@
       "metadata_options": {
         "http_tokens": "required"
       },
-      "user_data_file": "{{user `user_data_file`}}"
+      "user_data_file": "{{user `user_data_file`}}",
+      "ena_support": true
     }
   ],
   "provisioners": [


### PR DESCRIPTION
**Description of changes:**

Enables ENA by default on instances launched with the AMIs. We already have the `ena` kernel module installed, and the base Amazon Linux AMIs have this enabled -- we just haven't been propagating the attribute to our AMI's.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
