### PR TITLE
Fix AL2023 Support for iam_instance_profile

### DIFF
--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -86,6 +86,7 @@
         "max_attempts": 480
       },
       "ami_regions": "{{user `ami_regions`}}",
+      "iam_instance_profile": "{{user `iam_instance_profile`}}",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_interface": "{{user `ssh_interface`}}",
       "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidrs`}}",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This fixes `iam_instance_profile` support for AL2023, which the variable was added here https://github.com/awslabs/amazon-eks-ami/pull/1679 but never actually added to the input of builder.

You can see it was added for AL2 (which I tested and works fine as well) but just missed for AL2023 https://github.com/awslabs/amazon-eks-ami/pull/1679/files#diff-c3563ab5a13c6689c9dc12566a56fa84b6d0fbe0b780c749ea4e4119e463e477R90

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

I built the image locally using `ssh_interface=session_manager iam_instance_profile=SSMAutomationPacker` and was able to successfully build AL2023 over SSM

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
