### PR TITLE
fix: circular dependency issue in nodeadm-run.service

### DIFF
--- a/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-run.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-run.service
@@ -11,4 +11,4 @@ Type=oneshot
 ExecStart=/usr/bin/nodeadm init --skip config
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=cloud-init.target


### PR DESCRIPTION
**Issue #, if available:**
Fixes #2269 

**Description of changes:**
nodeadm-run.service will be triggered by cloud-init.target instead of multi-user.target

**Testing Done**

I updated the systemd service nodeadm-run.service and rebooted the EC2 instance.
Then I ran the command `sudo journalctl -b -p 3`.

Result: the error boot log did not contain any error related to noeadm-run.service anymore (expected).
