### PR TITLE
Fix kernel tools version mismatch

### DIFF
--- a/templates/al2/provisioners/install-worker.sh
+++ b/templates/al2/provisioners/install-worker.sh
@@ -56,7 +56,7 @@ sudo yum install -y \
   yum-plugin-versionlock
 
 # lock the version of the kernel and associated packages before we yum update
-sudo yum versionlock kernel-$(uname -r) kernel-headers-$(uname -r) kernel-devel-$(uname -r)
+sudo yum versionlock kernel-$(uname -r) kernel-headers-$(uname -r) kernel-devel-$(uname -r) kernel-tools-$(uname -r)
 
 # Update the OS to begin with to catch up to the latest packages.
 sudo yum update -y

--- a/templates/al2/provisioners/upgrade-kernel.sh
+++ b/templates/al2/provisioners/upgrade-kernel.sh
@@ -17,7 +17,7 @@ else
   sudo yum install -y "kernel-${KERNEL_VERSION}*"
 fi
 
-sudo yum install -y "kernel-headers-${KERNEL_VERSION}*" "kernel-devel-${KERNEL_VERSION}*"
+sudo yum install -y "kernel-headers-${KERNEL_VERSION}*" "kernel-devel-${KERNEL_VERSION}*" "kernel-tools-${KERNEL_VERSION}*"
 
 # enable pressure stall information
 sudo grubby \


### PR DESCRIPTION
This PR adds the kernel-tools package to the version-locked packages in the AL2 AMI. Currently, kernel-tools can be updated to versions independent of the installed kernel version when applying other updates when we run `yum update -y` to patch the OS. This gets flagged as a "high" vulnerability by our Tenable scans, because Tenable thinks that there is a pending kernel upgrade that we need to reboot our EC2s for to apply, even though there is no pending kernel upgrade:

![image](https://github.com/user-attachments/assets/246514ad-2ba9-48c3-afae-aebf33551063)

By version locking kernel tools to the kernel version, this should no longer be an issue, and we can coordinate kernel-tools upgrades with kernel upgrades by manually unlocking the packages when we are ready to apply updates.

******************************************

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
