### PR TITLE
Disable motd

### DIFF
--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -140,6 +140,12 @@
     {
       "type": "shell",
       "inline": [
+        "sudo systemctl disable update-motd"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
         "sudo mkdir -p /etc/eks/log-collector-script/",
         "sudo cp -v {{user `working_dir`}}/log-collector-script/eks-log-collector.sh /etc/eks/log-collector-script/"
       ]


### PR DESCRIPTION
Disabling motd results in a faster boot of the
AMI.

**Issue #, if available:** #1751

**Description of changes:** 

By disabling motd the AMI is able to boot up faster. The difference is about 20s. Analysis was done using systemd-analyze:

Before change:
Startup finished in 698ms (kernel) + 7.574s (initrd) + 1min 2.208s (userspace) = 1min 10.481s graphical.target reached after 1min 2.146s in userspace.

After change:
Startup finished in 454ms (kernel) + 3.842s (initrd) + 38.513s (userspace) = 42.810s graphical.target reached after 38.055s in userspace.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**: Launching a custom AMI made from one of the release AMI's

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
