### PR TITLE
fix(nodeadm): calculate max pods on default network card

### DIFF
--- a/nodeadm/internal/kubelet/eni_max_pods.go
+++ b/nodeadm/internal/kubelet/eni_max_pods.go
@@ -49,7 +49,7 @@ func init() {
 // CalcMaxPods handle the edge case when instance type is not present in MaxPodsPerInstanceType
 // The behavior should align with AL2, which essentially is:
 //
-//	# of ENI * (# of IPv4 per ENI - 1) + 2
+//	max # of ENI on default network card * (# of IPv4 per ENI - 1) + 2
 func CalcMaxPods(awsRegion string, instanceType string) int32 {
 	zap.L().Info("calculate the max pod for instance type", zap.String("instanceType", instanceType))
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(awsRegion))

--- a/nodeadm/internal/util/ec2.go
+++ b/nodeadm/internal/util/ec2.go
@@ -3,6 +3,8 @@ package util
 import (
 	"context"
 	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
@@ -35,8 +37,9 @@ func GetEniInfoForInstanceType(ec2API EC2API, instanceType string) (EniInfo, err
 
 	if len(describeResp.InstanceTypes) > 0 {
 		instanceTypeInfo := describeResp.InstanceTypes[0]
+		defaultNetworkCardIndex := aws.ToInt32(instanceTypeInfo.NetworkInfo.DefaultNetworkCardIndex)
 		return EniInfo{
-			EniCount:        *instanceTypeInfo.NetworkInfo.MaximumNetworkInterfaces,
+			EniCount:        *instanceTypeInfo.NetworkInfo.NetworkCards[defaultNetworkCardIndex].MaximumNetworkInterfaces,
 			PodsPerEniCount: *instanceTypeInfo.NetworkInfo.Ipv4AddressesPerInterface,
 		}, nil
 	}

--- a/nodeadm/internal/util/ec2_test.go
+++ b/nodeadm/internal/util/ec2_test.go
@@ -42,8 +42,13 @@ func TestGetEniInfoForInstanceType(t *testing.T) {
 					{
 						InstanceType: "t3.medium",
 						NetworkInfo: &types.NetworkInfo{
-							MaximumNetworkInterfaces:  aws.Int32(3),
+							DefaultNetworkCardIndex:   aws.Int32(0),
 							Ipv4AddressesPerInterface: aws.Int32(6),
+							NetworkCards: []types.NetworkCardInfo{
+								{
+									MaximumNetworkInterfaces: aws.Int32(3),
+								},
+							},
 						},
 					},
 				},
@@ -68,6 +73,37 @@ func TestGetEniInfoForInstanceType(t *testing.T) {
 			},
 			mockError:     fmt.Errorf("invalid instance type"),
 			expectedError: fmt.Errorf("error describing instance type mock-type.large: %w", errors.New("invalid instance type")),
+		},
+		{
+			instanceType: "mock-multicard.large",
+			expectedResult: ec2util.EniInfo{
+				EniCount:        int32(15),
+				PodsPerEniCount: int32(50),
+			},
+			mockResponse: ec2.DescribeInstanceTypesOutput{
+				InstanceTypes: []types.InstanceTypeInfo{
+					{
+						InstanceType: "mock-multicard.large",
+						NetworkInfo: &types.NetworkInfo{
+							DefaultNetworkCardIndex:   aws.Int32(1),
+							Ipv4AddressesPerInterface: aws.Int32(50),
+							NetworkCards: []types.NetworkCardInfo{
+								{
+									MaximumNetworkInterfaces: aws.Int32(0),
+								},
+								{
+									MaximumNetworkInterfaces: aws.Int32(15),
+								},
+								{
+									MaximumNetworkInterfaces: aws.Int32(0),
+								},
+							},
+						},
+					},
+				},
+			},
+			mockError:     nil,
+			expectedError: nil,
 		},
 	}
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

At the moment there's a gap between the max pods value from [eni-max-pods.txt](https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/internal/kubelet/eni-max-pods.txt) and the [fallback calculator](https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/internal/kubelet/eni_max_pods.go#L53) for multicard instance types.

Both use the equation `max # network interfaces * (max # ipv4 addresses per interface -1) +2` for the max pods value, but the text file is calculated using the max number of network interfaces for the default network card, whereas the fallback uses the total maximum number of network interfaces for the instance. To take an example, consider `p4de.24xlarge`


```
$ aws ec2 describe-instance-types --region=us-west-2 --instance-type=p4d.24xlarge | jq '.InstanceTypes[].NetworkInfo'
{
  "NetworkPerformance": "4x 100 Gigabit",
  "MaximumNetworkInterfaces": 60,
  "MaximumNetworkCards": 4,
  "DefaultNetworkCardIndex": 0,
  "NetworkCards": [
    {
      "NetworkCardIndex": 0,
      "NetworkPerformance": "100 Gigabit",
      "MaximumNetworkInterfaces": 15,
      "BaselineBandwidthInGbps": 100,
      "PeakBandwidthInGbps": 100
    },
    {
      "NetworkCardIndex": 1,
      "NetworkPerformance": "100 Gigabit",
      "MaximumNetworkInterfaces": 15,
      "BaselineBandwidthInGbps": 100,
      "PeakBandwidthInGbps": 100
    },
    {
      "NetworkCardIndex": 2,
      "NetworkPerformance": "100 Gigabit",
      "MaximumNetworkInterfaces": 15,
      "BaselineBandwidthInGbps": 100,
      "PeakBandwidthInGbps": 100
    },
    {
      "NetworkCardIndex": 3,
      "NetworkPerformance": "100 Gigabit",
      "MaximumNetworkInterfaces": 15,
      "BaselineBandwidthInGbps": 100,
      "PeakBandwidthInGbps": 100
    }
  ],
  "Ipv4AddressesPerInterface": 50,
  "Ipv6AddressesPerInterface": 50,
  "Ipv6Supported": true,
  "EnaSupport": "required",
  "EfaSupported": true,
  "EfaInfo": {
    "MaximumEfaInterfaces": 4
  },
  "EncryptionInTransitSupported": true,
  "EnaSrdSupported": false
}
```

[eni-max-pods.txt shows 737](https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/internal/kubelet/eni-max-pods.txt#L636), which follows from `NetworkCards[DefaultNetworkCardIndex].MaximumNetworkInterfaces * (Ipv4AddressesPerInterface - 1) + 2 = 15 * (50 - 1) + 2 = 737`. On the other hand, the calculator fallback currently uses `MaximumNetworkInterfaces * (Ipv4AddressesPerInterface - 1) + 2 = 60 * (50 - 1) + 2 = 2,942`.

The max pods value is mainly intended to account for the fact that the VPC CNI only allocates pods using the first network interface. Since this calculator is only used if no corresponding value was found in the text file for the instance type, this could also lead to a major discrepancy between AMI versions for new instance types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Added a unit test for a mock multi-card instance type.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
