### PR TITLE
bug(al2023): reset CNI cache on boot

### DIFF
--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -239,3 +239,8 @@ sudo chown -R root:root /etc/eks
 sudo sed -i \
   's/ - package-update-upgrade-install/# Removed so that nodes do not have version skew based on when the node was started.\n# - package-update-upgrade-install/' \
   /etc/cloud/cloud.cfg
+
+# the CNI results cache is not valid across reboots, and errant files can prevent cleanup of pod sandboxes
+# https://github.com/containerd/containerd/issues/8197
+# this was fixed in 1.2.x of libcni but containerd < 2.x are using libcni 1.1.x
+sudo systemctl enable cni-cache-reset

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/cni-cache-reset.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/cni-cache-reset.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Reset the CNI results cache
+Before=cloud-init.target
+
+[Service]
+Type=oneshot
+ExecStart=rm -rf /var/lib/cni/results
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
**Description of changes:**

This attempts to mitigate an issue with containerd 1.7.x (using libcni 1.1.x) in which pod sandboxes cannot be cleaned up because an errant (empty) file exists in the CNI results cache on disk.

More discussion: https://github.com/containerd/containerd/issues/8197

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
