### PR TITLE
Fix max-pods-calculator to consider only network card 0

### DIFF
--- a/templates/al2/runtime/max-pods-calculator.sh
+++ b/templates/al2/runtime/max-pods-calculator.sh
@@ -116,7 +116,7 @@ if [[ "$CNI_MAJOR_VERSION" -gt 1 ]] || ([[ "$CNI_MAJOR_VERSION" = 1 ]] && [[ "$C
   PREFIX_DELEGATION_SUPPORTED=true
 fi
 
-DESCRIBE_INSTANCES_RESULT=$(aws ec2 describe-instance-types --instance-type "${INSTANCE_TYPE}" --query 'InstanceTypes[0].{Hypervisor: Hypervisor, EniCount: NetworkInfo.MaximumNetworkInterfaces, PodsPerEniCount: NetworkInfo.Ipv4AddressesPerInterface, CpuCount: VCpuInfo.DefaultVCpus}' --output json)
+DESCRIBE_INSTANCES_RESULT=$(aws ec2 describe-instance-types --instance-type "${INSTANCE_TYPE}" --query 'InstanceTypes[0].{Hypervisor: Hypervisor, EniCount: NetworkInfo.NetworkCards[0].MaximumNetworkInterfaces, PodsPerEniCount: NetworkInfo.Ipv4AddressesPerInterface, CpuCount: VCpuInfo.DefaultVCpus}' --output json)
 
 HYPERVISOR_TYPE=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r '.Hypervisor')
 IS_NITRO=false

--- a/templates/al2/runtime/max-pods-calculator.sh
+++ b/templates/al2/runtime/max-pods-calculator.sh
@@ -116,15 +116,16 @@ if [[ "$CNI_MAJOR_VERSION" -gt 1 ]] || ([[ "$CNI_MAJOR_VERSION" = 1 ]] && [[ "$C
   PREFIX_DELEGATION_SUPPORTED=true
 fi
 
-DESCRIBE_INSTANCES_RESULT=$(aws ec2 describe-instance-types --instance-type "${INSTANCE_TYPE}" --query 'InstanceTypes[0].{Hypervisor: Hypervisor, EniCount: NetworkInfo.NetworkCards[0].MaximumNetworkInterfaces, PodsPerEniCount: NetworkInfo.Ipv4AddressesPerInterface, CpuCount: VCpuInfo.DefaultVCpus}' --output json)
-
+DESCRIBE_INSTANCES_RESULT=$(aws ec2 describe-instance-types --instance-type "${INSTANCE_TYPE}" --query 'InstanceTypes[0].{Hypervisor: Hypervisor, NetworkInfo: NetworkInfo, CpuCount: VCpuInfo.DefaultVCpus}' --output json)
 HYPERVISOR_TYPE=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r '.Hypervisor')
 IS_NITRO=false
 if [[ "$HYPERVISOR_TYPE" == "nitro" ]]; then
   IS_NITRO=true
 fi
-INSTANCE_MAX_ENIS=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r '.EniCount')
-INSTANCE_MAX_ENIS_IPS=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r '.PodsPerEniCount')
+# Only one network card is used for pods, the default network card which is usually the network card 0
+DEFAULT_NETWORK_CARD_INDEX=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r '.NetworkInfo.DefaultNetworkCardIndex')
+INSTANCE_MAX_ENIS=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r ".NetworkInfo.NetworkCards[$DEFAULT_NETWORK_CARD_INDEX].MaximumNetworkInterfaces")
+INSTANCE_MAX_ENIS_IPS=$(echo $DESCRIBE_INSTANCES_RESULT | jq -r '.NetworkInfo.Ipv4AddressesPerInterface')
 
 if [ -z "$CNI_MAX_ENI" ]; then
   enis_for_pods=$INSTANCE_MAX_ENIS

--- a/templates/test/cases/max-pods-cni-1-18-0.sh
+++ b/templates/test/cases/max-pods-cni-1-18-0.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "-> Should calc max-pods successfully for c6in.32xlarge VPC CNI 1.18.0"
+exit_code=0
+out=$(/etc/eks/max-pods-calculator.sh \
+  --instance-type c6in.32xlarge \
+  --cni-version 1.18.0 \
+  --show-max-allowed || exit_code=$?)
+echo $out
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a non-zero exit code but got '${exit_code}'"
+  exit 1
+fi
+expected_max_pods="394"
+actual_max_pods=$(grep -o '[0-9]\+' <<< ${out})
+if [[ ${actual_max_pods} -ne ${expected_max_pods} ]]; then
+  echo "❌ Test Failed: expected max-pods for c6in.32xlarge w/ CNI 1.18.5 to be '${expected_max_pods}', but got '${actual_max_pods}'"
+  exit 1
+fi

--- a/templates/test/mocks/describe-instance-types/c6in-32xlarge.json
+++ b/templates/test/mocks/describe-instance-types/c6in-32xlarge.json
@@ -1,0 +1,36 @@
+{
+    "Hypervisor": "nitro",
+    "NetworkInfo": {
+        "NetworkPerformance": "200 Gigabit",
+        "MaximumNetworkInterfaces": 16,
+        "MaximumNetworkCards": 2,
+        "DefaultNetworkCardIndex": 0,
+        "NetworkCards": [
+            {
+                "NetworkCardIndex": 0,
+                "NetworkPerformance": "Up to 170 Gigabit",
+                "MaximumNetworkInterfaces": 8,
+                "BaselineBandwidthInGbps": 200.0,
+                "PeakBandwidthInGbps": 200.0
+            },
+            {
+                "NetworkCardIndex": 1,
+                "NetworkPerformance": "Up to 170 Gigabit",
+                "MaximumNetworkInterfaces": 8,
+                "BaselineBandwidthInGbps": 200.0,
+                "PeakBandwidthInGbps": 200.0
+            }
+        ],
+        "Ipv4AddressesPerInterface": 50,
+        "Ipv6AddressesPerInterface": 50,
+        "Ipv6Supported": true,
+        "EnaSupport": "required",
+        "EfaSupported": true,
+        "EfaInfo": {
+            "MaximumEfaInterfaces": 2
+        },
+        "EncryptionInTransitSupported": true,
+        "EnaSrdSupported": false
+    },
+    "CpuCount": 128
+}

--- a/templates/test/mocks/describe-instance-types/m4-xlarge.json
+++ b/templates/test/mocks/describe-instance-types/m4-xlarge.json
@@ -1,6 +1,26 @@
 {
     "Hypervisor": "xen",
-    "EniCount": 4,
-    "PodsPerEniCount": 15,
+    "NetworkInfo": {
+        "NetworkPerformance": "High",
+        "MaximumNetworkInterfaces": 4,
+        "MaximumNetworkCards": 1,
+        "DefaultNetworkCardIndex": 0,
+        "NetworkCards": [
+            {
+                "NetworkCardIndex": 0,
+                "NetworkPerformance": "High",
+                "MaximumNetworkInterfaces": 4,
+                "BaselineBandwidthInGbps": 0.75,
+                "PeakBandwidthInGbps": 2.8
+            }
+        ],
+        "Ipv4AddressesPerInterface": 15,
+        "Ipv6AddressesPerInterface": 15,
+        "Ipv6Supported": true,
+        "EnaSupport": "unsupported",
+        "EfaSupported": false,
+        "EncryptionInTransitSupported": false,
+        "EnaSrdSupported": false
+    },
     "CpuCount": 4
 }

--- a/templates/test/mocks/describe-instance-types/m5-8xlarge.json
+++ b/templates/test/mocks/describe-instance-types/m5-8xlarge.json
@@ -1,6 +1,26 @@
 {
     "Hypervisor": "nitro",
-    "EniCount": 8,
-    "PodsPerEniCount": 30,
+    "NetworkInfo": {
+        "NetworkPerformance": "10 Gigabit",
+        "MaximumNetworkInterfaces": 8,
+        "MaximumNetworkCards": 1,
+        "DefaultNetworkCardIndex": 0,
+        "NetworkCards": [
+            {
+                "NetworkCardIndex": 0,
+                "NetworkPerformance": "10 Gigabit",
+                "MaximumNetworkInterfaces": 8,
+                "BaselineBandwidthInGbps": 10.0,
+                "PeakBandwidthInGbps": 10.0
+            }
+        ],
+        "Ipv4AddressesPerInterface": 30,
+        "Ipv6AddressesPerInterface": 30,
+        "Ipv6Supported": true,
+        "EnaSupport": "required",
+        "EfaSupported": false,
+        "EncryptionInTransitSupported": false,
+        "EnaSrdSupported": false
+    },
     "CpuCount": 32
 }


### PR DESCRIPTION
**Issue #, if available:** Customer issue

**Description of changes:**
CNI only works with network card 0 for pods creation. In max-pods-calculator we are taking interfaces from all network cards which is resulting in wrong values for instances with multiple network cards. This is causing issues to cx who are using this script to generate max pod values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Ran the script across all instance types here https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/misc/eni-max-pods.txt and verified max pods values from the above file
