### PR TITLE
feat(test): build nodeadm on host

### DIFF
--- a/nodeadm/Makefile
+++ b/nodeadm/Makefile
@@ -68,6 +68,8 @@ test: crds generate fmt vet ## Run go test against code.
 	go test ./...
 
 .PHONY: test-e2e
+# the test infra container needs a linux executable
+test-e2e: GOOS=linux
 test-e2e: build ## Run e2e tests.
 	test/e2e/run.sh
 
@@ -75,7 +77,7 @@ test-e2e: build ## Run e2e tests.
 
 .PHONY: build
 build: ## Build binary.
-	go build -o $(LOCALBIN)/nodeadm cmd/nodeadm/main.go
+	GOOS=$(GOOS) go build -o $(LOCALBIN)/nodeadm cmd/nodeadm/main.go
 
 .PHONY: run
 run: build ## Run binary.

--- a/nodeadm/test/e2e/infra/Dockerfile
+++ b/nodeadm/test/e2e/infra/Dockerfile
@@ -3,12 +3,6 @@ RUN go env -w GOPROXY=direct
 RUN GOBIN=/bin go install github.com/aws/amazon-ec2-metadata-mock/cmd@v1.11.2
 RUN mv /bin/cmd /imds-mock
 
-FROM golang:1.23 AS nodeadm-build
-WORKDIR /go/src/github.com/awslabs/amazon-eks-ami/nodeadm
-COPY . .
-RUN make build
-RUN mv _bin/nodeadm /nodeadm
-
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN dnf -y update && \
     dnf -y install systemd containerd jq python3 awscli && \
@@ -35,7 +29,6 @@ COPY --from=imds-mock-build /imds-mock /usr/local/bin/imds-mock
 #     cidr: 10.100.0.0/16
 COPY test/e2e/infra/aemm-default-config.json /etc/aemm-default-config.json
 COPY test/e2e/infra/nvidia-ctk /usr/bin/nvidia-ctk
-COPY --from=nodeadm-build /nodeadm /usr/local/bin/nodeadm
 COPY test/e2e/infra/systemd/kubelet.service /usr/lib/systemd/system/kubelet.service
 COPY test/e2e/infra/systemd/containerd.service /usr/lib/systemd/system/containerd.service
 COPY test/e2e/infra/mock/ /sys_devices_system_mock/

--- a/nodeadm/test/e2e/run.sh
+++ b/nodeadm/test/e2e/run.sh
@@ -6,6 +6,13 @@ set -o pipefail
 
 cd $(dirname $0)/../..
 
+NODEADM=$PWD/_bin/nodeadm
+
+if [ ! -f "${NODEADM}" ]; then
+  echo >&2 "error: you must build nodeadm (run \`make\`) before you can run the e2e tests!"
+  exit 1
+fi
+
 printf "🛠️ Building test infra image..."
 TEST_IMAGE=$(docker build -q -f test/e2e/infra/Dockerfile .)
 echo "done! Test image: $TEST_IMAGE"
@@ -19,6 +26,7 @@ for CASE_DIR in $(ls -d test/e2e/cases/*); do
     -d \
     --rm \
     --privileged \
+    -v $NODEADM:/usr/local/bin/nodeadm \
     -v $PWD/$CASE_DIR:/test-case \
     $TEST_IMAGE)
   LOG_FILE=$(mktemp)


### PR DESCRIPTION
**Description of changes:**

This speeds up repeated runs of `make test-e2e` by using the `nodeadm` executable built by the `build` target (on the host) instead of in a multi-stage build of the test infra container image. Lots of time is wasted re-downloading go dependencies with that approach.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
