### PR TITLE
AL2023 Isolated build temp workaround for EFA installer

### DIFF
--- a/templates/al2023/provisioners/install-efa.sh
+++ b/templates/al2023/provisioners/install-efa.sh
@@ -35,10 +35,16 @@ sudo dnf swap -y gnupg2-minimal gnupg2-full
 ##########################################################################################
 ### Download installer ###################################################################
 ##########################################################################################
-curl -O ${EFA_DOMAIN}/${EFA_PACKAGE}
+if [ ${PARTITION} == "aws-iso-f" ||  ${PARTITION} == "aws-iso-e" ]; then
+  aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/${EFA_PACKAGE} .
+  aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/aws-efa-installer.key . && gpg --import aws-efa-installer.key
+  aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/${EFA_PACKAGE}.sig .
+else
+  curl -O ${EFA_DOMAIN}/${EFA_PACKAGE}
+  curl -O ${EFA_DOMAIN}/aws-efa-installer.key && gpg --import aws-efa-installer.key
+  curl -O ${EFA_DOMAIN}/${EFA_PACKAGE}.sig
+fi
 
-curl -O ${EFA_DOMAIN}/aws-efa-installer.key && gpg --import aws-efa-installer.key
-curl -O ${EFA_DOMAIN}/${EFA_PACKAGE}.sig
 if ! gpg --verify ./aws-efa-installer-${EFA_VERSION}.tar.gz.sig &> /dev/null; then
   echo "EFA Installer signature failed verification!"
   exit 2

--- a/templates/al2023/provisioners/install-efa.sh
+++ b/templates/al2023/provisioners/install-efa.sh
@@ -35,7 +35,7 @@ sudo dnf swap -y gnupg2-minimal gnupg2-full
 ##########################################################################################
 ### Download installer ###################################################################
 ##########################################################################################
-if [ ${PARTITION} == "aws-iso-f" ||  ${PARTITION} == "aws-iso-e" ]; then
+if [ ${PARTITION} == "aws-iso-f" ] || [ ${PARTITION} == "aws-iso-e" ]; then
   aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/${EFA_PACKAGE} .
   aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/aws-efa-installer.key . && gpg --import aws-efa-installer.key
   aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/${EFA_PACKAGE}.sig .

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -265,6 +265,11 @@
       "script": "{{template_dir}}/provisioners/install-efa.sh",
       "environment_vars": [
         "AWS_REGION={{user `aws_region`}}",
+        "AWS_ACCESS_KEY_ID={{user `aws_access_key_id`}}",
+        "AWS_SECRET_ACCESS_KEY={{user `aws_secret_access_key`}}",
+        "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
+        "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",
+        "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}",
         "ENABLE_EFA={{user `enable_efa`}}"
       ]
     },


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

For some isolated builds that are still in build, we are attempting to self host EFA and pull artifacts down in build until officially supported to test out GPU builds.