### PR TITLE
Use unique artifact names in CI workflow

### DIFF
--- a/.github/actions/ci/build/action.yaml
+++ b/.github/actions/ci/build/action.yaml
@@ -33,5 +33,5 @@ runs:
         echo "ami_id=$(jq -r .builds[0].artifact_id "${AMI_NAME}-manifest.json" | cut -d ':' -f 2)" >> $GITHUB_OUTPUT
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # 4.3.3
       with:
-        name: version-info
+        name: version-info-${{ inputs.k8s_version }}-${{ inputs.os_distro }}
         path: "*-version-info.json"


### PR DESCRIPTION
**Description of changes:**

#1850  updated us to 4.x of the upload-artifact action, which requires unique artifact names across an entire workflow.

Ex failure: https://github.com/awslabs/amazon-eks-ami/actions/runs/9568957937/job/26380369916

> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
