### PR TITLE
fix: make kmod-util module-version comptaible with all dkms versions

### DIFF
--- a/templates/al2023/runtime/gpu/kmod-util
+++ b/templates/al2023/runtime/gpu/kmod-util
@@ -14,7 +14,7 @@ function log() {
 
 # get the version of a registered kernel module
 function module-version() {
-  ${DKMS} status -m "${1}" | tr -s ',' '/' | tr -d ' ' | awk -F '/' '{print $2}'
+  ls /var/lib/dkms/${1}/ | head -n 1
 }
 
 # load a kernel module from the archives


### PR DESCRIPTION
**Issue #, if available:**


**Description of changes:**
Some versions of dkms have a different format like so `nvidia, 550.163.01: added`. This change looks at the dkms module path directly to determine the module version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
