### PR TITLE
feat(al2023): initialize critical binaries from EBS filesystem

### DIFF
--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -133,6 +133,8 @@ fi
 sudo dnf install -y runc-${RUNC_VERSION}
 sudo dnf install -y containerd-${CONTAINERD_VERSION}
 
+sudo systemctl enable ebs-initialize-bin@containerd
+
 ###############################################################################
 ### Nerdctl setup #############################################################
 ###############################################################################
@@ -189,6 +191,8 @@ sudo rm ./*.sha256
 
 kubelet --version > "${WORKING_DIR}/kubelet-version.txt"
 sudo mv "${WORKING_DIR}/kubelet-version.txt" /etc/eks/kubelet-version.txt
+
+sudo systemctl enable ebs-initialize-bin@kubelet
 
 ################################################################################
 ### ECR Credential Provider Binary #############################################

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/ebs-initialize-bin@.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/ebs-initialize-bin@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Initialize critical binary (%i) from an EBS filesystem
+After=basic.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ebs-initialize /usr/bin/%i
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/shared/runtime/bin/ebs-initialize
+++ b/templates/shared/runtime/bin/ebs-initialize
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# EBS blocks are loaded lazily, which can cause a noticeable delay before the first read/write of a file
+# this script allows specific, important files to be pre-loaded
+# see: https://docs.aws.amazon.com/ebs/latest/userguide/ebs-initialize.html
+
+if [ "$#" -ne 1 ]; then
+  echo >&2 "usage: $0 FILE"
+  exit 1
+fi
+
+FILE="$1"
+
+dd if="${FILE}" of=/dev/null bs=1M


### PR DESCRIPTION
**Issue #, if available:**

Improves #1751.

**Description of changes:**

This PR adds a systemd "template unit"  (`ebs-initialize-bin@.service`) that is used to "initialize" various critical binaries which are stored on the root EBS filesystem (`nodeadm`, `kubelet`, `containerd`).

EBS blocks are lazily loaded, meaning the first read of one of these binaries usually involves a delay of a handful of seconds. By accessing these files as early in the boot process as possible, this delay is not felt in hot path of `nodeadm-config` and `nodeadm-run`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.