### PR TITLE
Wait for networking to be up before loading NVIDIA kernel modules

### DIFF
--- a/templates/al2023/runtime/gpu/nvidia-kmod-load.service
+++ b/templates/al2023/runtime/gpu/nvidia-kmod-load.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Loading NVIDIA kernel modules
-# load modules after cloud-init
-After=cloud-final.service
-Requires=cloud-final.service
-Before=nvidia-persistenced.service
+# the script needs to use IMDS, so wait for the network to be up to avoid any flakiness
+After=network-online.target
+Wants=network-online.target
+Before=nvidia-fabricmanager.service nvidia-persistenced.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We do a call to IMDS in the script that loads the NVIDIA kernel modules. We noticed that in some cases module loading fails because the networking stack is not yet ready. When modules are not loaded, NVIDIA device plugin crashes and GPU workloads (in our case `aws-k8s-tester` tests) are not executed on the node. In this PR we wire the systemd service to run after networking is up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Built the AMI and executed NVIDIA test suite from `aws-k8s-tester` multiple times.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
