### PR TITLE
feat(nodeadm): configure container runtime based on binaries

### DIFF
--- a/nodeadm/internal/containerd/config.go
+++ b/nodeadm/internal/containerd/config.go
@@ -33,10 +33,6 @@ type containerdTemplateVars struct {
 }
 
 func writeContainerdConfig(cfg *api.NodeConfig) error {
-	if err := writeBaseRuntimeSpec(cfg); err != nil {
-		return err
-	}
-
 	containerdConfig, err := generateContainerdConfig(cfg)
 	if err != nil {
 		return err
@@ -61,12 +57,12 @@ func writeContainerdConfig(cfg *api.NodeConfig) error {
 }
 
 func generateContainerdConfig(cfg *api.NodeConfig) ([]byte, error) {
-	instanceOptions := applyInstanceTypeMixins(cfg.Status.Instance.Type)
+	runtimeOptions := getRuntimeOptions(cfg)
 
 	configVars := containerdTemplateVars{
 		SandboxImage:      cfg.Status.Defaults.SandboxImage,
-		RuntimeBinaryName: instanceOptions.RuntimeBinaryName,
-		RuntimeName:       instanceOptions.RuntimeName,
+		RuntimeBinaryName: runtimeOptions.RuntimeBinaryPath,
+		RuntimeName:       runtimeOptions.RuntimeName,
 		EnableCDI:         semver.Compare(cfg.Status.KubeletVersion, "v1.32.0") >= 0,
 	}
 	var buf bytes.Buffer

--- a/nodeadm/internal/containerd/daemon.go
+++ b/nodeadm/internal/containerd/daemon.go
@@ -20,6 +20,9 @@ func NewContainerdDaemon(daemonManager daemon.DaemonManager) daemon.Daemon {
 }
 
 func (cd *containerd) Configure(c *api.NodeConfig) error {
+	if err := writeBaseRuntimeSpec(c); err != nil {
+		return err
+	}
 	return writeContainerdConfig(c)
 }
 

--- a/nodeadm/internal/containerd/runtime_config.go
+++ b/nodeadm/internal/containerd/runtime_config.go
@@ -1,65 +1,37 @@
 package containerd
 
-import (
-	"slices"
-	"strings"
+import "github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
 
-	"go.uber.org/zap"
-)
-
-type instanceOptions struct {
+type runtimeConfig struct {
 	RuntimeName       string
-	RuntimeBinaryName string
+	RuntimeBinaryPath string
 }
 
-type instanceTypeMixin struct {
-	instanceFamilies []string
-	apply            func() instanceOptions
+type runtimeConfigMixin interface {
+	Apply(*runtimeConfig)
+	Matches(*api.NodeConfig) bool
 }
 
-func (m *instanceTypeMixin) matches(instanceType string) bool {
-	instanceFamily := strings.Split(instanceType, ".")[0]
-	return slices.Contains(m.instanceFamilies, instanceFamily)
-}
-
-var (
-	// TODO: fetch this list dynamically
-	nvidiaInstances         = []string{"p3", "p3dn", "p4d", "p4de", "p5", "p5e", "p5en", "g4", "g4dn", "g5", "g6", "g6e", "g5g"}
-	NvidiaInstanceTypeMixin = instanceTypeMixin{
-		instanceFamilies: nvidiaInstances,
-		apply:            applyNvidia,
-	}
-
-	mixins = []instanceTypeMixin{
-		NvidiaInstanceTypeMixin,
-	}
+const (
+	defaultRuntimeName       = "runc"
+	defaultRuntimeBinaryPath = "/usr/sbin/runc"
 )
 
-const nvidiaRuntimeName = "nvidia"
-const nvidiaRuntimeBinaryName = "/usr/bin/nvidia-container-runtime"
-const defaultRuntimeName = "runc"
-const defaultRuntimeBinaryName = "/usr/sbin/runc"
+var mixins = []runtimeConfigMixin{
+	NewNvidiaRuntimeConfigMixin(),
+}
 
-// applyInstanceTypeMixins adds the needed OCI hook options to containerd config.toml
-// based on the instance family
-func applyInstanceTypeMixins(instanceType string) instanceOptions {
+// getRuntimeOptions adds the needed OCI hook options to containerd config.toml
+// based on the instance family and available runtime binaries
+func getRuntimeOptions(cfg *api.NodeConfig) runtimeConfig {
+	options := runtimeConfig{
+		RuntimeName:       defaultRuntimeName,
+		RuntimeBinaryPath: defaultRuntimeBinaryPath,
+	}
 	for _, mixin := range mixins {
-		if mixin.matches(instanceType) {
-			return mixin.apply()
+		if mixin.Matches(cfg) {
+			mixin.Apply(&options)
 		}
 	}
-	zap.L().Info("No instance specific containerd runtime configuration needed..", zap.String("instanceType", instanceType))
-	return applyDefault()
-}
-
-// applyNvidia adds the needed NVIDIA containerd options
-func applyNvidia() instanceOptions {
-	zap.L().Info("Configuring NVIDIA runtime..")
-	return instanceOptions{RuntimeName: nvidiaRuntimeName, RuntimeBinaryName: nvidiaRuntimeBinaryName}
-}
-
-// applyDefault adds the default runc containerd options
-func applyDefault() instanceOptions {
-	zap.L().Info("Configuring default runtime..")
-	return instanceOptions{RuntimeName: defaultRuntimeName, RuntimeBinaryName: defaultRuntimeBinaryName}
+	return options
 }

--- a/nodeadm/internal/containerd/runtime_config_nvidia.go
+++ b/nodeadm/internal/containerd/runtime_config_nvidia.go
@@ -1,0 +1,35 @@
+package containerd
+
+import (
+	"os"
+
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"go.uber.org/zap"
+)
+
+const (
+	nvidiaRuntimeName       = "nvidia"
+	nvidiaRuntimeBinaryPath = "/usr/bin/nvidia-container-runtime"
+)
+
+func NewNvidiaRuntimeConfigMixin() *nvidiaRuntimeConfigMixin {
+	return &nvidiaRuntimeConfigMixin{
+		runtimeBinaryPath: nvidiaRuntimeBinaryPath,
+	}
+}
+
+type nvidiaRuntimeConfigMixin struct {
+	runtimeBinaryPath string
+}
+
+func (m *nvidiaRuntimeConfigMixin) Matches(*api.NodeConfig) bool {
+	// TODO: use nodeconfig data to discern if necessary.
+	_, err := os.Stat(m.runtimeBinaryPath)
+	return err == nil
+}
+
+func (m *nvidiaRuntimeConfigMixin) Apply(opts *runtimeConfig) {
+	zap.L().Info("Configuring NVIDIA runtime..")
+	opts.RuntimeName = nvidiaRuntimeName
+	opts.RuntimeBinaryPath = m.runtimeBinaryPath
+}

--- a/nodeadm/internal/containerd/runtime_config_test.go
+++ b/nodeadm/internal/containerd/runtime_config_test.go
@@ -1,31 +1,38 @@
 package containerd
 
 import (
-	"reflect"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestApplyInstanceTypeMixins(t *testing.T) {
-
-	var nvidiaExpectedOutput = instanceOptions{RuntimeName: "nvidia", RuntimeBinaryName: "/usr/bin/nvidia-container-runtime"}
-	var neuronExpectedOutput = instanceOptions{RuntimeName: "runc", RuntimeBinaryName: "/usr/sbin/runc"}
-	var nonAcceleratedExpectedOutput = instanceOptions{RuntimeName: "runc", RuntimeBinaryName: "/usr/sbin/runc"}
-
-	var tests = []struct {
-		name           string
-		instanceType   string
-		expectedOutput instanceOptions
-	}{
-		{name: "nvidia_test", instanceType: "p5.xlarge", expectedOutput: nvidiaExpectedOutput},
-		{name: "neuron_test", instanceType: "inf2.xlarge", expectedOutput: neuronExpectedOutput},
-		// non accelerated instance
-		{name: "non_accelerated_test", instanceType: "m5.xlarge", expectedOutput: nonAcceleratedExpectedOutput},
+func TestDefaultRuntimeOptions(t *testing.T) {
+	expectedRuntimeConfig := runtimeConfig{
+		RuntimeName:       defaultRuntimeName,
+		RuntimeBinaryPath: defaultRuntimeBinaryPath,
 	}
-	for _, test := range tests {
-		expected := applyInstanceTypeMixins(test.instanceType)
+	actualRuntimeConfig := getRuntimeOptions(&api.NodeConfig{})
 
-		if !reflect.DeepEqual(expected, test.expectedOutput) {
-			t.Fatalf("unexpected output in test case %s: %s, expecting: %s", test.name, expected, test.expectedOutput)
-		}
+	assert.Equal(t, expectedRuntimeConfig, actualRuntimeConfig)
+}
+
+func TestNvidiaRuntimeOptionsMixin(t *testing.T) {
+	mockNvidiaContainerRuntimePath := filepath.Join(t.TempDir(), "nvidia-container-runtime")
+	_, err := os.Create(mockNvidiaContainerRuntimePath)
+	assert.NoError(t, err)
+
+	mixin := nvidiaRuntimeConfigMixin{runtimeBinaryPath: mockNvidiaContainerRuntimePath}
+	expectedRuntimeConfig := runtimeConfig{
+		RuntimeName:       nvidiaRuntimeName,
+		RuntimeBinaryPath: mockNvidiaContainerRuntimePath,
 	}
+	assert.True(t, mixin.Matches(&api.NodeConfig{}))
+
+	var actualRuntimeConfig runtimeConfig
+	mixin.Apply(&actualRuntimeConfig)
+
+	assert.Equal(t, expectedRuntimeConfig, actualRuntimeConfig)
 }

--- a/nodeadm/test/e2e/cases/containerd-runtime-config-nvidia/run.sh
+++ b/nodeadm/test/e2e/cases/containerd-runtime-config-nvidia/run.sh
@@ -10,6 +10,8 @@ mock::aws aemm-g5-config.json
 mock::kubelet 1.27.0
 wait::dbus-ready
 
+touch /usr/bin/nvidia-container-runtime
+
 nodeadm init --skip run --config-source file://config.yaml
 
 assert::files-equal /etc/containerd/config.toml expected-containerd-config.toml


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This PR removes validation of instance type for loading the nvidia container runtime by relying on the presence of the `nvidia-container-runtime` binaries being present in the AMI. This is normally a safe assumption, since you should only be using NVIDIA-enabled EKS AMIs with NVIDIA-based EC2 instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

the only edge cases we really need to test is when the GPU AMI is used on a non-GPU instance type, because the assumptions is baked in that the `nvidia-container-runtime` exists, but we need to know if this introduces any conflicts.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
