### PR TITLE
feat(ci): allow additional kubetest2 deployer args

### DIFF
--- a/.github/actions/ci/kubetest2/action.yaml
+++ b/.github/actions/ci/kubetest2/action.yaml
@@ -18,6 +18,9 @@ inputs:
   log_bucket:
     required: true
     type: string
+  additional_arguments:
+    required: false
+    type: string
 runs:
   using: "composite"
   steps:
@@ -40,6 +43,10 @@ runs:
             exit 1
           ;;
         esac
+
+        if [ ! "${{ inputs.additional_arguments }}" = "" ]; then
+          KUBETEST2_ARGS="${KUBETEST2_ARGS} ${{ inputs.additional_arguments }}"
+        fi
 
         TESTER_NAME=ginkgo
         # k8s_version below 1.26 use the older ginkgo tester

--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -37,6 +37,9 @@ on:
       build_arguments:
         required: false
         type: string
+      test_arguments:
+        required: false
+        type: string
 
 jobs:
   setup:
@@ -75,6 +78,7 @@ jobs:
       os_distros: ${{ inputs.os_distros }}
       git_sha: ${{ inputs.git_sha }}
       build_arguments: ${{ inputs.build_arguments }}
+      test_arguments: ${{ inputs.test_arguments }}
       resource_id: "ci-${{ inputs.pr_number }}-${{ needs.setup.outputs.git_sha_short }}-${{ inputs.uuid }}"
       run_name: "ci(#${{ inputs.pr_number }}@${{ needs.setup.outputs.git_sha_short }}): ${{ inputs.uuid }}"
       goal: "${{ inputs.goal }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,9 @@ on:
       build_arguments:
         required: false
         type: string
+      test_arguments:
+        required: false
+        type string
     outputs:
       ci_step_name_prefix:
         description: "Prefix of job steps containing CI activities"
@@ -101,3 +104,4 @@ jobs:
           build_id: ${{ inputs.resource_id }}
           aws_region: ${{ secrets.AWS_REGION }}
           log_bucket: ${{ secrets.CI_LOG_BUCKET }}
+          additional_arguments: ${{ inputs.test_arguments }}


### PR DESCRIPTION
**Description of changes:**

Allows additional args to be passed to the `kubetest2` deployer for CI jobs.

e.g.
```
/ci
+test --instance-types=m6i.xlarge
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
