### PR TITLE
fix: setup-local-disks for mode “none”

### DIFF
--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -237,7 +237,7 @@ if [[ "${DISK_SETUP}" != "raid0" && "${DISK_SETUP}" != "mount" && "${DISK_SETUP}
 fi
 
 if [ "${DISK_SETUP}" = "none" ]; then
-  "disk setup is 'none', nothing to do!"
+  echo "disk setup is 'none', nothing to do!"
   exit 0
 fi
 


### PR DESCRIPTION
**Issue #, if available:** [2104](https://github.com/awslabs/amazon-eks-ami/issues/2104)

**Description of changes:**
Add a missing "echo" to setup-local-disks script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

None
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
