### PR TITLE
feat(al2023): versionlock amazon-ec2-net-utils

### DIFF
--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -73,6 +73,9 @@ sudo dnf install -y \
 # needed by kubelet
 sudo dnf install -y iptables-nft
 
+# updating this package may trigger post-install hooks or config changes that undo what happens below
+sudo dnf versionlock amazon-ec2-net-utils
+
 # Mask udev triggers installed by amazon-ec2-net-utils package
 sudo touch /etc/udev/rules.d/99-vpc-policy-routes.rules
 


### PR DESCRIPTION
**Description of changes:**

Updating/re-installing this package can break networking on EKS nodes.

For example, this post install script bypasses the `udev` rules change we make at build time: https://github.com/amazonlinux/amazon-ec2-net-utils/blob/49a9f1b40a7102cc683708bc157bc5f46d1ed81c/amazon-ec2-net-utils.spec#L43-L56

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
