### PR TITLE
feat: align dummy kernel mod options with newer systemd default

### DIFF
--- a/templates/al2/provisioners/install-worker.sh
+++ b/templates/al2/provisioners/install-worker.sh
@@ -140,6 +140,12 @@ sudo mv "${WORKING_DIR}/runtime.slice" /etc/systemd/system/runtime.slice
 sudo mv $WORKING_DIR/set-nvidia-clocks.service /etc/systemd/system/set-nvidia-clocks.service
 sudo systemctl enable set-nvidia-clocks.service
 
+# backporting removal of default dummy0 network interface in systemd v236
+# https://github.com/systemd/systemd/blob/16ac586e5a77942bf1147bc9eae684d544ded88f/NEWS#L11139-L11144
+cat << EOF | sudo tee /lib/modprobe.d/10-no-dummies.conf
+options dummy numdummies=0
+EOF
+
 ###############################################################################
 ### Containerd setup ##########################################################
 ###############################################################################


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

the dummy kernel module default is to load one `dummy0` interface. this behavior was changes in systemd v236+ to set `numdummies=0` to avoid creating any dummy interfaces when loading the module. 
https://github.com/systemd/systemd/blob/16ac586e5a77942bf1147bc9eae684d544ded88f/NEWS#L11139-L11144

this PR backports the feature to the AL2 build where the systemd version if v219

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
