### PR TITLE
Bump pause image to 3.10

### DIFF
--- a/templates/al2/variables-default.json
+++ b/templates/al2/variables-default.json
@@ -22,7 +22,7 @@
     "kms_key_id": "",
     "iam_instance_profile": "",
     "launch_block_device_mappings_volume_size": "4",
-    "pause_container_version": "3.5",
+    "pause_container_version": "3.10",
     "pull_cni_from_github": "true",
     "remote_folder": "/tmp",
     "runc_version": "1.1.*",

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -21,7 +21,7 @@
     "launch_block_device_mappings_volume_size": "20",
     "nodeadm_build_image": "public.ecr.aws/eks-distro-build-tooling/golang:1.23",
     "nvidia_driver_major_version": "560",
-    "pause_container_image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.5",
+    "pause_container_image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.10",
     "remote_folder": "/tmp",
     "runc_version": "*",
     "security_group_id": "",


### PR DESCRIPTION
We are on an old pause image, let's switch to newer ones.

example https://github.com/containerd/containerd/pull/10258