### PR TITLE
Do not running ci-canary workflows on a fork

### DIFF
--- a/.github/workflows/ci-canary.yaml
+++ b/.github/workflows/ci-canary.yaml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   setup:
+    # Don't run if this is on a fork
+    if: github.repository == 'awslabs/amazon-eks-ami'
     runs-on: ubuntu-latest
     outputs:
       timestamp: ${{ steps.variables.outputs.timestamp }}


### PR DESCRIPTION
This is a small fix, but after rebasing the fork with main got repeated emails about the CI Canary a workflow failing on the fork. This probably shouldn't run unless it it specified to run seeing as it requires some amount of setup before it will pass on a fork. 
