### PR TITLE
docs: fix incorrect policy permission guidelines for log collector

### DIFF
--- a/log-collector-script/linux/README.md
+++ b/log-collector-script/linux/README.md
@@ -91,7 +91,7 @@ Trying to archive gathered information...
 
 * SSM agent should be installed and running on Worker Node(s). [How to Install SSM Agent link](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html)
 
-* Worker Node(s) should have required permissions to communicate with SSM service. IAM managed role `AmazonSSMManagedInstanceCore` will have all the required permission for SSM agent to run on EC2 instances. The IAM managed role `AmazonSSMManagedInstanceCore` has `S3:PutObject` permission to all S3 resources.
+* Worker Node(s) should have required permissions to communicate with SSM service. IAM managed policy `AmazonSSMManagedInstanceCore` will have all the required permission for SSM agent to run on EC2 instances. Worker Node(s) should have `S3:PutObject` permission to all S3 resources.
 
 *Note:* For more granular control of the IAM permission check [Actions defined by AWS Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html%23awssystemsmanager-actions-as-permissions)
 

--- a/log-collector-script/linux/README.md
+++ b/log-collector-script/linux/README.md
@@ -91,7 +91,7 @@ Trying to archive gathered information...
 
 * SSM agent should be installed and running on Worker Node(s). [How to Install SSM Agent link](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html)
 
-* Worker Node(s) should have required permissions to communicate with SSM service. IAM managed policy `AmazonSSMManagedInstanceCore` will have all the required permission for SSM agent to run on EC2 instances. Worker Node(s) should have `S3:PutObject` permission to all S3 resources.
+* Worker Node(s) should have required permissions to communicate with SSM service and upload data to your S3 Bucket. The IAM managed policy `AmazonSSMManagedInstanceCore` will have all the required permissions for SSM agent to run on EC2 instances. You will need `S3:PutObject` permission to your S3 resources accordingly.
 
 *Note:* For more granular control of the IAM permission check [Actions defined by AWS Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html%23awssystemsmanager-actions-as-permissions)
 

--- a/log-collector-script/windows/README.md
+++ b/log-collector-script/windows/README.md
@@ -84,7 +84,7 @@ Done... your bundled logs are located in  C:\log-collector\eks_i-0b318f704c74b6a
 
 * SSM agent should be installed and running on Worker Node(s). [How to Install SSM Agent link](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html)
 
-* Worker Node(s) should have required permissions to communicate with SSM service. IAM managed policy `AmazonSSMManagedInstanceCore` will have all the required permission for SSM agent to run on EC2 instances. Worker Node(s) should have `S3:PutObject` permission to all S3 resources.
+* Worker Node(s) should have required permissions to communicate with SSM service and upload data to your S3 Bucket. The IAM managed policy `AmazonSSMManagedInstanceCore` will have all the required permissions for SSM agent to run on EC2 instances. You will need `S3:PutObject` permission to your S3 resources accordingly.
 
 *Note:* For more granular control of the IAM permission check [Actions defined by AWS Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html%23awssystemsmanager-actions-as-permissions)
 

--- a/log-collector-script/windows/README.md
+++ b/log-collector-script/windows/README.md
@@ -84,7 +84,7 @@ Done... your bundled logs are located in  C:\log-collector\eks_i-0b318f704c74b6a
 
 * SSM agent should be installed and running on Worker Node(s). [How to Install SSM Agent link](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html)
 
-* Worker Node(s) should have required permissions to communicate with SSM service. IAM managed role `AmazonSSMManagedInstanceCore` will have all the required permission for SSM agent to run on EC2 instances. The IAM managed role `AmazonSSMManagedInstanceCore` has `S3:PutObject` permission to all S3 resources.
+* Worker Node(s) should have required permissions to communicate with SSM service. IAM managed policy `AmazonSSMManagedInstanceCore` will have all the required permission for SSM agent to run on EC2 instances. Worker Node(s) should have `S3:PutObject` permission to all S3 resources.
 
 *Note:* For more granular control of the IAM permission check [Actions defined by AWS Systems Manager](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awssystemsmanager.html%23awssystemsmanager-actions-as-permissions)
 


### PR DESCRIPTION
…ut AmazonSSMManagedInstanceCore

**Issue #, if available:**

Fixes: https://github.com/awslabs/amazon-eks-ami/issues/1940

1. "IAM managed role AmazonSSMManagedInstanceCore" is not a role, it is an AWS managed role.
2. The IAM managed role AmazonSSMManagedInstanceCore does not have S3:PutObject permission to all S3 resources.

**Description of changes:**

1. Modify role into policy about AmazonSSMManagedInstanceCore.
2. Delete the documentation of  The IAM managed role AmazonSSMManagedInstanceCore has S3:PutObject permission to all S3 resources and add an instruction to have the S3:PutObject permission to all S3 resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
