### PR TITLE
bug(bot): fix handling of listFiles response

### DIFF
--- a/.github/actions/bot/index.js
+++ b/.github/actions/bot/index.js
@@ -183,7 +183,7 @@ class CICommand {
             pull_number: this.pr_number
         });
         const osDistros = [];
-        for (const file of files) {
+        for (const file of files.data) {
             for (const prefix of osDistroPathPrefixHints) {
                 if (file.filename.startsWith(prefix)) {
                     const osDistro = this.osDistroPathPrefixHints[prefix];


### PR DESCRIPTION
**Description of changes:**

Type returned by `listFiles` was handled incorrectly in #1750, tested this fix locally with:
```
const { Octokit } = require("@octokit/rest");

const octokit = new Octokit();

const res = octokit.rest.pulls
  .listFiles({
    owner: "awslabs",
    repo: "amazon-eks-ami",
    pull_number: 1750
});

res.then((files) => {
  for (const file of files.data) {
    console.log(file.filename);
  }
});
```

Output:
```
.github/actions/bot/index.js
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
