### PR TITLE
Upgraded to Get-WinEvent cmdlet

### DIFF
--- a/log-collector-script/windows/eks-log-collector.ps1
+++ b/log-collector-script/windows/eks-log-collector.ps1
@@ -268,7 +268,7 @@ Function get_eks_logs{
 Function get_k8s_info{
     try {
         Write-Host "Collecting Kubelet logs"
-        Get-EventLog -LogName EKS -Source kubelet | Export-CSV $info_system/kubelet/kubelet-service.csv
+        Get-WinEvent -ProviderName kubelet | Export-CSV $info_system/kubelet/kubelet-service.csv
         Write-Host "OK" -foregroundcolor "green"
     }
     catch{
@@ -278,7 +278,7 @@ Function get_k8s_info{
 
     try {
         Write-Host "Collecting Kube-proxy logs"
-        Get-EventLog -LogName EKS -Source kube-proxy | Export-CSV $info_system/kube-proxy/kube-proxy-service.csv
+        Get-WinEvent -ProviderName kube-proxy | Export-CSV $info_system/kube-proxy/kube-proxy-service.csv
         Write-Host "OK" -foregroundcolor "green"
     }
     catch{
@@ -303,7 +303,7 @@ Function get_docker_logs{
     Write-Host "Collecting Docker daemon logs"
     if (check_service_installed_and_running "docker") {
         try {
-            Get-EventLog -LogName Application -Source Docker | Export-CSV $info_system/docker_log/docker-daemon.csv
+            Get-WinEvent -ProviderName Docker | Export-CSV $info_system/docker_log/docker-daemon.csv
             Write-Host "OK" -foregroundcolor "green"
         }
         catch {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
According to Microsoft, `Get-EventLog` uses a Win32 API that is deprecated and results provided may not be accurate. Instead, it is recommended that `Get-WinEvent` is used. This PR changes the log fetching mechanism to use that Cmdlet. Reference: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-eventlog?view=powershell-5.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->
- Ran the changes locally on a Windows instance
- Verified the CSV files based on RecordID number. Also ensured all the necessary fields are available (
*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*

**Test Result**
#### Old Kubelet CSV
![image](https://github.com/user-attachments/assets/4943c457-085f-4754-97a0-e843980c90ca)

#### New Kubelet CSV
![image](https://github.com/user-attachments/assets/0fdff4eb-37bb-4395-a6ae-09f296176316)

