### PR TITLE
Add in AWS Credentials variable for NVIDIA install script

### DIFF
--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -237,6 +237,9 @@
       "environment_vars": [
         "AWS_REGION={{user `aws_region`}}",
         "ENABLE_ACCELERATOR={{user `enable_accelerator`}}",
+        "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
+        "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
+        "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
         "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",
         "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}",
         "NVIDIA_DRIVER_MAJOR_VERSION={{user `nvidia_driver_major_version`}}",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Add in AWS Credentials variable so NVIDIA artifacts can be pulled from s3 in isolated partitions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

