### PR TITLE
fetch the correct kubernetes build date for linux binaries

### DIFF
--- a/hack/latest-binaries.sh
+++ b/hack/latest-binaries.sh
@@ -13,7 +13,7 @@ MINOR_VERSION="${1}"
 
 # retrieve the available "VERSION/BUILD_DATE" prefixes (e.g. "1.28.1/2023-09-14")
 # from the binary object keys, sorted in descending semver order, and pick the first one
-LATEST_BINARIES=$(aws s3api list-objects-v2 --bucket amazon-eks --prefix "${MINOR_VERSION}" --query 'Contents[*].[Key]' --output text | cut -d'/' -f-2 | sort -Vru | head -n1)
+LATEST_BINARIES=$(aws s3api list-objects-v2 --bucket amazon-eks --prefix "${MINOR_VERSION}" --query 'Contents[*].[Key]' --output text | grep linux | cut -d'/' -f-2 | sort -Vru | head -n1)
 
 if [ "${LATEST_BINARIES}" == "None" ]; then
   echo >&2 "No binaries available for minor version: ${MINOR_VERSION}"


### PR DESCRIPTION
**Issue #, if available:**
* we refresh the windows binaries only this week. And this script should get the latest build date for linux binaries instead of windows. 
* For Issue #1888, the build AMI failed because of the wrong binary info

**Description of changes:**
* add grep linux when fetching `LATEST_BINARIES`

**Test**
```
> aws s3api list-objects-v2 --bucket amazon-eks --prefix "${MINOR_VERSION}" --query 'Contents[*].[Key]' --output text | grep linux | cut -d'/' -f-2 | sort -Vru | head -n1

1.29.3/2024-04-19
```