### PR TITLE
bug(al2023): Do not bind containerd restarts to kubelet

### DIFF
--- a/templates/al2023/runtime/rootfs/etc/systemd/system/kubelet.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/kubelet.service
@@ -2,7 +2,7 @@
 Description=Kubernetes Kubelet
 Documentation=https://github.com/kubernetes/kubernetes
 After=containerd.service
-Requires=containerd.service
+Wants=containerd.service
 
 [Service]
 Slice=runtime.slice


### PR DESCRIPTION
**Issue #, if available:**

Fixes #1846.

**Description of changes:**

This updates the `kubelet.service` on AL2023 to be loosely-coupled with `containerd`, so that restarts/kills of `containerd` do not impact `kubelet`.

We're not making this change on AL2 because folks may see different behavior if they're starting/stopping either of these units in their existing user data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.