### PR TITLE
Add ListBucket action in IAM permissions.

### DIFF
--- a/doc/usage/overview.md
+++ b/doc/usage/overview.md
@@ -149,9 +149,13 @@ To build the EKS Optimized AMI, you will need the following permissions:
         {
             "Effect": "Allow",
             "Action": [
-                "s3:GetObject"
+                "s3:GetObject",
+                "s3:ListBucket"
             ],
-            "Resource": "arn:aws:s3:::amazon-eks/*"
+            "Resource": [
+                "arn:aws:s3:::amazon-eks/*",
+                "arn:aws:s3:::amazon-eks"
+            ]
         }
     ]
 }


### PR DESCRIPTION
In order to make this work with cross-account IAM we had to explicitly add ListBucket to the role we use to build our AMIs. And in order for ListBucket to work properly, we also had to reference the bucket rather than a wildcard path at root.

**Issue #, if available:**

**Description of changes:**

Changes to permissions documentation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
