### PR TITLE
build(al2023,neuron): add dkms module check and pin kernel packages

### DIFF
--- a/templates/al2023/provisioners/install-neuron-driver.sh
+++ b/templates/al2023/provisioners/install-neuron-driver.sh
@@ -29,4 +29,9 @@ metadata_expire=0" | sudo tee /etc/yum.repos.d/neuron.repo
 ################################################################################
 ### Install packages ###########################################################
 ################################################################################
+
+sudo dnf -y install \
+  kernel-devel-$(uname -r) \
+  kernel-headers-$(uname -r)
+
 sudo dnf install -y aws-neuronx-dkms aws-neuronx-tools

--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -61,3 +61,14 @@ if sudo ip link | grep nerdctl0; then
   echo "nerdctl0 interface should be removed."
   exit 1
 fi
+
+#############################
+### dkms ####################
+#############################
+
+if command -v dkms > /dev/null; then
+  if ! diff <(sudo dkms status | grep 'installed') <(sudo dkms status); then
+    echo "At least one dkms module is not installed."
+    exit 1
+  fi
+fi


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

port the same fix for kernel packages from https://github.com/awslabs/amazon-eks-ami/pull/2200 to neuron and add a validation that all `dkms` modules are installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

see https://github.com/awslabs/amazon-eks-ami/pull/2230#issuecomment-2831552207

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
