### PR TITLE
 feat(docs): add nodeadm wasm targets to call from docs

### DIFF
--- a/.github/workflows/ci-auto.yaml
+++ b/.github/workflows/ci-auto.yaml
@@ -23,6 +23,11 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
     - run: cd nodeadm && make build
+  nodeadm-build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - run: cd nodeadm && make wasm
   nodeadm-check-generate:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -10,6 +10,12 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # 5.1.0
+    - run: |
+        pushd nodeadm && make wasm && popd
+        mkdir -p ./site/assets/wasm && cp ./nodeadm/_bin/nodeadm.wasm ./site/assets/wasm/
+        mkdir -p ./site/assets/javascripts && cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" ./site/assets/javascripts/
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
     - run: pip install mkdocs mkdocs-material
-    - run: mkdocs gh-deploy --strict --no-history --force
+      # use the --dirty flag so that we dont purge our custom assets
+    - run: mkdocs gh-deploy --dirty --no-history --force

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 site/
 .git-commit
+*.wasm

--- a/doc/nodeadm/doc/playground.md
+++ b/doc/nodeadm/doc/playground.md
@@ -1,0 +1,61 @@
+# Playground
+
+This an interactive playground for `nodeadm`'s config parser packaged in the
+browser via WebAssembly!
+
+You can test out the validity of your EC2 Userdata and see any of the potential
+errors that might happen at runtime.
+
+<div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.36.5/ace.min.js" integrity="sha512-NIDAOLuPuewIzUrGoK5fXxowwGDm0DFJhI5TJPyTP6MeY2hUcCSKJr54fecQTEZ8kxxEO2NBrILQSUl4qZ37FA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="/amazon-eks-ami/assets/javascripts/wasm_exec.js"></script>
+    <body>
+        <div style="display: grid; margin: auto;">
+            <div id="editor" style="height:50vh"></div>
+            <textarea readonly style="height:15vh" id="response"></textarea>
+        </div>
+    </body>
+    <script>
+        const editor = ace.edit("editor", {
+            useWorker: false,
+            theme: "ace/theme/monokai",
+            mode: "ace/mode/yaml",
+            showPrintMargin: false,
+        });
+
+        // a global hook established ahead of time with the target WASM binary
+        function wasmLoadedHook() {
+            editor.session.on("change", function(_) {
+                document.getElementById("response").textContent = nodeadmCheck(editor.session.getValue())
+            });
+            editor.session.setValue(`
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="BOUNDARY"
+
+--BOUNDARY
+Content-Type: application/node.eks.aws
+
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+  kubelet:
+    config:
+      shutdownGracePeriod: 30s
+      featureGates:
+        DisableKubeletCloudCredentialProviders: true
+
+--BOUNDARY--`.trim());
+        }
+
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("/amazon-eks-ami/assets/wasm/nodeadm.wasm"), go.importObject).then((result) => {
+            go.run(result.instance);
+        });
+    </script>
+</div>

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -20,6 +20,7 @@ nav:
       - 'Concepts': nodeadm/doc/api-concepts.md
       - 'Reference': nodeadm/doc/api.md
     - 'Examples': nodeadm/doc/examples.md
+    - 'Playground': nodeadm/doc/playground.md
 theme:
   name: material
   palette:

--- a/nodeadm/Makefile
+++ b/nodeadm/Makefile
@@ -78,8 +78,12 @@ build: ## Build binary.
 	go build -o $(LOCALBIN)/nodeadm cmd/nodeadm/main.go
 
 .PHONY: run
-run: build ## Run binary
+run: build ## Run binary.
 	go run cmd/nodeadm/main.go $(args)
+
+.PHONY: wasm
+wasm: ## Build WASM binary.
+	GOOS=js GOARCH=wasm go build -o $(LOCALBIN)/nodeadm.wasm cmd/nodeadm-wasm/main.go
 
 ##@ Build Dependencies
 

--- a/nodeadm/cmd/nodeadm-wasm/main.go
+++ b/nodeadm/cmd/nodeadm-wasm/main.go
@@ -1,0 +1,58 @@
+//go:build wasm
+
+package main
+
+import (
+	"fmt"
+	"syscall/js"
+
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/configprovider"
+)
+
+type jsWrapperFunc = func(this js.Value, args []js.Value) any
+
+func main() {
+	for jsFuncName, jsFunc := range map[string]jsWrapperFunc{
+		"nodeadmCheck": nodeadmCheckFunc,
+	} {
+		fmt.Printf("loading %q from Go WASM module\n", jsFuncName)
+		js.Global().Set(jsFuncName, js.FuncOf(func(this js.Value, args []js.Value) any {
+			defer func() {
+				// Since we cannot return errors in proper convention back to
+				// javascript through the WebAssembly Goroutine, we'll wrap the
+				// panic handler instead and print the information to keep the
+				// execution Go-like.
+				if r := recover(); r != nil {
+					errString := fmt.Sprintf("%s", r)
+					fmt.Printf("encountered error: %s\n", errString)
+					js.Global().Call("alert", errString)
+				}
+			}()
+			return jsFunc(this, args)
+		}))
+	}
+	// search for a hook in the global namesapace and invoke it. this helps
+	// prevent timing issues when attemping to call WASM functions when they are
+	// still being loaded.
+	if wasmLoadedHook := js.Global().Get("wasmLoadedHook"); wasmLoadedHook.Truthy() {
+		wasmLoadedHook.Invoke()
+	}
+	// block function completion to keep the Go routines loaded in memory
+	<-make(chan struct{})
+}
+
+var nodeadmCheckFunc = func(this js.Value, args []js.Value) any {
+	if len(args) != 1 {
+		panic("incorrect number of arguments.")
+	}
+	document := args[0].String()
+	nodeConfig, err := configprovider.ParseMaybeMultipart([]byte(document))
+	if err != nil {
+		return js.ValueOf(err.Error())
+	}
+	if err := api.ValidateNodeConfig(nodeConfig); err != nil {
+		return js.ValueOf(fmt.Errorf("validating NodeConfig: %w", err).Error())
+	}
+	return js.ValueOf("Looks Good! 👍")
+}

--- a/nodeadm/internal/configprovider/file.go
+++ b/nodeadm/internal/configprovider/file.go
@@ -35,5 +35,5 @@ func (fcs *fileConfigProvider) Provide() (*internalapi.NodeConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parseMaybeMultipart(data)
+	return ParseMaybeMultipart(data)
 }

--- a/nodeadm/internal/configprovider/mime.go
+++ b/nodeadm/internal/configprovider/mime.go
@@ -13,11 +13,11 @@ import (
 	apibridge "github.com/awslabs/amazon-eks-ami/nodeadm/internal/api/bridge"
 )
 
-func parseMaybeMultipart(data []byte) (*internalapi.NodeConfig, error) {
+func ParseMaybeMultipart(data []byte) (*internalapi.NodeConfig, error) {
 	// if the MIME data fails to parse as a multipart document, then fall back
 	// to parsing the entire userdata as the node config.
 	if multipartReader, err := getMultipartReader(data); err == nil {
-		config, err := parseMultipart(multipartReader)
+		config, err := ParseMultipart(multipartReader)
 		if err != nil {
 			return nil, err
 		}
@@ -31,7 +31,7 @@ func parseMaybeMultipart(data []byte) (*internalapi.NodeConfig, error) {
 	}
 }
 
-func parseMultipart(userDataReader *multipart.Reader) (*internalapi.NodeConfig, error) {
+func ParseMultipart(userDataReader *multipart.Reader) (*internalapi.NodeConfig, error) {
 	var nodeConfigs []*internalapi.NodeConfig
 	for {
 		part, err := userDataReader.NextPart()

--- a/nodeadm/internal/configprovider/userdata.go
+++ b/nodeadm/internal/configprovider/userdata.go
@@ -49,5 +49,5 @@ func (p *userDataConfigProvider) Provide() (*internalapi.NodeConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to decompress user data: %v", err)
 	}
-	return parseMaybeMultipart(userData)
+	return ParseMaybeMultipart(userData)
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

It would be helpful to be able to test a `NodeConfig` straight from the browser without installing any tools. 

This PR adds a WebAssembly package containing nodeadm's config parsing hook and provides a minimal editor that users can paste their config into.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

deployed to my fork's ghpages: https://ndbaker1.github.io/amazon-eks-ami/nodeadm/doc/playground/

```shell
rm -rf ./site
pushd nodeadm && make wasm && popd
mkdir -p ./site/assets/javascripts && cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" ./site/assets/javascripts/
mkdir -p site/assets/wasm && cp nodeadm/_bin/nodeadm.wasm ./site/assets/wasm
mkdocs gh-deploy -r ndbaker1 --dirty --no-history --force
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
