### PR TITLE
Added LLM-based issue summarizer.

### DIFF
--- a/.github/actions/summarizer/index.js
+++ b/.github/actions/summarizer/index.js
@@ -6,6 +6,14 @@ const context = github.context;
 const { BedrockRuntimeClient, InvokeModelCommand } = require("@aws-sdk/client-bedrock-runtime");
 
 (async () => {
+
+  const author = payload.comment.user.login;
+  const authorized = ["OWNER", "MEMBER"].includes(payload.comment.author_association);
+  if (!authorized) {
+    console.log(`Comment author is not authorized: ${author}`);
+    return;
+  }
+  console.log(`Comment author is authorized: ${author}`);
   // Split the command into parts
   const parts = process.env.COMMENT_BODY.trim().split(' ');
 

--- a/.github/actions/summarizer/index.js
+++ b/.github/actions/summarizer/index.js
@@ -2,11 +2,11 @@ const github  = require('@actions/github');
 const core    = require('@actions/core');
 const token   = process.env.GITHUB_TOKEN;
 const octokit = new github.getOctokit(token);
-const context = github.context;
 const { BedrockRuntimeClient, InvokeModelCommand } = require("@aws-sdk/client-bedrock-runtime");
 
 (async () => {
-
+  const context = github.context;
+  const payload = context.payload;
   const author = payload.comment.user.login;
   const authorized = ["OWNER", "MEMBER"].includes(payload.comment.author_association);
   if (!authorized) {
@@ -60,7 +60,7 @@ const { BedrockRuntimeClient, InvokeModelCommand } = require("@aws-sdk/client-be
       Assistant:
     `
   });
-  const payload = {
+  const modelInput = {
     anthropic_version: "bedrock-2023-05-31",
     max_tokens: 16384, // Adjust this if issue comment chain is long.
     messages: messages
@@ -68,11 +68,11 @@ const { BedrockRuntimeClient, InvokeModelCommand } = require("@aws-sdk/client-be
 
   const command = new InvokeModelCommand({
     contentType: "application/json",
-    body: JSON.stringify(payload),
+    body: JSON.stringify(modelInput),
     modelId: process.env.MODEL_ID,
   });
 
-  console.log("Prompting LLM with:\n" + JSON.stringify(payload));
+  console.log("Prompting LLM with:\n" + JSON.stringify(modelInput));
 
   try {
     const response = await client.send(command);

--- a/.github/actions/summarizer/index.js
+++ b/.github/actions/summarizer/index.js
@@ -1,0 +1,90 @@
+const github  = require('@actions/github');
+const core    = require('@actions/core');
+const token   = process.env.GITHUB_TOKEN;
+const octokit = new github.getOctokit(token);
+const context = github.context;
+const { BedrockRuntimeClient, InvokeModelCommand } = require("@aws-sdk/client-bedrock-runtime");
+
+(async () => {
+  // Split the command into parts
+  const parts = process.env.COMMENT_BODY.trim().split(' ');
+
+  // Initialize the result object with default values
+  let issueContext = {
+    owner: parts.length == 4 ? parts[1] : context.repo.owner,
+    repo: parts.length == 4 ? parts[2] : context.repo.repo,
+    issue_number: parts.length == 4 ? parts[3] : ( parts.length == 2 ? parts[1] : context.issue.number),
+  };
+
+  console.log("Issue Context:\n" + JSON.stringify(issueContext));
+
+  const { data: issue } = await octokit.rest.issues.get(issueContext);
+
+  const { data: comments } = await octokit.rest.issues.listComments(issueContext);
+
+  let commentLog = "Comment Log:\n";
+
+  commentLog += `${issue.user.login} created the issue:\n "${issue.body}"\n`
+
+  for (const comment of comments) {
+    if(
+      (comment.user.login != "github-actions[bot]") && 
+      (!comment.body.startsWith("/"))
+    ){
+      commentLog += `${comment.user.login} says:\n"${comment.body}"\n`
+    }
+  }
+
+  const client = new BedrockRuntimeClient({ region: process.env.AWS_REGION });
+
+  const prompt = `Give me a short summary of this GitHub Issue reply chain. Include details on what the issue is, and what was the conclusion. The full comment history is below: ${commentLog}`;
+
+  const messages = [
+    {
+      role: "user",
+      content: []
+    }
+  ];
+  messages[0].content.push({
+    type: "text",
+    text: `
+      Human: ${prompt}
+      Assistant:
+    `
+  });
+  const payload = {
+    anthropic_version: "bedrock-2023-05-31",
+    max_tokens: 16384, // Adjust this if issue comment chain is long.
+    messages: messages
+  };
+
+  const command = new InvokeModelCommand({
+    contentType: "application/json",
+    body: JSON.stringify(payload),
+    modelId: process.env.MODEL_ID,
+  });
+
+  console.log("Prompting LLM with:\n" + JSON.stringify(payload));
+
+  try {
+    const response = await client.send(command);
+
+    const responseBody = JSON.parse(new TextDecoder().decode(response.body));
+    const generation = responseBody.content[0].text;
+    //const generation = JSON.parse(responseBody).generation;
+
+    console.log(`Raw response:\n${JSON.stringify(response)}`);
+    console.log(`parsed response:\n${generation}`);
+
+    await octokit.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      body: generation,
+    });
+    console.log("Finished!");
+  } catch (error) {
+    console.log(error)
+    throw error;
+  }
+})();

--- a/.github/workflows/summarize.yml
+++ b/.github/workflows/summarize.yml
@@ -19,9 +19,7 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   summarize:
-    if: |
-      contains(github.event.comment.body, '/summarize') && 
-      (github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER' )
+    if: contains(github.event.comment.body, '/summarize')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/summarize.yml
+++ b/.github/workflows/summarize.yml
@@ -1,27 +1,17 @@
-# This is a basic workflow that is manually triggered
-
 name: Summarizer
-
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
 on:
   issue_comment:
     types: [created]
-
 permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read  # This is required for actions/checkout
+  id-token: write
+  contents: read
   issues: write
-
-
 env:
   AWS_REGION : "us-west-2"
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   summarize:
     if: contains(github.event.comment.body, '/summarize')
     runs-on: ubuntu-latest
-
     steps:
         # Checkout the repo
       - name: Checkout repository

--- a/.github/workflows/summarize.yml
+++ b/.github/workflows/summarize.yml
@@ -19,7 +19,9 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   summarize:
-    if: contains(github.event.comment.body, '/summarize')
+    if: |
+      contains(github.event.comment.body, '/summarize') && 
+      (github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER' )
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/summarize.yml
+++ b/.github/workflows/summarize.yml
@@ -1,0 +1,54 @@
+# This is a basic workflow that is manually triggered
+
+name: Summarizer
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+  issues: write
+
+
+env:
+  AWS_REGION : "us-west-2"
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  summarize:
+    if: contains(github.event.comment.body, '/summarize')
+    runs-on: ubuntu-latest
+
+    steps:
+        # Checkout the repo
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        # Get Nodejs lib
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+        # Install github actions lib
+      - name: Install github actions lib
+        run: npm install @actions/github@5.0.0
+      - name: Install core actions lib
+        run: npm install @actions/core
+      - name: Install aws bedrock lib
+        run: npm install @aws-sdk/client-bedrock-runtime
+        # Get AWS Credentials
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.BEDROCK_ACTION_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: GITHUB_ACTION
+        # invoke Bedrock to summarize the issue
+      - name: Summarize issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODEL_ID    : "anthropic.claude-3-5-sonnet-20240620-v1:0"
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: node .github/actions/summarizer/index.js


### PR DESCRIPTION
**Issue #, if available:**
N/A
**Description of changes:**
Added a GitHub Action that will summarize issues via: 
- `/summarize`
  - *Will summarize the issue in which the command is being called*
- `/summarize 123`
  - *Will summarize issue number 123*
- `/summarize bob dotfiles 123`
  - *Will summarize issue number 123 of the repository: bob/dotfiles*

**Example Output:**
> /summarize awslabs amazon-eks-ami 1751

>Here's a summary of the GitHub Issue reply chain:
>
>Issue: Startup is significantly slower on the AL2023 AMI compared to the AL2 AMI for Amazon EKS.
>
>Key points:
>1. The issue creator (stijndehaes) noticed that startup time increased from about 40 seconds on AL2 to over 100 seconds on AL2023.
>
>2. Analysis using systemd-analyze showed that nodeadm components were in the critical path, with nodeadm-config.service and nodeadm-run.service taking significant time.
>
>3. Investigations revealed that getting the kubelet version was a major bottleneck, taking about 13 seconds.
>
>4. Enabling EBS fast-restore improved startup time to around 50 seconds, but it was still slower than AL2.
>
>5. Experiments were conducted to optimize the startup process:
>   - Caching the kubelet version in an environment variable reduced nodeadm-config.service time from 21s to 5.12s.
>   - Disabling update-motd.service further improved startup time.
>
>6. Despite optimizations, AL2023 startup remained slower than AL2 (about 40s vs. 22s).
>
>Conclusions/Proposed Solutions:
>1. A pull request was created to disable update-motd.service for performance improvement.
>2. Caching the kubelet version during build time was suggested to avoid slow executable access during startup.
>3. The team is considering various optimizations to reduce startup time, including changing how the kubelet version is obtained and stored.
>
>The issue remains open, with ongoing discussions about further optimizations to bring AL2023 startup time closer to that of AL2.

The bot utilizes AWS Bedrock to trigger a `InvokeModelCommand` to Claude 3.5 Sonnet. In order to achieve this, a few things will have to be configured on a AWS Account:
- [An OIDC Identity Provider for GitHub](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
- (An IAM Role with access to Bedrock)[https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html]
  - This role must have a trust policy allowing the GitHub OIDC Identity Provider to `sts:AssumeRoleWithWebIdentity`

**⚠️ This Repository must also provide the ARN of this role in Secrets as BEDROCK_ACTION_ROLE_ARN**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
- Tested on forked repository.
- Tested on awslabs/amazon-eks-ami, awslabs/aws-shell, hashicorp/packer and verified robustness of summarization.
- Tested auth (confirmed that only owner/members can invoke command)
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
