### PR TITLE
build(al2023): update to kernel 6.12 for 1.33

### DIFF
--- a/templates/al2023/variables-1.30.json
+++ b/templates/al2023/variables-1.30.json
@@ -1,0 +1,3 @@
+{
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*"
+}

--- a/templates/al2023/variables-1.31.json
+++ b/templates/al2023/variables-1.31.json
@@ -1,0 +1,3 @@
+{
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*"
+}

--- a/templates/al2023/variables-1.32.json
+++ b/templates/al2023/variables-1.32.json
@@ -1,0 +1,3 @@
+{
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*"
+}

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -26,7 +26,7 @@
     "remote_folder": "/tmp",
     "runc_version": "*",
     "security_group_id": "",
-    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.12-*",
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
     "ssh_interface": "",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Bumping the AL2023 kernel version to 6.12 in k8s 1.33

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
