### PR TITLE
feat(nodeadm): add nodeadm config dump command

### DIFF
--- a/nodeadm/cmd/nodeadm/config/dump.go
+++ b/nodeadm/cmd/nodeadm/config/dump.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/cli"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/configprovider"
+	"github.com/integrii/flaggy"
+	"go.uber.org/zap"
+)
+
+type dumpCmd struct {
+	cmd *flaggy.Subcommand
+}
+
+func NewDumpCommand() cli.Command {
+	cmd := flaggy.NewSubcommand("dump")
+	cmd.Description = "Dump configuration"
+	return &dumpCmd{
+		cmd: cmd,
+	}
+}
+
+func (c *dumpCmd) Flaggy() *flaggy.Subcommand {
+	return c.cmd
+}
+
+func (c *dumpCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+	log.Info("Dumping configuration", zap.String("source", opts.ConfigSource))
+	provider, err := configprovider.BuildConfigProvider(opts.ConfigSource)
+	if err != nil {
+		return err
+	}
+	config, err := provider.Provide()
+	if err != nil {
+		return err
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err = encoder.Encode(config); err != nil {
+		return err
+	}
+	log.Info("Configuration dumped")
+	return nil
+}

--- a/nodeadm/cmd/nodeadm/config/root.go
+++ b/nodeadm/cmd/nodeadm/config/root.go
@@ -7,5 +7,6 @@ import (
 func NewConfigCommand() cli.Command {
 	container := cli.NewCommandContainer("config", "Manage configuration")
 	container.AddCommand(NewCheckCommand())
+	container.AddCommand(NewDumpCommand())
 	return container.AsCommand()
 }


### PR DESCRIPTION
**Issue #, if available:** https://github.com/awslabs/amazon-eks-ami/issues/2106

**Description of changes:**
Add a `config dump` command to nodeadm that print the resolved config to stdout.
It allow to dump as json (default) or yaml.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
`make test`: ok

Tested locally with a user-data from an actual instance in a file.
`go run cmd/nodeadm/main.go config dump -c file://userdata.txt`
<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->
