### PR TITLE
chore: fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ make k8s=1.29 os_distro=al2023
 make help
 ```
 
-The Makefile chooses a particular kubelet binary to use per Kubernetes version which you can [view here](Makefile).
+The Makefile chooses a particular kubelet binary to use per Kubernetes version which you can [view here](https://github.com/awslabs/amazon-eks-ami/blob/main/Makefile).
 
 > **Note**
 > The default instance type to build this AMI does not qualify for the AWS free tier.
@@ -54,7 +54,7 @@ The Makefile chooses a particular kubelet binary to use per Kubernetes version w
 
 ## 🔒 Security
 
-For security issues or concerns, please do not open an issue or pull request on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/
+For security issues or concerns, please do not open an issue or pull request on GitHub. Please report any suspected or confirmed security issues to [AWS Security](https://aws.amazon.com/security/vulnerability-reporting/)
 
 ## ⚖️ License Summary
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The Makefile chooses a particular kubelet binary to use per Kubernetes version w
 
 ## 🔒 Security
 
-For security issues or concerns, please do not open an issue or pull request on GitHub. Please report any suspected or confirmed security issues to [AWS Security](https://aws.amazon.com/security/vulnerability-reporting/)
+For security issues or concerns, please do not open an issue or pull request on GitHub. Please report any suspected or confirmed security issues to [AWS Security](https://aws.amazon.com/security/vulnerability-reporting/).
 
 ## ⚖️ License Summary
 


### PR DESCRIPTION
**Description of changes:**

Fixing a few links in the README file.
The `Makefile` link isn' currently accessible through the documentation website. 
The `AWS Security` link was in plain text.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
