### PR TITLE
fix(build): correct build variable order of precedence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,13 +80,14 @@ endif
 # then store variables that are defined in the Makefile's execution context
 AVAILABLE_PACKER_VARIABLES := $(shell $(PACKER_BINARY) inspect -machine-readable $(PACKER_TEMPLATE_FILE) | grep 'template-variable' | awk -F ',' '{print $$4}')
 PACKER_VARIABLES := $(foreach packerVar,$(AVAILABLE_PACKER_VARIABLES),$(if $($(packerVar)),$(packerVar)))
-# read & construct Packer arguments in order from the following sources:
-# 1. default variable files
+# Set Packer arguments in descending order of precedence from the following sources:
+# 1. variables specified in the Make context
 # 2. (optional) user-specified variable file
-# 3. variables specified in the Make context
-PACKER_ARGS := -var-file $(PACKER_DEFAULT_VARIABLE_FILE) \
+# 2. (optional) k8s-version variable file
+# 4. default variable files
+PACKER_ARGS := $(if $(PACKER_VARIABLE_FILE),-var-file=$(PACKER_VARIABLE_FILE),) \
 	$(if $(PACKER_OPTIONAL_K8S_VARIABLE_FILE),-var-file=$(PACKER_OPTIONAL_K8S_VARIABLE_FILE),) \
-	$(if $(PACKER_VARIABLE_FILE),-var-file=$(PACKER_VARIABLE_FILE),) \
+	-var-file $(PACKER_DEFAULT_VARIABLE_FILE) \
 	$(foreach packerVar,$(PACKER_VARIABLES),-var $(packerVar)='$($(packerVar))')
 
 .PHONY: validate


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

At the moment, variables in the "defaults" are actually forced at a higher precedence than any other variable files. This is due to the way packer handles precedence. Specifically, variables are resolved in descending order of precedence by command-line flags, variable files, environment variables, and variable defaults [ref](https://developer.hashicorp.com/packer/tutorials/aws-get-started/aws-get-started-variables#build-image-with-variables). Packer uses a 'first defined, first used' heuristic for variables in general [ref](https://developer.hashicorp.com/packer/tutorials/aws-get-started/aws-get-started-variables#build-image-with-variables), so by specifying the default variable file first, we were disabling any other files from overriding values set there. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
