### PR TITLE
set max application clock for H200

### DIFF
--- a/templates/al2023/runtime/gpu/set-nvidia-clocks.sh
+++ b/templates/al2023/runtime/gpu/set-nvidia-clocks.sh
@@ -31,6 +31,8 @@ elif [[ $GPUNAME == *"L4"* ]]; then
   nvidia-smi -ac 6251,2040
 elif [[ $GPUNAME == *"L40S"* ]]; then
   nvidia-smi -ac 9001,2520
+elif [[ $GPUNAME == *"H200"* ]]; then
+  nvidia-smi -ac 3201,1980
 else
   echo "unsupported gpu"
 fi


### PR DESCRIPTION
**Issue #, if available:**
None

**Description of changes:**
We didn't include H200 GPUs where we set the Nvidia boost clock when bootstrapping GPU AMI, so when launching a P5e node in the cluster, we'll see an output of `ERROR: unsupported GPU` in your cloud-init execution logs.

**Testing Done**
check the max supported clock by running `nvidia-smi -q -d CLOCK` and `nvidia-smi -q -d SUPPORTED_CLOCKS` in P5e.48xlarge instance
```
sh-4.2$ nvidia-smi -q -d CLOCK

==============NVSMI LOG==============

Timestamp                                 : Tue Oct  1 20:21:32 2024
Driver Version                            : 550.90.07
CUDA Version                              : 12.4

Attached GPUs                             : 8
GPU 00000000:53:00.0
    Clocks
        Graphics                          : 345 MHz
        SM                                : 345 MHz
        Memory                            : 3199 MHz
        Video                             : 765 MHz
    Applications Clocks
        Graphics                          : 1980 MHz
        Memory                            : 3201 MHz
    Default Applications Clocks
        Graphics                          : 1980 MHz
        Memory                            : 3201 MHz
    Deferred Clocks
        Memory                            : N/A
    Max Clocks
        Graphics                          : 1980 MHz
        SM                                : 1980 MHz
        Memory                            : 3201 MHz
        Video                             : 1545 MHz
    Max Customer Boost Clocks
        Graphics                          : 1980 MHz
    SM Clock Samples
        Duration                          : Not Found



sh-4.2$ nvidia-smi -q -d SUPPORTED_CLOCKS

==============NVSMI LOG==============

Timestamp                                 : Tue Oct  1 19:47:39 2024
Driver Version                            : 550.90.07
CUDA Version                              : 12.4

Attached GPUs                             : 8
GPU 00000000:53:00.0
    Supported Clocks
        Memory                            : 3201 MHz
            Graphics                      : 1980 MHz
            Graphics                      : 1965 MHz
            Graphics                      : 1950 MHz
            Graphics                      : 1935 MHz
            Graphics                      : 1920 MHz
            Graphics                      : 1905 MHz
            Graphics                      : 1890 MHz
            Graphics                      : 1875 MHz
            Graphics                      : 1860 MHz
            Graphics                      : 1845 MHz
            Graphics                      : 1830 MHz
            Graphics                      : 1815 MHz
            Graphics                      : 1800 MHz
            Graphics                      : 1785 MHz
            Graphics                      : 1770 MHz
            Graphics                      : 1755 MHz
            Graphics                      : 1740 MHz
            Graphics                      : 1725 MHz
            Graphics                      : 1710 MHz
            Graphics                      : 1695 MHz

```