### PR TITLE
Add nvidia-bug-report to eks-logs-collector

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -803,7 +803,7 @@ get_nvidia_bug_report() {
   if ! command -v nvidia-bug-report.sh &> /dev/null; then
     echo "No Nvidia drivers found, nothing to do."
   else
-    timeout 75 command nvidia-bug-report.sh --output-file "${COLLECT_DIR}"/gpu/nvidia-bug-report.log &> /dev/null
+    timeout 75 nvidia-bug-report.sh --output-file "${COLLECT_DIR}"/gpu/nvidia-bug-report.log &> /dev/null
   fi
   ok
 }

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -800,7 +800,7 @@ get_io_throttled_processes() {
 
 get_nvidia_bug_report() {
   try "Collect Nvidia Bug report"
-  if ! command -v nvidia-bug-report.sh  &> /dev/null; then
+  if ! command -v nvidia-bug-report.sh &> /dev/null; then
     echo "No Nvidia drivers found, nothing to do."
   else
     timeout 75 command nvidia-bug-report.sh --output-file "${COLLECT_DIR}"/gpu/nvidia-bug-report.log &> /dev/null        

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -63,6 +63,7 @@ COMMON_DIRECTORIES=(
   kubelet       # eks
   nodeadm       # eks
   cni           # eks
+  gpu           # eks
 )
 
 COMMON_LOGS=(
@@ -287,6 +288,7 @@ collect() {
   get_sandboxImage_info
   get_cpu_throttled_processes
   get_io_throttled_processes
+  get_nvidia_bug_report
 }
 
 pack() {
@@ -793,6 +795,16 @@ get_io_throttled_processes() {
   # column 42 is Aggregated block I/O delays, measured in centiseconds so we capture the non-zero block
   # I/O delays.
   command cut -d" " -f 1,2,42 /proc/[0-9]*/stat | sort -n -k+3 -r | grep -v 0$ >> ${IO_THROTTLE_LOG}
+  ok
+}
+
+get_nvidia_bug_report() {
+  try "Collect Nvidia Bug report"
+  if ! command -v nvidia-bug-report.sh  &> /dev/null; then
+    echo "No Nvidia drivers found, nothing to do."
+  else
+    timeout 75 command nvidia-bug-report.sh --output-file "${COLLECT_DIR}"/gpu/nvidia-bug-report.log &> /dev/null        
+  fi
   ok
 }
 

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -803,7 +803,7 @@ get_nvidia_bug_report() {
   if ! command -v nvidia-bug-report.sh &> /dev/null; then
     echo "No Nvidia drivers found, nothing to do."
   else
-    timeout 75 command nvidia-bug-report.sh --output-file "${COLLECT_DIR}"/gpu/nvidia-bug-report.log &> /dev/null        
+    timeout 75 command nvidia-bug-report.sh --output-file "${COLLECT_DIR}"/gpu/nvidia-bug-report.log &> /dev/null
   fi
   ok
 }


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This PR adds the execution of `nvidia-bug-report.sh` in the eks-logs-collector. This executable is part of the Nvidia drivers and is useful for debugging. Script is alsot mentioned in https://docs.nvidia.com/deploy/gpu-debug-guidelines/index.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

I tested this script on a g4dn instance which has an Nvidia GPU, and verified that the log.gz file created by `nvidia-bug-report.sh` is included in the log collector archive.

```
Trying to Collect CPU Throttled Process Information...
Trying to Collect IO Throttled Process Information...
Trying to Collect Nvidia Bug report...
Trying to archive gathered information...

	Done... your bundled logs are located in /var/log/eks_i-...tar.gz
```

Also ran the script against a t3.large to make sure the script doesn't break - 

```
Trying to Collect CPU Throttled Process Information...
Trying to Collect IO Throttled Process Information...
Trying to Collect Nvidia Bug report... No Nvidia drivers found, nothing to do.

Trying to archive gathered information...

	Done... your bundled logs are located in /var/log/eks_i-....tar.gz
```
*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
