### PR TITLE
Added HTTP Check for FIPS endpoint

### DIFF
--- a/nodeadm/internal/aws/ecr/ecr.go
+++ b/nodeadm/internal/aws/ecr/ecr.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"go.uber.org/zap"
-	"net"
+	"net/http"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -49,8 +49,8 @@ func GetEKSRegistry(region string) (ECRRegistry, error) {
 	}
 	if fipsInstalled && fipsEnabled {
 		fipsRegistry := getRegistry(account, "ecr-fips", region, servicesDomain)
-		addresses, err := net.LookupHost(fipsRegistry)
-		if err == nil && len(addresses) > 0 {
+		resp, err := http.Get(fipsRegistry)
+		if err == nil && resp.StatusCode == 401 {
 			return ECRRegistry(fipsRegistry), nil
 		} else {
 			zap.L().Info("Fail to look up Fips registry for requested region, fall back to default", zap.String("fipsRegistry", fipsRegistry))

--- a/nodeadm/internal/aws/ecr/ecr.go
+++ b/nodeadm/internal/aws/ecr/ecr.go
@@ -49,11 +49,13 @@ func GetEKSRegistry(region string) (ECRRegistry, error) {
 	}
 	if fipsInstalled && fipsEnabled {
 		fipsRegistry := getRegistry(account, "ecr-fips", region, servicesDomain)
-		resp, err := http.Get(fipsRegistry)
+		fipsRegistryUrl := "https://" + fipsRegistry
+		resp, err := http.Get(fipsRegistryUrl)
 		if err == nil && resp.StatusCode == 401 {
+			zap.L().Info("Connected to FIPS ECR registry, using the FIPS registry endpoint", zap.String("fipsRegistry", fipsRegistry))
 			return ECRRegistry(fipsRegistry), nil
 		} else {
-			zap.L().Info("Fail to look up Fips registry for requested region, fall back to default", zap.String("fipsRegistry", fipsRegistry))
+			zap.L().Info("Fail to connect to the FIPS ECR registry for requested region, fall back to default", zap.String("fipsRegistry", fipsRegistry))
 		}
 	}
 	return ECRRegistry(getRegistry(account, "ecr", region, servicesDomain)), nil


### PR DESCRIPTION
**Issue #, if available:**
#1984
**Description of changes:**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

There is a bug when you have enabled FIPS on the image, in a region with FIPS endpoints, and have VPC endpoints enabled. The issue is that the check implemented in https://github.com/awslabs/amazon-eks-ami/pull/1524 , checks to see if the FIPS endpoint resolves. In an isolated environment, the endpoint does resolve. But, there is not a FIPS enabled ECR VPC endpoint available. I switched the check from being a DNS request, to a HTTP call.


**Testing Done**
I used packer to build an Al2023 node with FIPS enabled to test. I also used the same code in a RHEL build downstream.


*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
