### PR TITLE
fix(al2023): move default link modification to drop-in

### DIFF
--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -85,7 +85,11 @@ ManageForeignRoutingPolicyRules=no
 EOF
 
 # Temporary fix for https://github.com/aws/amazon-vpc-cni-k8s/pull/2118
-sudo sed -i "s/^MACAddressPolicy=.*/MACAddressPolicy=none/" /usr/lib/systemd/network/99-default.link || true
+sudo mkdir -p /etc/systemd/network/99-default.link.d/
+cat << EOF | sudo tee /etc/systemd/network/99-default.link.d/no-policy.conf
+[Link]
+MACAddressPolicy=none
+EOF
 
 ################################################################################
 ### SSH ########################################################################

--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -86,7 +86,10 @@ EOF
 
 # Temporary fix for https://github.com/aws/amazon-vpc-cni-k8s/pull/2118
 sudo mkdir -p /etc/systemd/network/99-default.link.d/
-cat << EOF | sudo tee /etc/systemd/network/99-default.link.d/no-policy.conf
+cat << EOF | sudo tee /etc/systemd/network/99-default.link.d/99-no-policy.conf
+# Ensure MACAddressPolicy=none, reinstalling systemd-udev writes /usr/lib/systemd/network/99-default.link
+# with value set to persistent
+# https://github.com/aws/amazon-vpc-cni-k8s/issues/2103#issuecomment-1321698870
 [Link]
 MACAddressPolicy=none
 EOF


### PR DESCRIPTION
**Issue #, if available:**

Fixes: https://github.com/awslabs/amazon-eks-ami/issues/2222

**Description of changes:**

updating the `systemd-udev` package on AL2023 can cause networking issues, due to link assumptions from build-time being overridden.

the content of the `/etc/systemd/network/99-default.link` file itself makes it clear that manual edits will be lost after an update. this PR moves the edit to a drop-in file.

newer versions recommend using `networkctl edit`, but this is effectively the same as creating the drop-in. `networkctl` also does not have the edit subcommand with the version installed.

```
# SPDX-License-Identifier: MIT-0
#
# This config file is installed as part of systemd.
# It may be freely copied and edited (following the MIT No Attribution license).
#
# To make local modifications, one of the following methods may be used:
# 1. add a drop-in file that extends this file by creating the
#    /etc/systemd/network/99-default.link.d/ directory and creating a
#    new .conf file there.
# 2. copy this file into /etc/systemd/network or one of the other paths checked
#    by systemd-udevd and edit it there.
# This file should not be edited in place, because it'll be overwritten on upgrades.

[Match]
OriginalName=*

[Link]
NamePolicy=keep kernel database onboard slot path
AlternativeNamesPolicy=database onboard slot path
MACAddressPolicy=none
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
