### PR TITLE
ci: increase canary frequency

### DIFF
--- a/.github/workflows/ci-canary.yaml
+++ b/.github/workflows/ci-canary.yaml
@@ -1,8 +1,8 @@
 name: '[CI] Canary'
 on:
   schedule:
-    # daily at midnight
-    - cron: "0 0 * * *"
+    # twice daily at 8pm and 8am PST
+    - cron: "0 3,15 * * *"
 
 jobs:
   setup:


### PR DESCRIPTION
**Description of changes:**

This increases the canary to twice daily.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
