### PR TITLE
docs: Fix link to gen_vpc_ip_limits.go

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -16,7 +16,7 @@ hack/mkdocs.sh serve
 By default, the maximum number of pods able to be scheduled on a node is based off of the number of ENIs
 available, which is determined by the instance type. Larger instances generally have more ENIs. The
 number of ENIs limits how many IPV4 addresses are available on an instance, and we need one IP address
-per pod. You can [see this file](https://github.com/aws/amazon-vpc-cni-k8s/blob/main/scripts/gen_vpc_ip_limits.go)
+per pod. You can [see this file](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/scripts/gen_vpc_ip_limits.go)
 for the code that calculates the max pods for more information.
 
 As an optimization, the default value for all known instance types are available in a resource file


### PR DESCRIPTION

**Issue #, if available:** n/a

**Description of changes:**
Fix broken link to nonexistent branch (HTTP 404): `s/main/master/`

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
n/a
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->