### PR TITLE
bug(bot): osDistroPathPrefixHints misreferenced

### DIFF
--- a/.github/actions/bot/index.js
+++ b/.github/actions/bot/index.js
@@ -184,7 +184,7 @@ class CICommand {
         });
         const osDistros = [];
         for (const file of files.data) {
-            for (const prefix of osDistroPathPrefixHints) {
+            for (const prefix of this.osDistroPathPrefixHints) {
                 if (file.filename.startsWith(prefix)) {
                     const osDistro = this.osDistroPathPrefixHints[prefix];
                     osDistros.push(osDistro);


### PR DESCRIPTION
**Description of changes:**

Fixes: https://github.com/awslabs/amazon-eks-ami/actions/runs/9890929392

> Error: ReferenceError: osDistroPathPrefixHints is not defined

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
