### PR TITLE
fix(ci): setup aws credentials before describe-cluster-versions 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,10 @@ jobs:
       ci_step_name_prefix: ${{ steps.variables.outputs.ci_step_name_prefix }}
       os_distros: ${{ steps.variables.outputs.os_distros }}
     steps:
+    - uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # 4.0.3
+      with:
+        aws-region: ${{ secrets.AWS_REGION }}
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN_CI }}
     - id: variables
       run: |
         echo 'ci_step_name_prefix=CI:' >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

need to setup the aws credentials and region before making the call in ci `setup`

see failure: https://github.com/awslabs/amazon-eks-ami/actions/runs/13210517214/job/36883003904#step:2:12

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
