### PR TITLE
Fall back to non fips endpoint per availability

### DIFF
--- a/nodeadm/internal/aws/ecr/ecr.go
+++ b/nodeadm/internal/aws/ecr/ecr.go
@@ -3,6 +3,7 @@ package ecr
 import (
 	"context"
 	"fmt"
+	"go.uber.org/zap"
 	"net"
 	"strings"
 	"time"
@@ -49,10 +50,11 @@ func GetEKSRegistry(region string) (ECRRegistry, error) {
 	}
 	if fipsInstalled && fipsEnabled {
 		fipsRegistry := getRegistry(account, "ecr-fips", region, servicesDomain)
-		if addresses, err := net.LookupHost(fipsRegistry); err != nil {
-			return "", err
-		} else if len(addresses) > 0 {
+		addresses, err := net.LookupHost(fipsRegistry)
+		if err == nil && len(addresses) > 0 {
 			return ECRRegistry(fipsRegistry), nil
+		} else {
+			zap.L().Info("Fail to look up Fips registry for requested region, fall back to default", zap.String("fipsRegistry", fipsRegistry))
 		}
 	}
 	return ECRRegistry(getRegistry(account, "ecr", region, servicesDomain)), nil


### PR DESCRIPTION
**Description of changes:**
apply same fix like https://github.com/awslabs/amazon-eks-ami/pull/1524 as FIPS endpoint only exists in a handful of regions: https://aws.amazon.com/compliance/fips/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

