### PR TITLE
bug(bot): fix usage of commits API

### DIFF
--- a/.github/actions/bot/index.js
+++ b/.github/actions/bot/index.js
@@ -218,12 +218,12 @@ class CICommand {
             default:
                 throw new Error(`Unknown mergeable value: ${mergeable}`);
         }
-        const merge_commit = await github.rest.commits.get({
+        const merge_commit = await github.rest.repos.getCommit({
             owner: this.repository_owner,
             repo: this.repository_name,
             ref: pr.data.merge_commit_sha
         });
-        if (new Date(this.comment_created_at) < new Date(merge_commit.data.author.date)) {
+        if (new Date(this.comment_created_at) < new Date(merge_commit.data.commit.committer.date)) {
             return `@${author} this PR has been updated since your request, you'll need to review the changes.`;
         }
         const inputs = {


### PR DESCRIPTION
**Description of changes:**

Fixes: https://github.com/awslabs/amazon-eks-ami/actions/runs/10206683885/job/28240048034

> Error: TypeError: Cannot read properties of undefined (reading 'get')

**Testing done:**

Setup:
```
> npm init
> npm install "@octokit/rest"
```

Script:
```
#!/usr/bin/env node

import { Octokit } from "@octokit/rest";

new Octokit().rest.repos.getCommit({
    owner: "awslabs",
    repo: "amazon-eks-ami",
    ref: "ae70c27999e782c5758793cf0daeb93498d21a1a"
}).then((res) => {
  console.log(res.data.commit.committer.date);
});
```

Output:
```
> ./index.js
2024-06-19T17:30:32Z

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
