### PR TITLE
nodeadm: retry IMDS 404 errors

### DIFF
--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/aws/ecr"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/aws/imds"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/cli"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/configprovider"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/containerd"
@@ -146,14 +146,18 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 // perform in-place updates when allowed by the user
 func enrichConfig(log *zap.Logger, cfg *api.NodeConfig) error {
 	log.Info("Fetching instance details..")
-	imdsClient := imds.New(imds.Options{})
-	awsConfig, err := config.LoadDefaultConfig(context.TODO(), config.WithClientLogMode(aws.LogRetries), config.WithEC2IMDSRegion(func(o *config.UseEC2IMDSRegion) {
-		o.Client = imdsClient
-	}))
+	awsConfig, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithClientLogMode(aws.LogRetries),
+		config.WithEC2IMDSRegion(func(o *config.UseEC2IMDSRegion) {
+			// Use our pre-configured IMDS client to avoid hitting common retry
+			// issues with the default config.
+			o.Client = imds.Client
+		}),
+	)
 	if err != nil {
 		return err
 	}
-	instanceDetails, err := api.GetInstanceDetails(context.TODO(), cfg.Spec.FeatureGates, imdsClient, ec2.NewFromConfig(awsConfig))
+	instanceDetails, err := api.GetInstanceDetails(context.TODO(), cfg.Spec.FeatureGates, ec2.NewFromConfig(awsConfig))
 	if err != nil {
 		return err
 	}

--- a/nodeadm/internal/aws/ecr/ecr.go
+++ b/nodeadm/internal/aws/ecr/ecr.go
@@ -39,7 +39,7 @@ func (r *ECRRegistry) GetSandboxImage() string {
 
 func GetEKSRegistry(region string) (ECRRegistry, error) {
 	account, region := getEKSRegistryCoordinates(region)
-	servicesDomain, err := imds.GetProperty(imds.ServicesDomain)
+	servicesDomain, err := imds.GetProperty(context.TODO(), imds.ServicesDomain)
 	if err != nil {
 		return "", err
 	}

--- a/nodeadm/internal/configprovider/userdata.go
+++ b/nodeadm/internal/configprovider/userdata.go
@@ -1,6 +1,7 @@
 package configprovider
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/api"
@@ -22,7 +23,7 @@ type userDataProvider interface {
 type imdsUserDataProvider struct{}
 
 func (p *imdsUserDataProvider) GetUserData() ([]byte, error) {
-	return imds.GetUserData()
+	return imds.GetUserData(context.TODO())
 }
 
 type userDataConfigProvider struct {

--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/url"
 	"os"
@@ -20,10 +19,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8skubelet "k8s.io/kubelet/config/v1beta1"
 
-	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/smithy-go/ptr"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/aws/imds"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/containerd"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/system"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
@@ -203,7 +202,7 @@ func (ksc *kubeletConfig) withOutpostSetup(cfg *api.NodeConfig) error {
 }
 
 func (ksc *kubeletConfig) withNodeIp(cfg *api.NodeConfig, flags map[string]string) error {
-	nodeIp, err := getNodeIp(context.TODO(), imds.New(imds.Options{}), cfg)
+	nodeIp, err := getNodeIp(context.TODO(), cfg)
 	if err != nil {
 		return err
 	}
@@ -407,36 +406,24 @@ func getProviderId(availabilityZone, instanceId string) string {
 }
 
 // Get the IP of the node depending on the ipFamily configured for the cluster
-func getNodeIp(ctx context.Context, imdsClient *imds.Client, cfg *api.NodeConfig) (string, error) {
+func getNodeIp(ctx context.Context, cfg *api.NodeConfig) (string, error) {
 	ipFamily, err := api.GetCIDRIpFamily(cfg.Spec.Cluster.CIDR)
 	if err != nil {
 		return "", err
 	}
 	switch ipFamily {
 	case api.IPFamilyIPv4:
-		ipv4Response, err := imdsClient.GetMetadata(ctx, &imds.GetMetadataInput{
-			Path: "local-ipv4",
-		})
+		ipv4, err := imds.GetProperty(ctx, "local-ipv4")
 		if err != nil {
 			return "", err
 		}
-		ip, err := io.ReadAll(ipv4Response.Content)
-		if err != nil {
-			return "", err
-		}
-		return string(ip), nil
+		return ipv4, nil
 	case api.IPFamilyIPv6:
-		ipv6Response, err := imdsClient.GetMetadata(ctx, &imds.GetMetadataInput{
-			Path: fmt.Sprintf("network/interfaces/macs/%s/ipv6s", cfg.Status.Instance.MAC),
-		})
+		ipv6, err := imds.GetProperty(ctx, imds.IMDSProperty(fmt.Sprintf("network/interfaces/macs/%s/ipv6s", cfg.Status.Instance.MAC)))
 		if err != nil {
 			return "", err
 		}
-		ip, err := io.ReadAll(ipv6Response.Content)
-		if err != nil {
-			return "", err
-		}
-		return string(ip), nil
+		return ipv6, nil
 	default:
 		return "", fmt.Errorf("invalid ip-family. %s is not one of %v", ipFamily, []api.IPFamily{api.IPFamilyIPv4, api.IPFamilyIPv6})
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

`nodeadm` fails to make IMDS calls when the instance's credentials propagate slower, causing IMDS to return an error indicating no iam credentials were provided for an instance and a 404 is returned.

It now checks for this error message and counts it as retryable

```
Aug 28 19:12:30 localhost nodeadm[1491]: {"level":"info","ts":1724872350.0166261,"caller":"init/init.go:148","msg":"Fetching instance details.."}
Aug 28 19:12:30 localhost nodeadm[1491]: SDK 2024/08/28 19:12:30 DEBUG attempting waiter request, attempt count: 1
Aug 28 19:12:30 localhost nodeadm[1491]: SDK 2024/08/28 19:12:30 DEBUG request failed with unretryable error http response error StatusCode: 404, request to EC2 IMDS failed
```

`cloud-init` showing IMDS resolving ~2 second later
```
2024-08-28 19:12:32,448 - url_helper.py[DEBUG]: Read from http://169.254.169.254:80/2021-03-23/meta-data/instance-id (200, 19b) after 1 attempts
```

other notable changes:
* removed all direct uses of the aws imds client besides in the internal helper implementation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

we have a test case https://github.com/awslabs/amazon-eks-ami/blob/71aa1082300050221bb940abf14f0ba635fc59eb/nodeadm/test/e2e/cases/imds-timeouts/run.sh, meant to show that nodeadm will succeed if IMDS comes up in the middle of execution 

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
