### PR TITLE
 fix: nerdctl login protocol

### DIFF
--- a/templates/al2023/provisioners/install-nodeadm.sh
+++ b/templates/al2023/provisioners/install-nodeadm.sh
@@ -8,7 +8,9 @@ sudo systemctl start containerd
 
 # if the image is from an ecr repository then try authenticate first
 if [[ "$BUILD_IMAGE" == *"dkr.ecr"* ]]; then
-  aws ecr get-login-password --region $AWS_REGION | nerdctl login --username AWS --password-stdin "${BUILD_IMAGE%%/*}"
+  # nerdctl needs the https:// prefix when logging in to the repository
+  # see: https://github.com/containerd/nerdctl/issues/742
+  aws ecr get-login-password --region $AWS_REGION | nerdctl login --username AWS --password-stdin "https://${BUILD_IMAGE%%/*}"
 fi
 
 sudo nerdctl run \


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

adds `https` prefix to AWS ECR repo login

see: https://github.com/containerd/nerdctl/issues/742 on logging in for AWS ECR with `nerdctl` and hitting `401` if not done correctly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
