### PR TITLE
nodeadm(docs): fix incorrect MIME boundary in userdata example

### DIFF
--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -25,7 +25,7 @@ spec:
     certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
     cidr: 10.100.0.0/16
 
---BOUNDARY--
+--BOUNDARY
 Content-Type: application/node.eks.aws
 
 ---


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

fix a typo with the MIME boundary that might be causing some users following the examples to be unable to properly use multiple node configs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
