### PR TITLE
fix(ci): disable go proxy

### DIFF
--- a/.github/actions/ci/kubetest2/action.yaml
+++ b/.github/actions/ci/kubetest2/action.yaml
@@ -28,6 +28,8 @@ runs:
       shell: bash
       run: |
         export PATH=${PATH}:$(go env GOPATH)/bin
+        # old versions of packages are sometimes cached by the proxy, just disable it
+        GOPROXY=direct
         go install sigs.k8s.io/kubetest2/...@latest
         go install github.com/aws/aws-k8s-tester/...@HEAD
 


### PR DESCRIPTION
**Description of changes:**

Our CI runs are receiving an old commit of our kubetest2 tools from mid-March. Just disabling the proxy for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
