### PR TITLE
Address installation of NVIDIA drivers for Isolated partitions

### DIFF
--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -237,6 +237,9 @@
       "environment_vars": [
         "AWS_REGION={{user `aws_region`}}",
         "ENABLE_ACCELERATOR={{user `enable_accelerator`}}",
+        "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
+        "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
+        "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
         "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",
         "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}",
         "NVIDIA_DRIVER_MAJOR_VERSION={{user `nvidia_driver_major_version`}}",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Isolated partitions are receiving an error of `missing groups or modules: nvidia-driver:555-open`. This is because the script previously attempts to simplify the nvidia driver installation process if you are connected to nvidia repos (which isolated partitions cannot do) by doing a module install.

In isolated partitions, the Amazon Linux repos have already sourced the necessary nvidia drivers from NVIDIA. So all we need to do is directly install the open and closed sourced packages of the nvidia driver. This PR only affects isolated partitions to directly install the package.


