### PR TITLE
feat(nodeadm): use cached kubelet version to reduce config time

### DIFF
--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -2,6 +2,7 @@ package init
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -46,6 +47,8 @@ func (c *initCmd) Flaggy() *flaggy.Subcommand {
 }
 
 func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+	start := time.Now()
+
 	log.Info("Checking user is root..")
 	root, err := cli.IsRunningAsRoot()
 	if err != nil {
@@ -138,6 +141,8 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 			log.Info("Finished post-launch tasks", nameField)
 		}
 	}
+
+	log.Info("done!", zap.Duration("duration", time.Since(start)))
 
 	return nil
 }

--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -187,6 +187,9 @@ done
 
 sudo rm ./*.sha256
 
+kubelet --version > "${WORKING_DIR}/kubelet-version.txt"
+sudo mv "${WORKING_DIR}/kubelet-version.txt" /etc/eks/kubelet-version.txt
+
 ################################################################################
 ### ECR Credential Provider Binary #############################################
 ################################################################################


### PR DESCRIPTION
**Issue #, if available:**

Improves #1751.

**Description of changes:**

This PR aims to reduce `nodeadm-config` time by determining the `kubelet` version using a text file created during the AMI build process, instead of executing `kubelet --version`.

Using `kubelet --version` involves EBS lazy-loading time plus the overhead of the child process, and doing this during `nodeadm-config` delays execution of the user's user data scripts and `nodeadm-run`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
