### PR TITLE
fix: install paths for test tools

### DIFF
--- a/.github/actions/ci/kubetest2/action.yaml
+++ b/.github/actions/ci/kubetest2/action.yaml
@@ -26,7 +26,7 @@ runs:
       run: |
         export PATH=${PATH}:$(go env GOPATH)/bin
         go install sigs.k8s.io/kubetest2/...@latest
-        go install github.com/aws/aws-k8s-tester/...@latest
+        go install github.com/aws/aws-k8s-tester/...@HEAD
 
         case "${{ inputs.os_distro }}" in
           al2)

--- a/.github/actions/janitor/kubetest2-sweeper/action.yaml
+++ b/.github/actions/janitor/kubetest2-sweeper/action.yaml
@@ -11,6 +11,6 @@ runs:
       run: |
         export PATH=${PATH}:$(go env GOPATH)/bin
         go install sigs.k8s.io/kubetest2/...@latest
-        go install github.com/aws/aws-k8s-tester/...@latest
+        go install github.com/aws/aws-k8s-tester/...@HEAD
 
         kubetest2 eksapi-janitor -max-resource-age=${{ inputs.max_resource_age_duration }}


### PR DESCRIPTION
**Description of changes:**

We need to use `@HEAD` instead of `@latest` to use the latest commit of the test tools, since there are previous tagged releases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
