### PR TITLE
bug(bot): fix osDistro prefix matching

### DIFF
--- a/.github/actions/bot/index.js
+++ b/.github/actions/bot/index.js
@@ -185,9 +185,8 @@ class CICommand {
         });
         const osDistros = [];
         for (const file of files.data) {
-            for (const prefix of this.osDistroPathPrefixHints) {
+            for (const [prefix, osDistro] of Object.entries(this.osDistroPathPrefixHints)) {
                 if (file.filename.startsWith(prefix)) {
-                    const osDistro = this.osDistroPathPrefixHints[prefix];
                     osDistros.push(osDistro);
                 }
             }


### PR DESCRIPTION
**Description of changes:**

Fixes: https://github.com/awslabs/amazon-eks-ami/actions/runs/10207022458/job/28241040089

> Error: TypeError: this.osDistroPathPrefixHints is not iterable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

