### PR TITLE
bug(nodeadm): Don't wrap kubelet systemd environment variable

### DIFF
--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -379,7 +379,7 @@ func (k *kubelet) writeKubeletConfigToDir(cfg *api.NodeConfig) error {
 		k.flags["config-dir"] = dirPath
 
 		zap.L().Info("Enabling kubelet config drop-in dir..")
-		k.setEnv("KUBELET_CONFIG_DROPIN_DIR_ALPHA", "on")
+		k.environment["KUBELET_CONFIG_DROPIN_DIR_ALPHA"] = "on"
 		filePath := path.Join(dirPath, "00-nodeadm.conf")
 
 		// merge in default type metadata like kind and apiVersion in case the

--- a/nodeadm/internal/kubelet/environment.go
+++ b/nodeadm/internal/kubelet/environment.go
@@ -2,7 +2,6 @@ package kubelet
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
@@ -31,11 +30,7 @@ func (k *kubelet) writeKubeletEnvironment(cfg *api.NodeConfig) error {
 	// write additional environment variables
 	var kubeletEnvironment []string
 	for eKey, eValue := range k.environment {
-		kubeletEnvironment = append(kubeletEnvironment, fmt.Sprintf(`%s=%s`, sanitize(eKey), sanitize(eValue)))
+		kubeletEnvironment = append(kubeletEnvironment, fmt.Sprintf(`%s=%s`, eKey, eValue))
 	}
 	return util.WriteFileWithDir(kubeletEnvironmentFilePath, []byte(strings.Join(kubeletEnvironment, "\n")), kubeletConfigPerm)
-}
-
-func sanitize(s string) string {
-	return regexp.MustCompile("[\n\r]").ReplaceAllString(s, " ")
 }

--- a/nodeadm/internal/kubelet/environment.go
+++ b/nodeadm/internal/kubelet/environment.go
@@ -2,6 +2,7 @@ package kubelet
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
@@ -30,12 +31,11 @@ func (k *kubelet) writeKubeletEnvironment(cfg *api.NodeConfig) error {
 	// write additional environment variables
 	var kubeletEnvironment []string
 	for eKey, eValue := range k.environment {
-		kubeletEnvironment = append(kubeletEnvironment, fmt.Sprintf(`%s="%s"`, eKey, eValue))
+		kubeletEnvironment = append(kubeletEnvironment, fmt.Sprintf(`%s=%s`, sanitize(eKey), sanitize(eValue)))
 	}
 	return util.WriteFileWithDir(kubeletEnvironmentFilePath, []byte(strings.Join(kubeletEnvironment, "\n")), kubeletConfigPerm)
 }
 
-// Add values to the environment variables map in a terse manner
-func (k *kubelet) setEnv(envName string, envArg string) {
-	k.environment[envName] = envArg
+func sanitize(s string) string {
+	return regexp.MustCompile("[\n\r]").ReplaceAllString(s, " ")
 }

--- a/nodeadm/test/e2e/cases/kubelet-flags/config.yaml
+++ b/nodeadm/test/e2e/cases/kubelet-flags/config.yaml
@@ -14,3 +14,6 @@ spec:
       - --v=5
       - --node-labels=foo=bar,foo2=baz
       - --register-with-taints=foo=bar:NoSchedule
+      - |
+        --foo
+        --bar

--- a/nodeadm/test/e2e/cases/kubelet-flags/config.yaml
+++ b/nodeadm/test/e2e/cases/kubelet-flags/config.yaml
@@ -14,6 +14,3 @@ spec:
       - --v=5
       - --node-labels=foo=bar,foo2=baz
       - --register-with-taints=foo=bar:NoSchedule
-      - |
-        --foo
-        --bar

--- a/nodeadm/test/e2e/cases/kubelet-flags/run.sh
+++ b/nodeadm/test/e2e/cases/kubelet-flags/run.sh
@@ -12,5 +12,5 @@ wait::dbus-ready
 
 nodeadm init --skip run --config-source file://config.yaml
 
-assert::file-contains /etc/eks/kubelet/environment '--v=5 --node-labels=foo=bar,foo2=baz --register-with-taints=foo=bar:NoSchedule"$'
+assert::file-contains /etc/eks/kubelet/environment '--v=5 --node-labels=foo=bar,foo2=baz --register-with-taints=foo=bar:NoSchedule --foo --bar $'
 assert::file-contains /etc/eks/kubelet/environment '--hostname-override=i-1234567890abcdef0'

--- a/nodeadm/test/e2e/cases/kubelet-flags/run.sh
+++ b/nodeadm/test/e2e/cases/kubelet-flags/run.sh
@@ -12,5 +12,5 @@ wait::dbus-ready
 
 nodeadm init --skip run --config-source file://config.yaml
 
-assert::file-contains /etc/eks/kubelet/environment '--v=5 --node-labels=foo=bar,foo2=baz --register-with-taints=foo=bar:NoSchedule --foo --bar $'
+assert::file-contains /etc/eks/kubelet/environment '--v=5 --node-labels=foo=bar,foo2=baz --register-with-taints=foo=bar:NoSchedule$'
 assert::file-contains /etc/eks/kubelet/environment '--hostname-override=i-1234567890abcdef0'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

referring to the docs on [`EnvironmentFile`](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#EnvironmentFile=) wrapping `"` isn't needed (interior whitespace is preserved verbatum), and conflict with user data if providing quotes within their own flags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->