### PR TITLE
Update dependency workflow to reuse branch, detect go version

### DIFF
--- a/.github/workflows/update-dependency.yaml
+++ b/.github/workflows/update-dependency.yaml
@@ -17,10 +17,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.8'
-      - uses: actions/checkout@v4
+          go-version-file: 'nodeadm/go.mod'
       - name: Update Nodeadm Dependencies
         id: update_deps
         run: |
@@ -38,7 +38,6 @@ jobs:
           committer: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
           author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
           branch: dependencies/update
-          branch-suffix: timestamp
           base: main
           delete-branch: true
           labels: |


### PR DESCRIPTION
**Description of changes:**

Two changes in our weekly dependency update workflow:
1. Use the go version that's defined in the `go.mod` file, so we don't have a go version defined in more than one place.
2. Re-use the existing branch (and PR) so we don't end up with multiple PR's open from the workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
