### PR TITLE
adding remote folder to shell provisioners scripts

### DIFF
--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -115,6 +115,7 @@
   "provisioners": [
     {
       "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
       "inline": [
         "mkdir -p {{user `working_dir`}}/rootfs",
         "mkdir -p {{user `working_dir`}}/shared",
@@ -139,6 +140,7 @@
     },
     {
       "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
       "inline": [
         "sudo mkdir -p /etc/eks/log-collector-script/",
         "sudo cp -v {{user `working_dir`}}/log-collector-script/eks-log-collector.sh /etc/eks/log-collector-script/"
@@ -151,12 +153,14 @@
     },
     {
       "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
       "inline": [
         "sudo cp -rv {{user `working_dir`}}/rootfs/* /"
       ]
     },
     {
       "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
       "inline": [
         "sudo chmod -R a+x {{user `working_dir`}}/shared/bin/",
         "sudo cp -rv {{user `working_dir`}}/shared/bin/* /usr/bin/"
@@ -220,6 +224,7 @@
     },
     {
       "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
       "inline": [
         "sudo rm -rf {{user `working_dir`}}"
       ]
@@ -242,7 +247,7 @@
       "custom_data": {
         "source_ami_name": "{{ build `SourceAMIName` }}",
         "source_ami_id": "{{ build `SourceAMI` }}"
-      }
     }
+   }
   ]
 }


### PR DESCRIPTION
**Issue #, if available:**
This is to fix an issue when applying EKS scripts on top of CIS_Amazon_Linux_2023_Benchmark_Level_1 AMI
**Description of changes:**

adding remote folder to shell provisioners scripts on template.json
When not having the option to add remote folder to shell provisioners scripts, scripts are created on /tmp
which is does not have required permissions on CIS_Amazon_Linux_2023_Benchmark_Level_1 AMI.
So you will face errors like:
```
2024-08-12T10:32:11+09:30: ==> amazon-ebs: Provisioning with shell script: /var/folders/2p/4n7c7gqs6xb23jgy_sq_3gsh0000gr/T/packer-shell2244599818
2024-08-12T10:32:12+09:30:     amazon-ebs: bash: line 1: /tmp/script_4590.sh: Permission denied
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

I am able to build an AMI after the changes with the following command
```
make k8s=1.30 os_distro=al2023 aws_region=ap-southeast-2 source_ami_id=ami-XXXXXXXXX source_ami_owners=XXXXXXXXX source_ami_filter_name="CIS Amazon Linux 2023 Benchmark - Level 1 - v07 -prod-fvm47vekg24oc" subnet_id=subnet-XXXXXXXXX associate_public_ip_address=true remote_folder=/home/ec2-user working_dir=/home/ec2-user
...
==> Builds finished. The artifacts of successful builds are:
--> amazon-ebs: AMIs were created:
ap-southeast-2: ami-XXXXXXXXXXXXXXXXXX
```
*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
