### PR TITLE
bug(nodeadm): continue polling containerd on not yet initialized response

### DIFF
--- a/nodeadm/internal/aws/ecr/ecr.go
+++ b/nodeadm/internal/aws/ecr/ecr.go
@@ -23,7 +23,7 @@ func GetAuthorizationToken(awsRegion string) (string, error) {
 	}
 	ecrClient := ecr.NewFromConfig(awsConfig)
 	var token *ecr.GetAuthorizationTokenOutput
-	err = util.RetryExponentialBackoff(3, 2*time.Second, func() error {
+	err = util.RetryExponentialBackoff(2*time.Second, util.ConditionRetryCount(3), func() error {
 		token, err = ecrClient.GetAuthorizationToken(context.Background(), &ecr.GetAuthorizationTokenInput{})
 		return err
 	})

--- a/nodeadm/internal/containerd/sandbox.go
+++ b/nodeadm/internal/containerd/sandbox.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
 	"github.com/containerd/containerd/integration/remote"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
@@ -44,13 +45,27 @@ func cacheSandboxImage(cfg *api.NodeConfig) error {
 	imageSpec := &v1.ImageSpec{Image: sandboxImage}
 	authConfig := &v1.AuthConfig{Auth: ecrUserToken}
 
-	return util.RetryExponentialBackoff(3, 2*time.Second, func() error {
-		zap.L().Info("Pulling sandbox image..", zap.String("image", sandboxImage))
-		imageRef, err := client.PullImage(imageSpec, authConfig, nil)
-		if err != nil {
-			return err
-		}
-		zap.L().Info("Finished pulling sandbox image", zap.String("image-ref", imageRef))
-		return nil
-	})
+	return util.RetryExponentialBackoff(time.Second,
+		func(i *int, err error) bool {
+			// Our process is responsible for ensuring containerd is running prior to
+			// calling this function, so there should never be a terminal failure connecting
+			// to the socket. If it does, don't count this retry against the total.
+			// see: https://github.com/containerd/containerd/blob/26d6fd0c3fe505ad3bb1525c4514ef21c19c24d4/internal/cri/instrument/instrumented_service.go#L60
+			if e, ok := status.FromError(err); ok {
+				if e.Message() == "server is not initialized yet" {
+					*i -= 1
+				}
+			}
+			return *i < 5 // continue retries on 4 valid errors
+		},
+		func() error {
+			zap.L().Info("Pulling sandbox image..", zap.String("image", sandboxImage))
+			imageRef, err := client.PullImage(imageSpec, authConfig, nil)
+			if err != nil {
+				return err
+			}
+			zap.L().Info("Finished pulling sandbox image", zap.String("image-ref", imageRef))
+			return nil
+		},
+	)
 }


### PR DESCRIPTION
**Issue #, if available:**

tries to address https://github.com/awslabs/amazon-eks-ami/issues/1917

**Description of changes:**

refactor the sandbox image retries to take a condition `func` where we will exclude "server is not initialized yet" messages from containerd when it's starting up: https://github.com/containerd/containerd/blob/26d6fd0c3fe505ad3bb1525c4514ef21c19c24d4/internal/cri/instrument/instrumented_service.go#L60

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
