### PR TITLE
better handle non eks optimized amis

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -312,9 +312,15 @@ get_mounts_info() {
   timeout 75 df --human-readable >> "${COLLECT_DIR}"/storage/mounts.txt
   timeout 75 df --inodes >> "${COLLECT_DIR}"/storage/inodes.txt
   lsblk > "${COLLECT_DIR}"/storage/lsblk.txt
-  lvs > "${COLLECT_DIR}"/storage/lvs.txt
-  pvs > "${COLLECT_DIR}"/storage/pvs.txt
-  vgs > "${COLLECT_DIR}"/storage/vgs.txt
+  if command -v lvs > /dev/null 2>&1; then
+    lvs > "${COLLECT_DIR}"/storage/lvs.txt
+  fi
+  if command -v pvs > /dev/null 2>&1; then
+    pvs > "${COLLECT_DIR}"/storage/pvs.txt
+  fi
+  if command -v vgs > /dev/null 2>&1; then
+    vgs > "${COLLECT_DIR}"/storage/vgs.txt
+  fi  
   cp --force /etc/fstab "${COLLECT_DIR}"/storage/fstab.txt
   mount -t xfs | awk '{print $1}' | xargs -I{} -- sh -c "xfs_info {}; xfs_db -r -c 'freesp -s' {}" > "${COLLECT_DIR}"/storage/xfs.txt
   mount | grep ^overlay | sed 's/.*upperdir=//' | sed 's/,.*//' | xargs -n 1 timeout 75 du -sh | grep -v ^0 > "${COLLECT_DIR}"/storage/pod_local_storage.txt
@@ -352,7 +358,7 @@ get_iptables_info() {
 
   if ! command -v ipvsadm && command -v ipset > /dev/null 2>&1; then
     echo "IPVS Linux kernel module not installed" | tee ipvsadm.txt ipset.txt
-  else
+  elif command -v ipvsadm > /dev/null 2>&1; then
     # check that ip_vs module is loaded in get_modinfo()
     try "collect ipvs information"
     ipvsadm --save | tee "${COLLECT_DIR}"/networking/ipvsadm.txt && sed -i '1s/^/add:service/server \tprotocol \tvirtual-server \tscheduler algorithm \treal-server \n/' "${COLLECT_DIR}"/networking/ipvsadm.txt
@@ -425,7 +431,7 @@ get_kernel_info() {
 # collect modinfo on specific modules for debugging purposes
 get_modinfo() {
   try "collect modinfo"
-  modinfo lustre > "${COLLECT_DIR}/modinfo/lustre"
+  modinfo lustre > "${COLLECT_DIR}/modinfo/lustre" 2> /dev/null
   lsmod | grep -e ip_vs -e nf_conntrack > "${COLLECT_DIR}/modinfo/ip_vs"
 }
 
@@ -483,20 +489,22 @@ get_k8s_info() {
   fi
 
   case "${INIT_TYPE}" in
-    systemd)
-      timeout 75 journalctl --unit=kubelet --since "${DAYS_10}" > "${COLLECT_DIR}"/kubelet/kubelet.log
+    systemd | snap)
+      timeout 75 snap list kubelet-eks > /dev/null 2>&1
+      if [ 0 -eq $? ]; then # Check if previous command was successful.
+        timeout 75 snap logs kubelet-eks -n all > "${COLLECT_DIR}"/kubelet/kubelet.log
 
-      systemctl cat kubelet > "${COLLECT_DIR}"/kubelet/kubelet_service.txt 2>&1
+        timeout 75 snap get kubelet-eks > "${COLLECT_DIR}"/kubelet/kubelet-eks_service.txt 2>&1
+      else
+        timeout 75 journalctl --unit=kubelet --since "${DAYS_10}" > "${COLLECT_DIR}"/kubelet/kubelet.log
 
-      cp --force --recursive --dereference /etc/kubernetes/kubelet/config.json "${COLLECT_DIR}"/kubelet/config.json 2> /dev/null
-      cp --force --recursive --dereference /etc/kubernetes/kubelet/config.json.d "${COLLECT_DIR}"/kubelet/config.json.d 2> /dev/null
+        systemctl cat kubelet > "${COLLECT_DIR}"/kubelet/kubelet_service.txt 2>&1
 
-      cp --force --recursive --dereference /etc/kubernetes/kubelet/kubelet-config.json "${COLLECT_DIR}"/kubelet/kubelet-config.json 2> /dev/null
-      ;;
-    snap)
-      timeout 75 snap logs kubelet-eks -n all > "${COLLECT_DIR}"/kubelet/kubelet.log
+        cp --force --recursive --dereference /etc/kubernetes/kubelet/config.json "${COLLECT_DIR}"/kubelet/config.json 2> /dev/null
+        cp --force --recursive --dereference /etc/kubernetes/kubelet/config.json.d "${COLLECT_DIR}"/kubelet/config.json.d 2> /dev/null
 
-      timeout 75 snap get kubelet-eks > "${COLLECT_DIR}"/kubelet/kubelet-eks_service.txt 2>&1
+        cp --force --recursive --dereference /etc/kubernetes/kubelet/kubelet-config.json "${COLLECT_DIR}"/kubelet/kubelet-config.json 2> /dev/null
+      fi
       ;;
     *)
       warning "The current operating system is not supported."
@@ -541,7 +549,9 @@ get_ipamd_info() {
   fi
 
   try "collect L-IPAMD checkpoint"
-  cp /var/run/aws-node/ipam.json "${COLLECT_DIR}"/ipamd/ipam.json
+  if [[ -f /var/run/aws-node/ipam.json ]]; then
+    cp /var/run/aws-node/ipam.json "${COLLECT_DIR}"/ipamd/ipam.json
+  fi
 
   ok
 }
@@ -563,13 +573,16 @@ get_sysctls_info() {
 
 get_network_policy_ebpf_info() {
   try "collect network policy ebpf loaded data"
-  echo "*** EBPF loaded data ***" >> "${COLLECT_DIR}"/networking/ebpf-data.txt
-  LOADED_EBPF=$(/opt/cni/bin/aws-eks-na-cli ebpf loaded-ebpfdata | tee -a "${COLLECT_DIR}"/networking/ebpf-data.txt)
+  if [[ -x /opt/cni/bin/aws-eks-na-cli ]]; then
+    echo "*** EBPF loaded data ***" >> "${COLLECT_DIR}"/networking/ebpf-data.txt
+    LOADED_EBPF=$(/opt/cni/bin/aws-eks-na-cli ebpf loaded-ebpfdata | tee -a "${COLLECT_DIR}"/networking/ebpf-data.txt)
 
-  for mapid in $(echo "$LOADED_EBPF" | grep "Map ID:" | sed 's/Map ID: \+//' | sort | uniq); do
-    echo "*** EBPF Maps Data for Map ID $mapid ***" >> "${COLLECT_DIR}"/networking/ebpf-maps-data.txt
-    /opt/cni/bin/aws-eks-na-cli ebpf dump-maps $mapid >> "${COLLECT_DIR}"/networking/ebpf-maps-data.txt
-  done
+    for mapid in $(echo "$LOADED_EBPF" | grep "Map ID:" | sed 's/Map ID: \+//' | sort | uniq); do
+      echo "*** EBPF Maps Data for Map ID $mapid ***" >> "${COLLECT_DIR}"/networking/ebpf-maps-data.txt
+      /opt/cni/bin/aws-eks-na-cli ebpf dump-maps $mapid >> "${COLLECT_DIR}"/networking/ebpf-maps-data.txt
+    done
+  fi
+
   ok
 }
 
@@ -577,15 +590,19 @@ get_networking_info() {
   try "collect networking infomation"
 
   # conntrack info
-  echo "*** Output of conntrack -S *** " >> "${COLLECT_DIR}"/networking/conntrack.txt
-  timeout 75 conntrack -S >> "${COLLECT_DIR}"/networking/conntrack.txt
-  echo "*** Output of conntrack -L ***" >> "${COLLECT_DIR}"/networking/conntrack.txt
-  timeout 75 conntrack -L >> "${COLLECT_DIR}"/networking/conntrack.txt
-  echo "*** Output of conntrack -L -f ipv6 ***" >> "${COLLECT_DIR}"/networking/conntrack6.txt
-  timeout 75 conntrack -L -f ipv6 >> "${COLLECT_DIR}"/networking/conntrack6.txt
+  if command -v conntrack > /dev/null 2>&1; then
+    echo "*** Output of conntrack -S *** " >> "${COLLECT_DIR}"/networking/conntrack.txt
+    timeout 75 conntrack -S >> "${COLLECT_DIR}"/networking/conntrack.txt
+    echo "*** Output of conntrack -L ***" >> "${COLLECT_DIR}"/networking/conntrack.txt
+    timeout 75 conntrack -L >> "${COLLECT_DIR}"/networking/conntrack.txt
+    echo "*** Output of conntrack -L -f ipv6 ***" >> "${COLLECT_DIR}"/networking/conntrack6.txt
+    timeout 75 conntrack -L -f ipv6 >> "${COLLECT_DIR}"/networking/conntrack6.txt
+  fi
 
   # ifconfig
-  timeout 75 ifconfig > "${COLLECT_DIR}"/networking/ifconfig.txt
+  if command -v ifconfig > /dev/null 2>&1; then
+    timeout 75 ifconfig > "${COLLECT_DIR}"/networking/ifconfig.txt
+  fi
 
   # ip rule show
   timeout 75 ip rule show > "${COLLECT_DIR}"/networking/iprule.txt

--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -320,7 +320,7 @@ get_mounts_info() {
   fi
   if command -v vgs > /dev/null 2>&1; then
     vgs > "${COLLECT_DIR}"/storage/vgs.txt
-  fi  
+  fi
   cp --force /etc/fstab "${COLLECT_DIR}"/storage/fstab.txt
   mount -t xfs | awk '{print $1}' | xargs -I{} -- sh -c "xfs_info {}; xfs_db -r -c 'freesp -s' {}" > "${COLLECT_DIR}"/storage/xfs.txt
   mount | grep ^overlay | sed 's/.*upperdir=//' | sed 's/,.*//' | xargs -n 1 timeout 75 du -sh | grep -v ^0 > "${COLLECT_DIR}"/storage/pod_local_storage.txt


### PR DESCRIPTION
**Description of changes:**

When running the log collector script on OS images other than the standard AL2/23 eks optimized ami and without the vpc-cni, there are a few potentially confusing log messages due to missing files/execs.  This adds:
- `command -v` checks around specific bins, `lvs` `pvs` `vgs` `ipvsadm` `ipset` `conntrack` `aws-eks-na-cli` similar to others within this script.  
- Skips saving ipam information if `/var/run/aws-node/ipam.json` does not exist. 

The one somewhat functional change is to handle Ubuntu nodes.  Ubuntu is `INIT_TYPE` `snap` in the script and when kubelet logs are retrieve the snap `kubelet-eks` is assumed to exist. The change checks for existence of the `kubelet-eks` snap and if it does not exist, falls back to the normal kubelet log collecting. Without this change, the kubelet logs would not be collected for these kinds of nodes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

- Successfully ran on the al23 optimized ami
- Successfully ran on Ubuntu EKS Optimized ami to ensure snap still functions as before
- Successfully ran on Ubuntu and Rhel nodes with the standard set of bins

Old Output:
```
        This is version 0.7.8. New versions can be found at https://github.com/awslabs/amazon-eks-ami/blob/main/log-collector-script/

Trying to collect common operating system logs... 
Trying to collect kernel logs... 
Trying to collect modinfo... modinfo: ERROR: Module lustre not found.
Trying to collect mount points and volume information... 
Trying to collect SELinux status... 
Trying to collect iptables information... Trying to collect ipvs information... script.sh: line 358: ipvsadm: command not found
sed: -e expression #1, char 18: unknown option to `s'
script.sh: line 359: ipvsadm: command not found

script.sh: line 361: ipvsadm: command not found
script.sh: line 362: ipset: command not found

script.sh: line 364: ipset: command not found

Trying to collect installed packages... 
Trying to collect active system services... 
Trying to Collect Containerd daemon information... 
Trying to Collect Containerd running information... 
Trying to Collect Docker daemon information... 

        Warning: The Docker daemon is not running. 

Trying to collect kubelet information... error: snap "kubelet-eks" not found

Trying to collect nodeadm information... 

        Warning: The current operating system is not supported. 

Trying to collect L-IPAMD introspection information... Trying to collect L-IPAMD prometheus metrics... Trying to collect L-IPAMD checkpoint... cp: cannot stat '/var/run/aws-node/ipam.json': No such file or directory

Trying to collect Multus logs if they exist... 
Trying to collect sysctls information... 
Trying to collect networking infomation... timeout: failed to run command 'conntrack': No such file or directory
timeout: failed to run command 'conntrack': No such file or directory
timeout: failed to run command 'conntrack': No such file or directory
timeout: failed to run command 'ifconfig': No such file or directory

Trying to collect CNI configuration information... 
Trying to collect CNI Configuration Variables from Docker... 

        Warning: The Docker daemon is not running. 
Trying to collect CNI Configuration Variables from Containerd...        Timed out, ignoring "cni configuration variables output " 

Trying to collect network policy ebpf loaded data... script.sh: line 567: /opt/cni/bin/aws-eks-na-cli: No such file or directory

Trying to collect Docker daemon logs... 
Trying to Collect sandbox-image daemon information... 
Trying to Collect CPU Throttled Process Information... 
Trying to Collect IO Throttled Process Information... 
Trying to Collect reboot history... 
Trying to Collect Nvidia Bug report... No Nvidia drivers found, nothing to do.

Trying to archive gathered information... 

        Done... your bundled logs are located in /var/log/eks_i-0be40b1aeed0c7986_2024-11-21_1755-UTC_0.7.8.tar.gz
 ```

New Output:

```
	        This is version 0.7.8. New versions can be found at https://github.com/awslabs/amazon-eks-ami/blob/main/log-collector-script/

Trying to collect common operating system logs... 
Trying to collect kernel logs... 
Trying to collect modinfo... Trying to collect mount points and volume information... 
Trying to collect SELinux status... 
Trying to collect iptables information... 
Trying to collect installed packages... 
Trying to collect active system services... 
Trying to Collect Containerd daemon information... 
Trying to Collect Containerd running information... 
Trying to Collect Docker daemon information... 

        Warning: The Docker daemon is not running. 

Trying to collect kubelet information... 
Trying to collect nodeadm information... 

        Warning: The current operating system is not supported. 

Trying to collect L-IPAMD introspection information... Trying to collect L-IPAMD prometheus metrics... Trying to collect L-IPAMD checkpoint... 
Trying to collect Multus logs if they exist... 
Trying to collect sysctls information... 
Trying to collect networking infomation... 
Trying to collect CNI configuration information... 
Trying to collect CNI Configuration Variables from Docker... 

        Warning: The Docker daemon is not running. 
Trying to collect CNI Configuration Variables from Containerd...        Timed out, ignoring "cni configuration variables output " 

Trying to collect network policy ebpf loaded data... 
Trying to collect Docker daemon logs... 
Trying to Collect sandbox-image daemon information... 
Trying to Collect CPU Throttled Process Information... 
Trying to Collect IO Throttled Process Information... 
Trying to Collect reboot history... 
Trying to Collect Nvidia Bug report... No Nvidia drivers found, nothing to do.

Trying to archive gathered information... 

        Done... your bundled logs are located in /var/log/eks_i-0be40b1aeed0c7986_2024-11-21_1753-UTC_0.7.8.tar.gz

```
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
