### PR TITLE
Bug fix for isolated partitons, wrap variable in quotes

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -77,7 +77,7 @@ sudo dnf -y install kernel-modules-extra.x86_64
 
 function archive-open-kmods() {
   if is-isolated-partition; then
-    sudo dnf -y install kmod-nvidia-open-dkms-${NVIDIA_DRIVER_MAJOR_VERSION}.*
+    sudo dnf -y install "kmod-nvidia-open-dkms-${NVIDIA_DRIVER_MAJOR_VERSION}.*"
   else
     sudo dnf -y module install nvidia-driver:${NVIDIA_DRIVER_MAJOR_VERSION}-open
   fi
@@ -103,7 +103,7 @@ function archive-open-kmods() {
 
 function archive-proprietary-kmod() {
   if is-isolated-partition; then
-    sudo dnf -y install kmod-nvidia-latest-dkms-${NVIDIA_DRIVER_MAJOR_VERSION}.*
+    sudo dnf -y install "kmod-nvidia-latest-dkms-${NVIDIA_DRIVER_MAJOR_VERSION}.*"
   else
     sudo dnf -y module install nvidia-driver:${NVIDIA_DRIVER_MAJOR_VERSION}-dkms
   fi


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Latest isolated partition build for NVIDIA drivers showed it wasn't able to find the necessary kmod-nvidia-open-dkms driver for the specified version although it is present. Our previous AL2 build scripts wrap these installations in quotes so going to mimic that.