### PR TITLE
chore: use conventional commits in automated PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     labels:
       - "dependencies"
       - "changelog/exclude"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -52,10 +52,10 @@ jobs:
           branch: update-changelog
           path: amazon-eks-ami/
           add-paths: CHANGELOG.md
-          commit-message: "Update CHANGELOG.md for release ${{ needs.setup.outputs.tag_name }}"
+          commit-message: "chore(docs): update CHANGELOG.md for release ${{ needs.setup.outputs.tag_name }}"
           committer: "GitHub <noreply@github.com>"
           author: "GitHub <noreply@github.com>"
-          title: "Update CHANGELOG.md"
+          title: "chore(docs): update CHANGELOG.md for release ${{ needs.setup.outputs.tag_name }}"
           labels: |
             changelog/exclude
           body: |

--- a/.github/workflows/update-dependency.yaml
+++ b/.github/workflows/update-dependency.yaml
@@ -33,8 +33,8 @@ jobs:
         if: ${{ steps.update_deps.outputs.changes != '' }}
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
         with:
-          title: 'Update dependencies'
-          commit-message: Update dependencies
+          title: "chore: update dependencies"
+          commit-message: "chore: update dependencies"
           committer: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
           author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
           branch: dependencies/update


### PR DESCRIPTION
**Description of changes:**

Updates the commit messages of automated PR's to use conventional commits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
