### PR TITLE
fix: check return code of aws eks wait call in bootstrap script

### DIFF
--- a/templates/al2/runtime/bootstrap.sh
+++ b/templates/al2/runtime/bootstrap.sh
@@ -362,9 +362,9 @@ if [[ -z "${B64_CLUSTER_CA}" ]] || [[ -z "${APISERVER_ENDPOINT}" ]]; then
 
     aws eks wait cluster-active \
       --region=${AWS_DEFAULT_REGION} \
-      --name=${CLUSTER_NAME}
+      --name=${CLUSTER_NAME} || rc=$?
 
-    aws eks describe-cluster \
+    [[ $rc -eq 0 ]] && aws eks describe-cluster \
       --region=${AWS_DEFAULT_REGION} \
       --name=${CLUSTER_NAME} \
       --output=text \


### PR DESCRIPTION
**Issue #, if available:** None Active (closed: https://github.com/awslabs/amazon-eks-ami/issues/803)

**Description of changes:**

this checks the return code for `aws eks wait cluster-active` in the bootstrap script.

we've noticed that if a lot of nodes are booting at the same time, this can get backed off via AWS:
```
Waiter ClusterActive failed: An error occurred (TooManyRequestsException): Too Many Requests
Exited with error on line 286
```
since `errexit` is set, this automatically fails the bootstrap script. With this change, I'm intending for this loop to check _both_ returns from `wait` and `describe cluster` to avoid throttling/errors from both.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

- I created an AMI via packer in our account via `make k8s=1.29`
- I used that AMI for a test node and the nodes joined successfully

testing a failure scenario would take a little more time and the code change is minimal, but I can try to replicate it if desired (probably easiest by creating an AMI where I set `$rc` to `286` manually on the first attempt between the wait / describe calls)

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
