### PR TITLE
templates(al2): update containerd to latest

### DIFF
--- a/templates/al2/variables-default.json
+++ b/templates/al2/variables-default.json
@@ -13,7 +13,7 @@
     "binary_bucket_region": "us-west-2",
     "cache_container_images": "false",
     "cni_plugin_version": "v1.2.0",
-    "containerd_version": "1.7.11-*",
+    "containerd_version": "1.7.*",
     "creator": "{{env `USER`}}",
     "docker_version": "none",
     "enable_fips": "false",


### PR DESCRIPTION
**Issue #, if available:**

Resolves partially #1933 .

**Description of changes:**

This updates to the latest version of `containerd` available in the Amazon Linux repository, `1.7.22`, which resolves the bug discussed in #1933. This is only available for Amazon Linux 2 at this time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.