### PR TITLE
feat(al2023): warn about bootstrap.sh usage

### DIFF
--- a/templates/al2023/runtime/rootfs/etc/eks/bootstrap.sh
+++ b/templates/al2023/runtime/rootfs/etc/eks/bootstrap.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+echo >&2 '
+!!!!!!!!!!
+!!!!!!!!!! ERROR: bootstrap.sh has been removed from AL2023-based EKS AMIs.
+!!!!!!!!!!
+!!!!!!!!!! EKS nodes are now initialized by nodeadm.
+!!!!!!!!!!
+!!!!!!!!!! To migrate your user data, see:
+!!!!!!!!!!
+!!!!!!!!!!     https://awslabs.github.io/amazon-eks-ami/nodeadm/
+!!!!!!!!!!
+'
+
+exit 1


### PR DESCRIPTION
**Description of changes:**

Adds more helpful logging to `/var/log/cloud-init-output.log` when AL2 user data is used on an AL2023 instance, using a fake `bootstrap.sh`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
