### PR TITLE
Add support for raid10

### DIFF
--- a/doc/usage/al2.md
+++ b/doc/usage/al2.md
@@ -171,6 +171,12 @@ A RAID-0 array is setup that includes all ephemeral NVMe instance storage disks.
 
 Another way of utilizing the ephemeral disks is to format and mount the individual disks. Mounting individual disks allows the [local-static-provisioner](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner) DaemonSet to create Persistent Volume Claims that pods can utilize.
 
+### Experimental: RAID-10 Kubelet and Containerd (raid10)
+
+Similar to RAID-0 array, it is possible to utilize RAID-10 array for instance types with four or more ephemeral NVMe instance storage disks. RAID-10 tolerates failure of maximum of 2 disks. However, individual ephemeral disks can not be replaced, so the purpose of redundancy is to make graceful decommisioning of a node possible.
+
+RAID-10 can be enabled by passing `--local-disks raid10` flag to the bootstrap script.
+
 ---
 
 ## Version-locked packages

--- a/nodeadm/api/v1alpha1/nodeconfig_types.go
+++ b/nodeadm/api/v1alpha1/nodeconfig_types.go
@@ -94,12 +94,15 @@ type LocalStorageOptions struct {
 }
 
 // LocalStorageStrategy specifies how to handle an instance's local storage devices.
-// +kubebuilder:validation:Enum={RAID0, Mount}
+// +kubebuilder:validation:Enum={RAID0, RAID10, Mount}
 type LocalStorageStrategy string
 
 const (
 	// LocalStorageRAID0 will create a single raid0 volume from any local disks
 	LocalStorageRAID0 LocalStorageStrategy = "RAID0"
+
+	// LocalStorageRAID10 will create a single raid10 volume from any local disks. Minimum of 4.
+	LocalStorageRAID10 LocalStorageStrategy = "RAID10"
 
 	// LocalStorageMount will mount each local disk individually
 	LocalStorageMount LocalStorageStrategy = "Mount"

--- a/nodeadm/crds/node.eks.aws_nodeconfigs.yaml
+++ b/nodeadm/crds/node.eks.aws_nodeconfigs.yaml
@@ -107,6 +107,7 @@ spec:
                           an instance's local storage devices.
                         enum:
                         - RAID0
+                        - RAID10
                         - Mount
                         type: string
                     type: object

--- a/nodeadm/doc/api.md
+++ b/nodeadm/doc/api.md
@@ -92,7 +92,7 @@ _Appears in:_
 - [LocalStorageOptions](#localstorageoptions)
 
 .Validation:
-- Enum: [RAID0 Mount]
+- Enum: [RAID0 RAID10 Mount]
 
 #### NodeConfig
 

--- a/nodeadm/internal/api/types.go
+++ b/nodeadm/internal/api/types.go
@@ -101,6 +101,7 @@ type LocalStorageStrategy string
 
 const (
 	LocalStorageRAID0 LocalStorageStrategy = "RAID0"
+	LocalStorageRAID10 LocalStorageStrategy = "RAID10"
 	LocalStorageMount LocalStorageStrategy = "Mount"
 )
 

--- a/templates/al2/runtime/bootstrap.sh
+++ b/templates/al2/runtime/bootstrap.sh
@@ -32,7 +32,7 @@ function print_help {
   echo "--enable-local-outpost Enable support for worker nodes to communicate with the local control plane when running on a disconnected Outpost. (true or false)"
   echo "--ip-family Specify ip family of the cluster"
   echo "--kubelet-extra-args Extra arguments to add to the kubelet. Useful for adding labels or taints."
-  echo "--local-disks Setup instance storage NVMe disks in raid0 or mount the individual disks for use by pods [mount | raid0]"
+  echo "--local-disks Setup instance storage NVMe disks in raid0 or mount the individual disks for use by pods <mount | raid0 | raid10>"
   echo "--mount-bpf-fs Mount a bpffs at /sys/fs/bpf (default: true)"
   echo "--pause-container-account The AWS account (number) to pull the pause container from"
   echo "--pause-container-version The tag of the pause container"

--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -15,7 +15,7 @@ err_report() {
 trap 'err_report $LINENO' ERR
 
 print_help() {
-  echo "usage: $0 <raid0 | mount | none>"
+  echo "usage: $0 <raid0 | raid10 | mount | none>"
   echo "Sets up Amazon EC2 Instance Store NVMe disks"
   echo ""
   echo "-d, --dir directory to mount the filesystem(s) (default: /mnt/k8s-disks/)"
@@ -26,11 +26,18 @@ print_help() {
   echo "-h, --help print this help"
 }
 
-# Sets up a RAID-0 of NVMe instance storage disks, moves
-# the contents of /var/lib/kubelet and /var/lib/containerd
+# Sets up a RAID-0 or RAID-10 of NVMe instance storage disks,
+# moves the contents of /var/lib/kubelet and /var/lib/containerd
 # to the new mounted RAID, and bind mounts the kubelet and
 # containerd state directories.
-maybe_raid0() {
+#
+# Do not wait for initial resync: raid0 has no redundancy so there
+# is no initial resync. Raid10 does not strictly needed a resync,
+# while the time taken for 4 1.9TB disk raid10 would be in range of
+# 20 minutes to 20 days, depending on dev.raid.speed_limit_min and
+# dev.raid.speed_limit_max sysctl parameters.
+maybe_raid() {
+  local raid_level="$1"
   local md_name="kubernetes"
   local md_device="/dev/md/${md_name}"
   local md_config="/.aws/mdadm.conf"
@@ -40,14 +47,10 @@ maybe_raid0() {
   if [[ ! -s "${md_config}" ]]; then
     mdadm --create --force --verbose \
       "${md_device}" \
-      --level=0 \
+      --level="${raid_level}" \
       --name="${md_name}" \
       --raid-devices="${#EPHEMERAL_DISKS[@]}" \
       "${EPHEMERAL_DISKS[@]}"
-    while [ -n "$(mdadm --detail "${md_device}" | grep -ioE 'State :.*resyncing')" ]; do
-      echo "Raid is resyncing..."
-      sleep 1
-    done
     mdadm --detail --scan > "${md_config}"
   fi
 
@@ -63,7 +66,8 @@ maybe_raid0() {
     ## for the log stripe unit, but the max log stripe unit is 256k.
     ## So instead, we use 32k (8 blocks) to avoid a warning of breaching the max.
     ## mkfs.xfs defaults to 32k after logging the warning since the default log buffer size is 32k.
-    mkfs.xfs -l su=8b "${md_device}"
+    ## Instances are delivered with disks fully trimmed, so TRIM is skipped at creation time.
+    mkfs.xfs -K -l su=8b "${md_device}"
   fi
 
   ## Create the mount directory
@@ -231,8 +235,8 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 DISK_SETUP="$1"
 set -u
 
-if [[ "${DISK_SETUP}" != "raid0" && "${DISK_SETUP}" != "mount" && "${DISK_SETUP}" != "none" ]]; then
-  echo "Valid disk setup options are: raid0, mount, or none"
+if [[ "${DISK_SETUP}" != "raid0" && "${DISK_SETUP}" != "raid10" && "${DISK_SETUP}" != "mount" && "${DISK_SETUP}" != "none" ]]; then
+  echo "Valid disk setup options are: raid0, raid10, mount or none"
   exit 1
 fi
 
@@ -256,10 +260,20 @@ fi
 ## Get devices of NVMe instance storage ephemeral disks
 EPHEMERAL_DISKS=($(realpath "${disks[@]}" | sort -u))
 
+## Also bail early if there are not enough disks for raid10
+if [[ "${DISK_SETUP}" == "raid10" && "${#EPHEMERAL_DISKS[@]}" -lt 4 ]]; then
+  echo "raid10 requires at least 4 disks, but only ${#EPHEMERAL_DISKS[@]} found, can not continue!"
+  exit 1
+fi
+
 case "${DISK_SETUP}" in
   "raid0")
-    maybe_raid0
+    maybe_raid 0
     echo "Successfully setup RAID-0 consisting of ${EPHEMERAL_DISKS[@]}"
+    ;;
+  "raid10")
+    maybe_raid 10
+    echo "Successfully setup RAID-10 consisting of ${EPHEMERAL_DISKS[@]}"
     ;;
   "mount")
     maybe_mount


### PR DESCRIPTION
**Description of changes:**
I would like to be able to migrate workloads away from a node gracefully in case of instance storage drive failure. Raid10 would provide redundancy and trade off disk space.

Adding support for creating raid10 in addition to raid0. This also removes the wait block for raid resync for two reasons:
1) raid0 does not have redundancy and therefore no initial resync[1]
2) with raid10 the resync time for 4x 1.9TB disks takes from tens of minutes to multiple hours, depending on sysctl params `dev.raid.speed_limit_min` and `dev.raid.speed_limit_max` and the speed of the disks. Initial resync for raid10 is not strictly needed[1]

**filesystem creation**: by default `mkfs.xfs` attempts to TRIM the drive. This is also something that can take tens of minutes or hours, depening on the size of drives. TRIM can be skipped, as instances are delivered with disks fully trimmed[2].

[1] https://raid.wiki.kernel.org/index.php/Initial_Array_Creation
[2] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html#InstanceStoreTrimSupport

**Testing Done**

on `m6id.metal` with kernel defaults:
```
# uname -a
Linux ip-10-24-0-65.eu-west-1.compute.internal 5.10.199-190.747.amzn2.x86_64 #1 SMP Sat Nov 4 16:55:14 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux

#  sysctl dev.raid.speed_limit_min
dev.raid.speed_limit_min = 1000

# sysctl dev.raid.speed_limit_max
dev.raid.speed_limit_max = 200000

# mdadm --create --force --verbose /dev/md/kubernetes --level=10 --name=kubernetes --raid-devices=4 /dev/nvme0n1 /dev/nvme1n1 /dev/nvme2n1 /dev/nvme3n1
mdadm: layout defaults to n2
mdadm: layout defaults to n2
mdadm: chunk size defaults to 512K
mdadm: size set to 1855337472K
mdadm: automatically enabling write-intent bitmap on large array
mdadm: Defaulting to version 1.2 metadata
mdadm: array /dev/md/kubernetes started.

# cat /proc/mdstat 
Personalities : [raid10] 
md127 : active raid10 nvme3n1[3] nvme2n1[2] nvme1n1[1] nvme0n1[0]
      3710674944 blocks super 1.2 512K chunks 2 near-copies [4/4] [UUUU]
      [>....................]  resync =  1.1% (41396352/3710674944) finish=304.3min speed=200910K/sec
      bitmap: 28/28 pages [112KB], 65536KB chunk
```

With increased resync limits:
```
# sysctl -w dev.raid.speed_limit_min=2146999999 ; sysctl -w dev.raid.speed_limit_max=2146999999
dev.raid.speed_limit_min = 2146999999
dev.raid.speed_limit_max = 2146999999

# cat /proc/mdstat 
Personalities : [raid10] 
md127 : active raid10 nvme3n1[3] nvme2n1[2] nvme1n1[1] nvme0n1[0]
      3710674944 blocks super 1.2 512K chunks 2 near-copies [4/4] [UUUU]
      [===>.................]  resync = 19.9% (740172096/3710674944) finish=20.4min speed=2418848K/sec
      bitmap: 23/28 pages [92KB], 65536KB chunk
```

Due to some... accidents, this replaces the old pull request: https://github.com/awslabs/amazon-eks-ami/pull/1549. There's further discussions about the details.