### PR TITLE
feat(al2023/nvidia): install nvlsm

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -119,6 +119,16 @@ archive-open-kmods
 archive-proprietary-kmod
 
 ################################################################################
+### Install NVLSM ##############################################################
+################################################################################
+# https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#systems-using-fourth-generation-nvswitches
+
+echo "ib_umad" | sudo tee -a /etc/modules-load.d/ib-umad.conf
+sudo dnf -y install libibumad
+sudo dnf -y install infiniband-diags
+sudo dnf -y install nvlsm
+
+################################################################################
 ### Prepare for nvidia init ####################################################
 ################################################################################
 

--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -123,11 +123,14 @@ archive-proprietary-kmod
 ################################################################################
 # https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#systems-using-fourth-generation-nvswitches
 
-echo "ib_umad" | sudo tee -a /etc/modules-load.d/ib-umad.conf
-sudo dnf -y install \
-  libibumad \
-  infiniband-diags \
-  nvlsm
+# TODO: install unconditionally once availability is guaranteed
+if ! is-isolated-partition; then
+  echo "ib_umad" | sudo tee -a /etc/modules-load.d/ib-umad.conf
+  sudo dnf -y install \
+    libibumad \
+    infiniband-diags \
+    nvlsm
+fi
 
 ################################################################################
 ### Prepare for nvidia init ####################################################

--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -124,9 +124,10 @@ archive-proprietary-kmod
 # https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#systems-using-fourth-generation-nvswitches
 
 echo "ib_umad" | sudo tee -a /etc/modules-load.d/ib-umad.conf
-sudo dnf -y install libibumad
-sudo dnf -y install infiniband-diags
-sudo dnf -y install nvlsm
+sudo dnf -y install \
+  libibumad \
+  infiniband-diags \
+  nvlsm
 
 ################################################################################
 ### Prepare for nvidia init ####################################################


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Nvidia systems using fourth generation NVSwitches, like DGX B200, NVIDIA HGX B200 8-GPU, and NVIDIA HGX B100 8-GPU, have an additional dependency on NVLink Subnet Manager (NVLSM). [ref](https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#systems-using-fourth-generation-nvswitches) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

This change is adding documented dependencies - I did spin up `p4d.24xlarge` instances to verify backwards compatibility though.

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
