### PR TITLE
bug(log-collector-script): look for kubelet config in the right place on AL2

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -474,6 +474,8 @@ get_k8s_info() {
 
       cp --force --recursive --dereference /etc/kubernetes/kubelet/config.json "${COLLECT_DIR}"/kubelet/config.json 2> /dev/null
       cp --force --recursive --dereference /etc/kubernetes/kubelet/config.json.d "${COLLECT_DIR}"/kubelet/config.json.d 2> /dev/null
+
+      cp --force --recursive --dereference /etc/kubernetes/kubelet/kubelet-config.json "${COLLECT_DIR}"/kubelet/kubelet-config.json 2> /dev/null
       ;;
     snap)
       timeout 75 snap logs kubelet-eks -n all > "${COLLECT_DIR}"/kubelet/kubelet.log


### PR DESCRIPTION
**Description of changes:**

Noticed our log bundles are missing the kubelet config in many cases, because on AL2 we put it at:
```
/etc/kubernetes/kubelet/kubelet-config.json
```
instead of:
```
/etc/kubernetes/kubelet/config.json
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
