### PR TITLE
eks-log-collector.sh: add reboot history

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -288,6 +288,7 @@ collect() {
   get_sandboxImage_info
   get_cpu_throttled_processes
   get_io_throttled_processes
+  get_reboot_history
   get_nvidia_bug_report
 }
 
@@ -797,6 +798,12 @@ get_io_throttled_processes() {
   # column 42 is Aggregated block I/O delays, measured in centiseconds so we capture the non-zero block
   # I/O delays.
   command cut -d" " -f 1,2,42 /proc/[0-9]*/stat | sort -n -k+3 -r | grep -v 0$ >> ${IO_THROTTLE_LOG}
+  ok
+}
+
+get_reboot_history() {
+  try "Collect reboot history"
+  timeout 75 last reboot > "${COLLECT_DIR}"/system/last_reboot.txt 2>&1 || echo -e "\tTimed out, ignoring \"reboot history output \" "
   ok
 }
 


### PR DESCRIPTION
**Issue #, if available:**
#1919

**Description of changes:**
Adds a reboot history log to the `system` dir in the collected logs. Logs will yield reboot events, timestamp and their status.
e.g.
```
reboot   system boot  6.1.102-108.177. Sun Aug 11 01:16   still running
reboot   system boot  6.1.102-108.177. Sun Aug 11 01:15   still running
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
Tested by executing the script on a `c6g.2xlarge` running AL23. Outputted successsfully, including feedback:
```
Trying to collect Docker daemon logs... 
Trying to collect sandbox-image daemon information... 
Trying to collect CPU Throttled Process Information... 
Trying to collect IO Throttled Process Information... 
Trying to collect reboot history... 
Trying to collect Nvidia Bug report... No Nvidia drivers found, nothing to do.

Trying to archive gathered information... 

	Done... your bundled logs are located in /var/log/eks_<instance-id>_2024-08-12_1313-UTC_0.7.8.tar.gz
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
