### PR TITLE
Removed Sort-Object by time from Windows log collector script

### DIFF
--- a/log-collector-script/windows/eks-log-collector.ps1
+++ b/log-collector-script/windows/eks-log-collector.ps1
@@ -268,7 +268,7 @@ Function get_eks_logs{
 Function get_k8s_info{
     try {
         Write-Host "Collecting Kubelet logs"
-        Get-EventLog -LogName EKS -Source kubelet | Sort-Object Time | Export-CSV $info_system/kubelet/kubelet-service.csv
+        Get-EventLog -LogName EKS -Source kubelet | Export-CSV $info_system/kubelet/kubelet-service.csv
         Write-Host "OK" -foregroundcolor "green"
     }
     catch{
@@ -278,7 +278,7 @@ Function get_k8s_info{
 
     try {
         Write-Host "Collecting Kube-proxy logs"
-        Get-EventLog -LogName EKS -Source kube-proxy | Sort-Object Time | Export-CSV $info_system/kube-proxy/kube-proxy-service.csv
+        Get-EventLog -LogName EKS -Source kube-proxy | Export-CSV $info_system/kube-proxy/kube-proxy-service.csv
         Write-Host "OK" -foregroundcolor "green"
     }
     catch{
@@ -303,7 +303,7 @@ Function get_docker_logs{
     Write-Host "Collecting Docker daemon logs"
     if (check_service_installed_and_running "docker") {
         try {
-            Get-EventLog -LogName Application -Source Docker | Sort-Object Time | Export-CSV $info_system/docker_log/docker-daemon.csv
+            Get-EventLog -LogName Application -Source Docker | Export-CSV $info_system/docker_log/docker-daemon.csv
             Write-Host "OK" -foregroundcolor "green"
         }
         catch {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
It was observed that the Windows log collection script was not properly sorting the CSV files in chronological order. This is because the Time property is a string and does not account for millisecond differences. By removing the sorting, the default "Get-EventLog" will return the true chronological order of the logs by when they were created.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->
- Installed the script using `Invoke-WebRequest -OutFile eks-log-collector.ps1 https://raw.githubusercontent.com/awslabs/amazon-eks-ami/main/log-collector-script/windows/eks-log-collector.ps1 `
- Removed `Sort-Object` cmdlet
- Executed script using `.\eks-log-collector.ps1`
- Observed the CSV files for `kube-proxy` and `kubelet`

### Result

#### Kubelet CSV
```
"EventID","MachineName","Data","Index","Category","CategoryNumber","EntryType","Message","Source","ReplacementStrings","InstanceId","TimeGenerated","TimeWritten","UserName","Site","Container"
"0","**************************","System.Byte[]","641","(0)","0","Information","I0801 21:59:16.733518    6032 fake_topology_manager.go:72] ""AddContainer"" pod=""default/amazon-eks-gmsa-test-795b9c9c98-4rjdm"" containerName=""iis"" containerID=""13ed39edaf4a3fac9ea161fbb8924bb8dec5d44a91770a0ebb3d387e3bd9c07f""","kubelet","System.String[]","0","8/1/2024 9:59:16 PM","8/1/2024 9:59:16 PM",,,
"0","**************************","System.Byte[]","640","(0)","0","Information","I0801 21:59:16.733518    6032 fake_memory_manager.go:50] ""Add container"" pod=""default/amazon-eks-gmsa-test-795b9c9c98-4rjdm"" containerName=""iis"" containerID=""13ed39edaf4a3fac9ea161fbb8924bb8dec5d44a91770a0ebb3d387e3bd9c07f""","kubelet","System.String[]","0","8/1/2024 9:59:16 PM","8/1/2024 9:59:16 PM",,,
"0","**************************","System.Byte[]","639","(0)","0","Information","I0801 21:59:16.733518    6032 fake_cpu_manager.go:51] ""AddContainer"" pod=""default/amazon-eks-gmsa-test-795b9c9c98-4rjdm"" containerName=""iis"" containerID=""13ed39edaf4a3fac9ea161fbb8924bb8dec5d44a91770a0ebb3d387e3bd9c07f""","kubelet","System.String[]","0","8/1/2024 9:59:16 PM","8/1/2024 9:59:16 PM",,,
"0","**************************","System.Byte[]","638","(0)","0","Information","I0801 21:58:34.811802    6032 operation_generator.go:744] ""MountVolume.SetUp succeeded for volume \""kube-api-access-vmql2\"" (UniqueName: \""kubernetes.io/projected/67fd936b-14fc-430c-8646-cced2cb5b572-kube-api-access-vmql2\"") pod \""amazon-eks-gmsa-test-795b9c9c98-4rjdm\"" (UID: \""67fd936b-14fc-430c-8646-cced2cb5b572\"") "" pod=""default/amazon-eks-gmsa-test-795b9c9c98-4rjdm""","kubelet","System.String[]","0","8/1/2024 9:58:34 PM","8/1/2024 9:58:34 PM",,,
"0","**************************","System.Byte[]","637","(0)","0","Information","I0801 21:58:34.778033    6032 reconciler_common.go:228] ""operationExecutor.MountVolume started for volume \""kube-api-access-vmql2\"" (UniqueName: \""kubernetes.io/projected/67fd936b-14fc-430c-8646-cced2cb5b572-kube-api-access-vmql2\"") pod \""amazon-eks-gmsa-test-795b9c9c98-4rjdm\"" (UID: \""67fd936b-14fc-430c-8646-cced2cb5b572\"") "" pod=""default/amazon-eks-gmsa-test-795b9c9c98-4rjdm""","kubelet","System.String[]","0","8/1/2024 9:58:34 PM","8/1/2024 9:58:34 PM",,,
"0","**************************","System.Byte[]","636","(0)","0","Information","I0801 21:58:34.663208    6032 reconciler.go:41] ""Reconciler: start to sync state""","kubelet","System.String[]","0","8/1/2024 9:58:34 PM","8/1/2024 9:58:34 PM",,,
"0","**************************","System.Byte[]","635","(0)","0","Information","I0801 21:58:34.663208    6032 reconciler_common.go:253] ""operationExecutor.VerifyControllerAttachedVolume started for volume \""kube-api-access-vmql2\"" (UniqueName: \""kubernetes.io/projected/67fd936b-14fc-430c-8646-cced2cb5b572-kube-api-access-vmql2\"") pod \""amazon-eks-gmsa-test-795b9c9c98-4rjdm\"" (UID: \""67fd936b-14fc-430c-8646-cced2cb5b572\"") "" pod=""default/amazon-eks-gmsa-test-795b9c9c98-4rjdm""","kubelet","System.String[]","0","8/1/2024 9:58:34 PM","8/1/2024 9:58:34 PM",,,
"0","**************************","System.Byte[]","634","(0)","0","Information","I0801 21:58:34.647376    6032 desired_state_of_world_populator.go:159] ""Finished populating initial desired state of world""","kubelet","System.String[]","0","8/1/2024 9:58:34 PM","8/1/2024 9:58:34 PM",,,
"0","**************************","System.Byte[]","633","(0)","0","Information","I0801 21:58:34.565117    6032 apiserver.go:52] ""Watching apiserver""","kubelet","System.String[]","0","8/1/2024 9:58:34 PM","8/1/2024 9:58:34 PM",,,
"0","**************************","System.Byte[]","604","(0)","0","Information","I0801 21:58:33.637434    6032 kubelet_node_status.go:73] ""Successfully registered node"" node=""ip-10-0-11-167.us-west-2.compute.internal""","kubelet","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
```

#### Kube-proxy CSV
```
"EventID","MachineName","Data","Index","Category","CategoryNumber","EntryType","Message","Source","ReplacementStrings","InstanceId","TimeGenerated","TimeWritten","UserName","Site","Container"
"0","**************************","System.Byte[]","632","(0)","0","Information","I0801 21:58:33.838241    4904 hns.go:398] ""Created Hns loadbalancer policy resource"" loadBalancer=&{Id:8af39b52-d5a6-4d12-a070-783d2835e855 HostComputeEndpoints:[98c1250f-7027-48d9-8c8d-64f5797bcfe2 9c4b729d-9159-4e46-bbb0-3eb002b1f7ca] SourceVIP: FrontendVIPs:[172.20.0.10] PortMappings:[{Protocol:6 InternalPort:53 ExternalPort:53 DistributionType:0 Flags:0}] SchemaVersion:{Major:2 Minor:0} Flags:0}","kube-proxy","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
"0","**************************","System.Byte[]","631","(0)","0","Information","I0801 21:58:33.835166    4904 proxier.go:1420] ""Hns endpoint resource"" endpointsInfo=""10.0.7.11:0""","kube-proxy","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
"0","**************************","System.Byte[]","630","(0)","0","Information","I0801 21:58:33.835166    4904 proxier.go:1420] ""Hns endpoint resource"" endpointsInfo=""10.0.15.246:0""","kube-proxy","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
"0","**************************","System.Byte[]","629","(0)","0","Information","I0801 21:58:33.835166    4904 hns.go:398] ""Created Hns loadbalancer policy resource"" loadBalancer=&{Id:5bd69051-1b21-47e6-8dad-0f2d9177b0be HostComputeEndpoints:[aeb56464-681d-4b0b-820d-f708a6bacd4a 9d373769-33ab-4537-b505-57848dfbca2c] SourceVIP: FrontendVIPs:[172.20.0.1] PortMappings:[{Protocol:6 InternalPort:443 ExternalPort:443 DistributionType:0 Flags:0}] SchemaVersion:{Major:2 Minor:0} Flags:0}","kube-proxy","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
"0","**************************","System.Byte[]","628","(0)","0","Information","I0801 21:58:33.827521    4904 proxier.go:1420] ""Hns endpoint resource"" endpointsInfo=""10.0.21.129:0""","kube-proxy","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
"0","**************************","System.Byte[]","627","(0)","0","Information","I0801 21:58:33.827521    4904 proxier.go:1420] ""Hns endpoint resource"" endpointsInfo=""10.0.1.201:0""","kube-proxy","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
"0","**************************","System.Byte[]","626","(0)","0","Information","I0801 21:58:33.827521    4904 hns.go:398] ""Created Hns loadbalancer policy resource"" loadBalancer=&{Id:ed0732ab-0e01-476f-8576-01960b360298 HostComputeEndpoints:[8ba6185d-be07-4e85-ba7f-7f677caeeeb4] SourceVIP: FrontendVIPs:[172.20.51.47] PortMappings:[{Protocol:6 InternalPort:443 ExternalPort:443 DistributionType:0 Flags:0}] SchemaVersion:{Major:2 Minor:0} Flags:0}","kube-proxy","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
"0","**************************","System.Byte[]","625","(0)","0","Information","I0801 21:58:33.827521    4904 proxier.go:1420] ""Hns endpoint resource"" endpointsInfo=""10.0.26.159:0""","kube-proxy","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
"0","**************************","System.Byte[]","624","(0)","0","Information","I0801 21:58:33.827521    4904 hns.go:398] ""Created Hns loadbalancer policy resource"" loadBalancer=&{Id:c8dcf4e3-124c-4742-a748-0169c485d30b HostComputeEndpoints:[98c1250f-7027-48d9-8c8d-64f5797bcfe2 9c4b729d-9159-4e46-bbb0-3eb002b1f7ca] SourceVIP: FrontendVIPs:[172.20.0.10] PortMappings:[{Protocol:17 InternalPort:53 ExternalPort:53 DistributionType:0 Flags:0}] SchemaVersion:{Major:2 Minor:0} Flags:0}","kube-proxy","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
"0","**************************","System.Byte[]","623","(0)","0","Information","I0801 21:58:33.821929    4904 proxier.go:1420] ""Hns endpoint resource"" endpointsInfo=""10.0.7.11:0""","kube-proxy","System.String[]","0","8/1/2024 9:58:33 PM","8/1/2024 9:58:33 PM",,,
```

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
