### PR TITLE
Add optional ECR auth to nodeadm

### DIFF
--- a/templates/al2023/provisioners/install-nodeadm.sh
+++ b/templates/al2023/provisioners/install-nodeadm.sh
@@ -6,6 +6,11 @@ set -o errexit
 
 sudo systemctl start containerd
 
+# if the image is from an ecr repository then try authenticate first
+if [[ "$BUILD_IMAGE" == *"dkr.ecr"* ]]; then
+  aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin "${BUILD_IMAGE%%/*}"
+fi
+
 sudo nerdctl run \
   --rm \
   --network host \

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -213,6 +213,10 @@
       "remote_folder": "{{ user `remote_folder`}}",
       "script": "{{template_dir}}/provisioners/install-nodeadm.sh",
       "environment_vars": [
+        "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
+        "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
+        "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
+        "AWS_REGION={{user `aws_region`}}",
         "BUILD_IMAGE={{user `nodeadm_build_image`}}",
         "PROJECT_DIR={{user `working_dir`}}/nodeadm"
       ]


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

allow ecr authentication when hitting non-open registries

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
