### PR TITLE
bug: remove printf from imds helper

### DIFF
--- a/templates/shared/runtime/bin/imds
+++ b/templates/shared/runtime/bin/imds
@@ -37,7 +37,7 @@ function imdscurl() {
     cat >&2 $OUTPUT_FILE
     return $CODE
   fi
-  printf "$(cat $OUTPUT_FILE)\n"
+  cat $OUTPUT_FILE
   rm $OUTPUT_FILE
 }
 

--- a/templates/shared/runtime/bin/imds
+++ b/templates/shared/runtime/bin/imds
@@ -38,6 +38,7 @@ function imdscurl() {
     return $CODE
   fi
   cat $OUTPUT_FILE
+  printf "\n"
   rm $OUTPUT_FILE
 }
 


### PR DESCRIPTION
**Issue #, if available:**

fix https://github.com/awslabs/amazon-eks-ami/issues/2092

**Description of changes:**

the imds helper uses `printf` when printing output, which can be confused by format specifiers inside of the returned data (like userdata)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

```shell
$ echo foo > foo
$ printf "$(cat foo)\n"
foo
$ cat foo
foo
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
