### PR TITLE
bug(bot): ensure unique osDistros passed to workflow

### DIFF
--- a/.github/actions/bot/index.js
+++ b/.github/actions/bot/index.js
@@ -183,22 +183,22 @@ class CICommand {
             repo: this.repository_name,
             pull_number: this.pr_number
         });
-        const osDistros = [];
+        const osDistros = new Set();
         for (const file of files.data) {
             for (const [prefix, osDistro] of Object.entries(this.osDistroPathPrefixHints)) {
                 if (file.filename.startsWith(prefix)) {
-                    osDistros.push(osDistro);
+                    osDistros.add(osDistro);
                 }
             }
         }
-        if (osDistros.includes('*')) {
+        if (osDistros.has('*')) {
             console.log("changed files matched a prefix mapped to the wildcard, not attempting to guess os_distros!");
             return null;
         }
-        if (osDistros.length == 0) {
+        if (osDistros.size == 0) {
             return null;
         }
-        return osDistros.join(',');
+        return Array.from(osDistros).join(',');
     }
 
     async run(author, github) {


### PR DESCRIPTION
**Description of changes:**

Prevents duplicate entries in the workflow matrix: https://github.com/awslabs/amazon-eks-ami/actions/runs/10306693609

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
