### PR TITLE
chore(al2023): remove EFA workaround for aws-iso-f

### DIFF
--- a/templates/al2023/provisioners/install-efa.sh
+++ b/templates/al2023/provisioners/install-efa.sh
@@ -35,7 +35,7 @@ sudo dnf swap -y gnupg2-minimal gnupg2-full
 ##########################################################################################
 ### Download installer ###################################################################
 ##########################################################################################
-if [ ${PARTITION} == "aws-iso-f" ] || [ ${PARTITION} == "aws-iso-e" ]; then
+if [ ${PARTITION} == "aws-iso-e" ]; then
   aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/${EFA_PACKAGE} .
   aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/aws-efa-installer.key . && gpg --import aws-efa-installer.key
   aws s3 cp --region ${BINARY_BUCKET_REGION} s3://${BINARY_BUCKET_NAME}/rpms/${EFA_PACKAGE}.sig .


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

ISOF EFA Bucket is finally created, no need for the self hosting workaround.
