### PR TITLE
docs(al2): fix broken link to `boostrap.sh`

### DIFF
--- a/doc/usage/al2.md
+++ b/doc/usage/al2.md
@@ -105,7 +105,7 @@ echo "$(jq ".registryPullQPS=20 | .registryBurst=40" /etc/kubernetes/kubelet/kub
 There are a couple of important caveats here:
 
 1. If you update the `kubelet` config file after `kubelet` has already started (i.e. `bootstrap.sh` already ran), you'll need to restart `kubelet` to pick up the latest configuration.
-2. [bootstrap.sh](https://github.com/awslabs/amazon-eks-ami/blob/main/src/runtime/bootstrap.sh) does modify a few fields, like `kubeReserved` and `evictionHard`, so you'd need to modify the config after the bootstrap script is run and restart `kubelet` to overwrite those properties.
+2. [bootstrap.sh](https://github.com/awslabs/amazon-eks-ami/blob/main/templates/al2/runtime/bootstrap.sh) does modify a few fields, like `kubeReserved` and `evictionHard`, so you'd need to modify the config after the bootstrap script is run and restart `kubelet` to overwrite those properties.
 
 **View active kubelet config**
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

https://github.com/awslabs/amazon-eks-ami/blob/main/src/runtime/bootstrap.sh is 404 now
```
$ curl -o /dev/null -s -w "%{http_code}\n" https://github.com/awslabs/amazon-eks-ami/blob/main/src/runtime/bootstrap.sh
404
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
