### PR TITLE
feat: discover current k8s versions using DescribeClusterVersions api

### DIFF
--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -32,7 +32,6 @@ on:
         type: string
       k8s_versions:
         description: 'Kubernetes Versions (comma-separated, e.g., 1.29,1.30)'
-        default: "1.24,1.25,1.26,1.27,1.28,1.29,1.30,1.31"
         required: false
         type: string
       build_arguments:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,6 @@ on:
         type: string
       k8s_versions:
         description: 'Kubernetes Versions (comma-separated, e.g., 1.29,1.30)'
-        default: "1.24,1.25,1.26,1.27,1.28,1.29,1.30,1.31"
         required: false
         type: string
       build_arguments:
@@ -45,8 +44,12 @@ jobs:
     - id: variables
       run: |
         echo 'ci_step_name_prefix=CI:' >> $GITHUB_OUTPUT
-        echo "kubernetes_versions=$(jq -Rn --arg input '${{ inputs.k8s_versions }}' '($input | split(","))' | jq -c .)" >> $GITHUB_OUTPUT
         echo "os_distros=$(jq -Rn --arg input '${{ inputs.os_distros }}' '($input | split(","))' | jq -c .)" >> $GITHUB_OUTPUT
+        if [ -z "${{ inputs.k8s_versions }}" ]; then
+          echo "kubernetes_versions=$(aws eks describe-cluster-versions | jq -c '.clusterVersions | map(.clusterVersion)')" >> $GITHUB_OUTPUT
+        else
+          echo "kubernetes_versions=$(jq -Rn --arg input '${{ inputs.k8s_versions }}' '($input | split(","))' | jq -c .)" >> $GITHUB_OUTPUT
+        fi
   kubernetes-versions:
     runs-on: ubuntu-latest
     name: ${{ matrix.k8s_version }} / ${{ matrix.os_distro }}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

use the EKS [DescribeClusterVerions api](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeClusterVersions.html) to get the default supported K8s versions on EKS when they aren't provided

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

validate the output is equivalent an proper JSON

```bash
> aws eks describe-cluster-versions | jq -c '.clusterVersions | map(.clusterVersion)'
["1.32","1.31","1.30","1.29","1.28","1.27","1.26","1.25"]
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
