### PR TITLE
Make bootstrap GPU helper container runtime aware

### DIFF
--- a/templates/al2/runtime/bootstrap.sh
+++ b/templates/al2/runtime/bootstrap.sh
@@ -639,7 +639,7 @@ fi
 BOOTSTRAP_GPU_HELPER=/etc/eks/bootstrap-gpu.sh
 if [ -x "${BOOTSTRAP_GPU_HELPER}" ]; then
   log "INFO: starting GPU bootstrap helper..."
-  "${BOOTSTRAP_GPU_HELPER}"
+  $BOOTSTRAP_GPU_HELPER -r "$CONTAINER_RUNTIME"
   log "INFO: completed GPU bootstrap helper!"
 fi
 


### PR DESCRIPTION
**Description of changes:**

Modifying the bootstrap GPU helper so it's aware of the container runtime (docker vs containerd) used by the bootstrap script.


**Testing done:**

Ran this script against when using both containerd and docker and made sure everything was working. 