### PR TITLE
fix: use nerdctl to get auth creds

### DIFF
--- a/templates/al2023/provisioners/install-nodeadm.sh
+++ b/templates/al2023/provisioners/install-nodeadm.sh
@@ -8,7 +8,7 @@ sudo systemctl start containerd
 
 # if the image is from an ecr repository then try authenticate first
 if [[ "$BUILD_IMAGE" == *"dkr.ecr"* ]]; then
-  aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin "${BUILD_IMAGE%%/*}"
+  aws ecr get-login-password --region $AWS_REGION | nerdctl login --username AWS --password-stdin "${BUILD_IMAGE%%/*}"
 fi
 
 sudo nerdctl run \


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

bugfix for https://github.com/awslabs/amazon-eks-ami/pull/2017

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

tested in an al2023 box
```
$ aws ecr get-login-password --region us-west-2 | nerdctl login  --username AWS --password-stdin 602401143452.dkr.ecr.us-west-2.amazonaws.com
WARNING: Your password will be stored unencrypted in /root/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
