### PR TITLE
Add flag to indicate script is running on EKS Hybrid nodes

### DIFF
--- a/log-collector-script/linux/README.md
+++ b/log-collector-script/linux/README.md
@@ -36,6 +36,8 @@ OPTIONS:
 
    --ignore_metrics Variable To ignore prometheus metrics collection; Pass this flag if DISABLE_METRICS enabled on CNI
 
+   --eks_hybrid Variable To denote that the script is running on an EKS Hybrid node; This will skip IMDS queries for AWS region and instance ID
+
    --help  Show this help message.
 ```
 


### PR DESCRIPTION
This PR adds a flag to indicate when this script is running on an EKS Hybrid node. This will ignore IMDS token collection and IMDS queries for AWS region and EC2 instance ID.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
