### PR TITLE
Fix cn build

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -12,7 +12,14 @@ echo "Installing NVIDIA ${NVIDIA_DRIVER_MAJOR_VERSION} drivers..."
 ################################################################################
 ### Add repository #############################################################
 ################################################################################
-sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/cuda-amzn2023.repo
+# Determine the domain based on the region
+if [[ $AWS_REGION == cn-* ]]; then
+  DOMAIN="nvidia.cn"
+else
+  DOMAIN="nvidia.com"
+fi
+
+sudo dnf config-manager --add-repo https://developer.download.${DOMAIN}/compute/cuda/repos/amzn2023/x86_64/cuda-amzn2023.repo
 sudo dnf config-manager --add-repo https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo
 
 sudo sed -i 's/gpgcheck=0/gpgcheck=1/g' /etc/yum.repos.d/nvidia-container-toolkit.repo /etc/yum.repos.d/cuda-amzn2023.repo

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -20,7 +20,7 @@
     "kms_key_id": "",
     "launch_block_device_mappings_volume_size": "20",
     "nodeadm_build_image": "public.ecr.aws/eks-distro-build-tooling/golang:1.23",
-    "nvidia_driver_major_version": "555",
+    "nvidia_driver_major_version": "560",
     "remote_folder": "/tmp",
     "runc_version": "*",
     "security_group_id": "",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Seeing intermittent connectivity issue when build AMI in ZHY
```
libnvidia-container-tools-1.16.2-1.x86_64.rpm: Curl error (28): Timeout was reached for https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/libnvidia-container-tools-1.16.2-1.x86_64.rpm [Operation too slow. Less than 1000 bytes/sec transferred the last 30 seconds][0m
```
switch to China mirror for fix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
