### PR TITLE
Increase snapshot creation polling timeout

### DIFF
--- a/templates/al2/template.json
+++ b/templates/al2/template.json
@@ -85,7 +85,7 @@
       ],
       "aws_polling": {
         "delay_seconds": 30,
-        "max_attempts": 90
+        "max_attempts": 480
       },
       "ami_regions": "{{user `ami_regions`}}",
       "iam_instance_profile": "{{user `iam_instance_profile`}}",

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -79,7 +79,7 @@
       ],
       "aws_polling": {
         "delay_seconds": 30,
-        "max_attempts": 90
+        "max_attempts": 480
       },
       "ami_regions": "{{user `ami_regions`}}",
       "ssh_username": "{{user `ssh_username`}}",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Increase the snapshot creation polling timeout. When we build our AMIs we need to cache _a lot_ of container images on the AMIs. This, in turn, creates large snapshots. For this to be cheap and pragmatic we just use the defaults in the project and make a rather big volume for the images, without optimizing any IO-config. So - for us it might take up to 4 hours to wait for the snapshot creation. Either way; in order for the ami to get tagged properly and for the job to clean up - I had to increase this timeout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
Building an image with the params;

launch_block_device_mappings_volume_size=300 aws_region=eu-north-1 ssm_agent_version=3.3.380.0 make k8s=1.29 cache_container_images=true os_distro=al2 subnet_id=<my_private_subnet>


<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
