### PR TITLE
fix: increase IMDS retries

### DIFF
--- a/nodeadm/internal/aws/imds/imds.go
+++ b/nodeadm/internal/aws/imds/imds.go
@@ -15,7 +15,7 @@ func init() {
 	Client = imds.New(imds.Options{
 		DisableDefaultTimeout: true,
 		Retryer: retry.NewStandard(func(so *retry.StandardOptions) {
-			so.MaxAttempts = 15
+			so.MaxAttempts = 60
 			so.MaxBackoff = 1 * time.Second
 			so.Retryables = append(so.Retryables,
 				&retry.RetryableHTTPStatusCode{


### PR DESCRIPTION
**Description of changes:**

This increases the number of retry attempts for IMDS requests from 15 to 60. We use exponential backoff with a max delay of 1 second, so this results in about 1 minute of retries. We've seen rare failures where the network is not up until the previous retries (15) were exhausted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
