### PR TITLE
build: pull s3 binaries as root

### DIFF
--- a/templates/al2/provisioners/install-worker.sh
+++ b/templates/al2/provisioners/install-worker.sh
@@ -282,8 +282,8 @@ BINARIES=(
 for binary in ${BINARIES[*]}; do
   if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
     echo "AWS cli present - using it to copy binaries from s3."
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
+    sudo -E aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
+    sudo -E aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
   else
     echo "AWS cli missing - using wget to fetch binaries from s3. Note: This won't work for private bucket."
     sudo wget $S3_URL_BASE/$binary
@@ -316,8 +316,8 @@ if [ "$PULL_CNI_FROM_GITHUB" = "true" ]; then
 else
   if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
     echo "AWS cli present - using it to copy binaries from s3."
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz .
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz.sha256 .
+    sudo -E aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz .
+    sudo -E aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/${CNI_PLUGIN_FILENAME}.tgz.sha256 .
   else
     echo "AWS cli missing - using wget to fetch cni binaries from s3. Note: This won't work for private bucket."
     sudo wget "$S3_URL_BASE/${CNI_PLUGIN_FILENAME}.tgz"
@@ -377,7 +377,7 @@ sudo chmod +x /etc/eks/max-pods-calculator.sh
 ECR_CREDENTIAL_PROVIDER_BINARY="ecr-credential-provider"
 if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
   echo "AWS cli present - using it to copy ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3."
-  aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .
+  sudo -E aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .
 else
   echo "AWS cli missing - using wget to fetch ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3. Note: This won't work for private bucket."
   sudo wget "$S3_URL_BASE/$ECR_CREDENTIAL_PROVIDER_BINARY"

--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -24,7 +24,7 @@ function rpm_install() {
   local RPMS=($@)
   echo "Pulling and installing local rpms from s3 bucket"
   for RPM in "${RPMS[@]}"; do
-    aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/${RPM} ${WORKING_DIR}/${RPM}
+    sudo -E aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/${RPM} ${WORKING_DIR}/${RPM}
     sudo dnf localinstall -y ${WORKING_DIR}/${RPM}
   done
 }
@@ -34,7 +34,7 @@ function install-nvidia-container-toolkit() {
   RPMS=("libnvidia-container1-1.17.1-1.x86_64.rpm" "nvidia-container-toolkit-base-1.17.1-1.x86_64.rpm" "libnvidia-container-tools-1.17.1-1.x86_64.rpm" "nvidia-container-toolkit-1.17.1-1.x86_64.rpm")
   for RPM in "${RPMS[@]}"; do
     echo "pulling and installing rpms: (${RPM}) from s3 bucket: (${BINARY_BUCKET_NAME}) in region: (${BINARY_BUCKET_REGION})"
-    aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/${RPM} ${WORKING_DIR}/${RPM}
+    sudo -E aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/${RPM} ${WORKING_DIR}/${RPM}
     echo "installing rpm: ${WORKING_DIR}/${RPM}"
     sudo rpm -ivh ${WORKING_DIR}/${RPM}
   done
@@ -47,7 +47,7 @@ echo "Installing NVIDIA ${NVIDIA_DRIVER_MAJOR_VERSION} drivers..."
 ################################################################################
 # Determine the domain based on the region
 if is-isolated-partition; then
-  aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/amzn2023-nvidia.repo ${WORKING_DIR}/amzn2023-nvidia.repo
+  sudo -E aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/amzn2023-nvidia.repo ${WORKING_DIR}/amzn2023-nvidia.repo
 
   sudo dnf config-manager --add-repo ${WORKING_DIR}/amzn2023-nvidia.repo
   rpm_install "opencl-filesystem-1.0-5.el7.noarch.rpm" "ocl-icd-2.2.12-1.el7.x86_64.rpm"

--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -175,8 +175,8 @@ BINARIES=(
 for binary in ${BINARIES[*]}; do
   if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
     echo "AWS cli present - using it to copy binaries from s3."
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
-    aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
+    sudo -E aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary .
+    sudo -E aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$binary.sha256 .
   else
     echo "AWS cli missing - using wget to fetch binaries from s3. Note: This won't work for private bucket."
     sudo wget $S3_URL_BASE/$binary
@@ -202,7 +202,7 @@ ECR_CREDENTIAL_PROVIDER_BINARY="ecr-credential-provider"
 
 if [[ -n "$AWS_ACCESS_KEY_ID" ]]; then
   echo "AWS cli present - using it to copy ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3."
-  aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .
+  sudo -E aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .
 else
   echo "AWS cli missing - using wget to fetch ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3. Note: This won't work for private bucket."
   sudo wget "$S3_URL_BASE/$ECR_CREDENTIAL_PROVIDER_BINARY"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Whenever the AMI builds pull from S3 they no longer use act as root (like all other operations). This change runs the `aws s3 cp` steps with `sudo -E` to preserve the AWS creds from the environment.

this affects kubelet for example, which you would expect to be owned by `root`
```bash
sh-5.2$ cat /etc/eks/release
BASE_AMI_ID="ami-0c968d9bc191231c8"
BUILD_TIME="Sat Nov  9 23:07:34 UTC 2024"
BUILD_KERNEL="6.1.112-124.190.amzn2023.x86_64"
ARCH="x86_64"
sh-5.2$ ls -latr /usr/bin/kubelet
-rwxrwxr-x. 1 ec2-user ec2-user 76931672 Sep 17 19:16 /usr/bin/kubelet
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**


results for a rebuild ami: 
```bash
sh-5.2$ cat /etc/eks/release
BASE_AMI_ID="ami-0f8bdccd767e6b0c6"
BUILD_TIME="Sun Nov 17 00:37:10 UTC 2024"
BUILD_KERNEL="6.1.115-126.197.amzn2023.x86_64"
ARCH="x86_64"
sh-5.2$ ls -latr /usr/bin/kubelet
-rwxr-xr-x. 1 root root 76931672 Sep 18 17:49 /usr/bin/kubelet
```



<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
