### PR TITLE
bug(nodeadm): run validation in config check

### DIFF
--- a/nodeadm/cmd/nodeadm/config/check.go
+++ b/nodeadm/cmd/nodeadm/config/check.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/cli"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/configprovider"
 	"github.com/integrii/flaggy"
@@ -29,8 +30,11 @@ func (c *fileCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	if err != nil {
 		return err
 	}
-	_, err = provider.Provide()
+	nodeConfig, err := provider.Provide()
 	if err != nil {
+		return err
+	}
+	if err := api.ValidateNodeConfig(nodeConfig); err != nil {
 		return err
 	}
 	log.Info("Configuration is valid")


### PR DESCRIPTION
**Issue #, if available:**

mentioned in https://github.com/awslabs/amazon-eks-ami/issues/2123

**Description of changes:**

The `nodeadm config check` command validates the document can be parsed, but if it is incorrectly formatted or missing data then fields are left empty and the command still reports the config is valid.

This PR adds the same validation call to the parsed `NodeConfig` in `config check` and in the `init` command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

```bash
cat << EOF > test.yaml
MIME-Version: 1.0
Content-Type: multipart/mixed; boundary="//"

--//
Content-Type: application/node.eks.aws

---
APIVersion: node.eks.aws/v1alpha1
Kind: NodeConfig

--//--
EOF

# before
> go run ./cmd/nodeadm/main.go config check -c file://../test.yaml
{"level":"info","ts":1738745826.997185,"caller":"config/check.go:27","msg":"Checking configuration","source":"file://../test.yaml"}
{"level":"info","ts":1738745826.9985948,"caller":"config/check.go:36","msg":"Configuration is valid"}

# after
> go run ./cmd/nodeadm/main.go config check -c file://../test.yaml
{"level":"info","ts":1738745868.4194193,"caller":"config/check.go:28","msg":"Checking configuration","source":"file://../test.yaml"}
{"level":"fatal","ts":1738745868.420988,"caller":"nodeadm/main.go:36","msg":"Command failed","error":"Name is missing in cluster configuration","stacktrace":"main.main\n\t/home/nbakerd/workspace/ami/nodeadm/cmd/nodeadm/main.go:36\nruntime.main\n\t/home/nbakerd/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.linux-amd64/src/runtime/proc.go:272"}


```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
