### PR TITLE
Enable CDI in containerd configuration

### DIFF
--- a/nodeadm/internal/api/merge_test.go
+++ b/nodeadm/internal/api/merge_test.go
@@ -119,6 +119,7 @@ discard_unpacked_layers = true
 
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "{{.SandboxImage}}"
+enable_cdi = true
 
 [plugins."io.containerd.grpc.v1.cri".registry]
 config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
@@ -195,6 +196,7 @@ discard_unpacked_layers = false
 
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "{{.SandboxImage}}"
+enable_cdi = true
 
 [plugins."io.containerd.grpc.v1.cri".registry]
 config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"

--- a/nodeadm/internal/containerd/config.template.toml
+++ b/nodeadm/internal/containerd/config.template.toml
@@ -11,6 +11,7 @@ discard_unpacked_layers = true
 
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "{{.SandboxImage}}"
+enable_cdi = true
 
 [plugins."io.containerd.grpc.v1.cri".registry]
 config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"

--- a/nodeadm/test/e2e/cases/containerd-config/expected-containerd-config.toml
+++ b/nodeadm/test/e2e/cases/containerd-config/expected-containerd-config.toml
@@ -7,6 +7,7 @@ address = '/run/foo/foo.sock'
 
 [plugins]
 [plugins.'io.containerd.grpc.v1.cri']
+enable_cdi = true
 sandbox_image = 'localhost/kubernetes/pause'
 
 [plugins.'io.containerd.grpc.v1.cri'.cni]

--- a/nodeadm/test/e2e/cases/containerd-runtime-config-neuron/expected-containerd-config.toml
+++ b/nodeadm/test/e2e/cases/containerd-runtime-config-neuron/expected-containerd-config.toml
@@ -7,6 +7,7 @@ address = '/run/foo/foo.sock'
 
 [plugins]
 [plugins.'io.containerd.grpc.v1.cri']
+enable_cdi = true
 sandbox_image = 'localhost/kubernetes/pause'
 
 [plugins.'io.containerd.grpc.v1.cri'.cni]

--- a/nodeadm/test/e2e/cases/containerd-runtime-config-nvidia/expected-containerd-config.toml
+++ b/nodeadm/test/e2e/cases/containerd-runtime-config-nvidia/expected-containerd-config.toml
@@ -7,6 +7,7 @@ address = '/run/foo/foo.sock'
 
 [plugins]
 [plugins.'io.containerd.grpc.v1.cri']
+enable_cdi = true
 sandbox_image = 'localhost/kubernetes/pause'
 
 [plugins.'io.containerd.grpc.v1.cri'.cni]

--- a/templates/al2/runtime/containerd-config.toml
+++ b/templates/al2/runtime/containerd-config.toml
@@ -12,6 +12,7 @@ discard_unpacked_layers = true
 
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "SANDBOX_IMAGE"
+enable_cdi = true
 
 [plugins."io.containerd.grpc.v1.cri".registry]
 config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"


### PR DESCRIPTION
`enable_cdi = true` is set to true in containerd 2.0:
https://github.com/containerd/containerd/commit/c8e8a093ce3dd9231173042e9828a679972f5d6b

Some DRA drivers are using CDI:
https://github.com/search?q=repo%3ANVIDIA%2Fk8s-dra-driver%20cdi&type=code

A bunch of CI jobs in upstream are now enabling CDI:
https://cs.k8s.io/?q=enable_cdi&i=nope&files=&excludeFiles=&repos=

So let's switch it on in our images as well please.