### PR TITLE
Update eks-log-collector.sh

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -567,7 +567,7 @@ get_networking_info() {
   timeout 75 conntrack -L -f ipv6 >> "${COLLECT_DIR}"/networking/conntrack6.txt
 
   # ifconfig
-  timeout 75 ifconfig > "${COLLECT_DIR}"/networking/ifconfig.txt
+  command -v ifconfig && timeout 75 ifconfig || timeout 75 ip addr show > "${COLLECT_DIR}"/networking/ifconfig.txt
 
   # ip rule show
   timeout 75 ip rule show > "${COLLECT_DIR}"/networking/iprule.txt
@@ -692,10 +692,10 @@ get_system_services() {
   timeout 75 top -b -n 1 > "${COLLECT_DIR}"/system/top.txt 2>&1
   timeout 75 ps fauxwww --headers > "${COLLECT_DIR}"/system/ps.txt 2>&1
   timeout 75 ps -eTF --headers > "${COLLECT_DIR}"/system/ps-threads.txt 2>&1
-  timeout 75 netstat -plant > "${COLLECT_DIR}"/system/netstat.txt 2>&1
+  command -v  netstat && timeout 75 netstat -plant || timeout 75 ss -plant > "${COLLECT_DIR}"/system/netstat.txt 2>&1
   timeout 75 cat /proc/stat > "${COLLECT_DIR}"/system/procstat.txt 2>&1
   timeout 75 cat /proc/[0-9]*/stat > "${COLLECT_DIR}"/system/allprocstat.txt 2>&1
-
+  timeout 75 nstat -rsz > "${COLLECT_DIR}"/system/nstat.txt 2>&1
   # collect pids which have large environments
   echo -e "PID\tCount" > "${COLLECT_DIR}/system/large_environments.txt"
   for i in /proc/*/environ; do


### PR DESCRIPTION
* Added fallback for `ss` from netstat[1]. 
* Added fallback for `ip addr show` from ifconfig[1].
* Added `nstat` to track network stats such as Reverse Path filters. 

[1] ifconfig, netstat being deprecated: https://www.redhat.com/sysadmin/deprecated-linux-command-replacements

**Issue #, if available:**

**Description of changes:**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
* Succcesfully ran on an EKS node created from [AWS RHEL Repo](https://github.com/aws-samples/amazon-eks-ami-rhel)
* Tested the individual commands that are changed on both AL2 and AL2023

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->
  
*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
