### PR TITLE
disable node swap on AL2

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version-file: 'nodeadm/go.mod'
       - run: go install github.com/securego/gosec/v2/cmd/gosec@latest
-      - run: gosec -exclude-generated ./...
+      - run: gosec -exclude-generated -exclude=G115 ./...
         working-directory: nodeadm
   govulncheck:
     runs-on: ubuntu-latest

--- a/templates/al2/runtime/kubelet-config.json
+++ b/templates/al2/runtime/kubelet-config.json
@@ -26,8 +26,10 @@
   "readOnlyPort": 0,
   "cgroupDriver": "cgroupfs",
   "cgroupRoot": "/",
+  "failSwapOn": false,
   "featureGates": {
-    "RotateKubeletServerCertificate": true
+    "RotateKubeletServerCertificate": true,
+    "NodeSwap": false
   },
   "protectKernelDefaults": true,
   "serializeImagePulls": false,


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/amazon-eks-ami/issues/1868
There is some instance have swap turned on, `c1.medium` and when it run with AL2 + 1.30+ AMIs, node failed to join the cluster

**Description of changes:**
Disable NodeSwap feature flag and not fail when swap on to unblock node join cluster


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
- repo: launch node with latest AMI on c1.medium, node fail to join
- fix: node able to join with fx

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
