### PR TITLE
fix(ci): wrong workflow build argument input key

### DIFF
--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -75,7 +75,7 @@ jobs:
       k8s_versions: ${{ inputs.k8s_versions }}
       os_distros: ${{ inputs.os_distros }}
       git_sha: ${{ inputs.git_sha }}
-      build_arguments: ${{ inputs.build-arguments }}
+      build_arguments: ${{ inputs.build_arguments }}
       resource_id: "ci-${{ inputs.pr_number }}-${{ needs.setup.outputs.git_sha_short }}-${{ inputs.uuid }}"
       run_name: "ci(#${{ inputs.pr_number }}@${{ needs.setup.outputs.git_sha_short }}): ${{ inputs.uuid }}"
       goal: "${{ inputs.goal }}"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

the expected bot behavior for the following doesn't work because the input key is wrong in the ci template.
 
```
/ci
+build ARGS..
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
