### PR TITLE
feat(al2023): ensure the sandbox image is present periodically

### DIFF
--- a/templates/al2023/provisioners/cache-pause-container.sh
+++ b/templates/al2023/provisioners/cache-pause-container.sh
@@ -7,3 +7,5 @@ set -o pipefail
 sudo systemctl start containerd
 cache-pause-container -i ${PAUSE_CONTAINER_IMAGE}
 sudo systemctl stop containerd
+
+sudo systemctl enable check-sandbox-image.timer

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/check-sandbox-image.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/check-sandbox-image.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Check that the sandbox image is present in the containerd content store
+After=containerd.service
+Wants=containerd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ctr image import --namespace k8s.io /etc/eks/pause.tar
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/check-sandbox-image.timer
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/check-sandbox-image.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run check-sandbox-image periodically
+Requires=check-sandbox-image.service
+
+[Timer]
+Unit=check-sandbox-image.service
+# start 1 minute after boot
+OnBootSec=1min
+# run every 5 minutes
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
**Description of changes:**

When the sandbox image goes missing, manual repairs are often necessary. This PR adds a service unit with an associated timer that will (re)import the local sandbox image tarball if necessary. The unit runs once every 5 minutes (beginning 1 minute after boot) and is a no-op if the image is present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.