### PR TITLE
added `writeConfigToFile` func to write nodeConfig during node initia…

### DIFF
--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -1,6 +1,10 @@
 package init
 
 import (
+	"encoding/json" 
+	"os"           
+	"path/filepath"
+
 	"context"
 	"time"
 
@@ -24,6 +28,7 @@ import (
 const (
 	configPhase = "config"
 	runPhase    = "run"
+	defaultConfigPath = "/var/lib/nodeadm/config.json" // adding a default path to write `config.json`` too.
 )
 
 func NewInitCommand() cli.Command {
@@ -71,6 +76,11 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	if err := enrichConfig(log, nodeConfig); err != nil {
 		return err
 	}
+
+    log.Info("Writing node configuration..") // adding a log entry and calling func `writeConfigToFile`
+    if err := writeConfigToFile(log, nodeConfig); err != nil {
+        return err
+    }
 
 	zap.L().Info("Validating configuration..")
 	if err := api.ValidateNodeConfig(nodeConfig); err != nil {
@@ -180,4 +190,27 @@ func enrichConfig(log *zap.Logger, cfg *api.NodeConfig) error {
 	}
 	log.Info("Default options populated", zap.Reflect("defaults", cfg.Status.Defaults))
 	return nil
+}
+
+// this func ensure to creation of directory `/var/lib/nodeadm` with 0500 and file `config.json` with 0200
+// after writing to `config.json` its changes the permisison to 0400 to only allow read.
+func writeConfigToFile(log *zap.Logger, cfg *api.NodeConfig) error { 
+    log.Info("Creating nodeadm directory..", zap.String("path", filepath.Dir(defaultConfigPath)))
+    if err := os.MkdirAll(filepath.Dir(defaultConfigPath), 0500); err != nil {
+        return err
+    }
+    log.Info("Writing configuration file..", zap.String("path", defaultConfigPath))
+    f, err := os.OpenFile(defaultConfigPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0200)
+    if err != nil {
+        return err
+    }
+    defer func() {
+        f.Close()
+        os.Chmod(defaultConfigPath, 0400)
+    }()
+    if err := json.NewEncoder(f).Encode(cfg); err != nil {
+        return err
+    }
+    log.Info("Configuration file written successfully", zap.String("path", defaultConfigPath))
+    return nil
 }


### PR DESCRIPTION
**Issue #, if available:**
#2106 

**Description of changes:**

1. added a new const called `defaultConfigPath = "/var/lib/nodeadm/config.json"`
2. calling the new func `writeConfigToFile` at line 88 right after we have all the nodeConfig information with enrichment.
3. added a new func `writeConfigToFile` that is suppose to ensuring creation of aforementioned directory and writing to `config.json`
4. also added logging 

```
{"level":"info","ts":1749381482.9189818,"caller":"init/init.go:80","msg":"Writing node configuration.."}
{"level":"info","ts":1749381482.918999,"caller":"init/init.go:196","msg":"Creating nodeadm directory..","path":"/var/lib/nodeadm"}
{"level":"info","ts":1749381482.9192424,"caller":"init/init.go:200","msg":"Writing configuration file..","path":"/var/lib/nodeadm/config.json"}
{"level":"info","ts":1749381482.9194622,"caller":"init/init.go:212","msg":"Configuration file written successfully","path":"/var/lib/nodeadm/config.json"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done** 

`cd amazon-eks-ami/nodeadm`

`go build -o nodeadm ./cmd/nodeadm`

`sudo ./nodeadm init -s run`

```
ec2-user@ip-172-31-27-0 nodeadm]$ sudo ./nodeadm init -s run
{"level":"info","ts":1749381482.7881672,"caller":"init/init.go:56","msg":"Checking user is root.."}
{"level":"info","ts":1749381482.788528,"caller":"init/init.go:64","msg":"Loading configuration..","configSource":"imds://user-data"}
{"level":"info","ts":1749381482.7930558,"caller":"init/init.go:73","msg":"Loaded configuration","config":{"metadata":{"creationTimestamp":null},"spec":{"cluster":{"name":"hardik-eks","apiServerEndpoint":"https://<redacted>.gr7.ap-south-1.eks.amazonaws.com","certificateAuthority":"<redacted>","cidr":"10.100.0.0/16"},"containerd":{},"instance":{"localStorage":{}},"kubelet":{"config":{"clusterDNS":["10.100.0.10"],"maxPods":110,"registerWithTaints":[{"effect":"NoExecute","key":"karpenter.sh/unregistered"}]},"flags":["--node-labels=\"karpenter.k8s.aws/ec2nodeclass=default,karpenter.sh/capacity-type=on-demand,karpenter.sh/nodepool=default\""]}},"status":{"instance":{},"default":{}}}}
{"level":"info","ts":1749381482.7932115,"caller":"init/init.go:75","msg":"Enriching configuration.."}
{"level":"info","ts":1749381482.7932932,"caller":"init/init.go:162","msg":"Fetching kubelet version.."}
{"level":"info","ts":1749381482.7934167,"caller":"kubelet/version.go:30","msg":"Reading kubelet version from file","path":"/etc/eks/kubelet-version.txt"}
{"level":"info","ts":1749381482.793488,"caller":"init/init.go:168","msg":"Fetched kubelet version","version":"v1.32.3"}
{"level":"info","ts":1749381482.7935147,"caller":"init/init.go:169","msg":"Fetching instance details.."}
SDK 2025/06/08 11:18:02 DEBUG attempting waiter request, attempt count: 1
{"level":"info","ts":1749381482.9188673,"caller":"init/init.go:186","msg":"Instance details populated","details":{"id":"i-0f420ced8fd813248","region":"ap-south-1","type":"c6a.xlarge","availabilityZone":"ap-south-1c","mac":"06:ec:fe:1c:cc:c1","privateDnsName":"ip-172-31-27-0.ap-south-1.compute.internal"}}
{"level":"info","ts":1749381482.918938,"caller":"init/init.go:187","msg":"Fetching default options..."}
{"level":"info","ts":1749381482.9189563,"caller":"init/init.go:191","msg":"Default options populated","defaults":{"sandboxImage":"localhost/kubernetes/pause"}}
{"level":"info","ts":1749381482.9189818,"caller":"init/init.go:80","msg":"Writing node configuration.."}
{"level":"info","ts":1749381482.918999,"caller":"init/init.go:196","msg":"Creating nodeadm directory..","path":"/var/lib/nodeadm"}
{"level":"info","ts":1749381482.9192424,"caller":"init/init.go:200","msg":"Writing configuration file..","path":"/var/lib/nodeadm/config.json"}
{"level":"info","ts":1749381482.9194622,"caller":"init/init.go:212","msg":"Configuration file written successfully","path":"/var/lib/nodeadm/config.json"}
{"level":"info","ts":1749381482.9194949,"caller":"init/init.go:85","msg":"Validating configuration.."}
{"level":"info","ts":1749381482.919504,"caller":"init/init.go:90","msg":"Creating daemon manager.."}
{"level":"info","ts":1749381482.9212008,"caller":"init/init.go:108","msg":"Configuring daemons..."}
{"level":"info","ts":1749381482.9212286,"caller":"init/init.go:115","msg":"Configuring daemon...","name":"containerd"}
{"level":"info","ts":1749381482.9212418,"caller":"containerd/base_runtime_spec.go:20","msg":"Writing containerd base runtime spec...","path":"/etc/containerd/base-runtime-spec.json"}
{"level":"info","ts":1749381482.921469,"caller":"containerd/config.go:55","msg":"Writing containerd config to file..","path":"/etc/containerd/config.toml"}
{"level":"info","ts":1749381482.9215674,"caller":"init/init.go:119","msg":"Configured daemon","name":"containerd"}
{"level":"info","ts":1749381482.9215882,"caller":"init/init.go:115","msg":"Configuring daemon...","name":"kubelet"}
{"level":"info","ts":1749381482.9226623,"caller":"kubelet/config.go:206","msg":"Setup IP for node","ip":"172.31.27.0"}
{"level":"info","ts":1749381482.9234078,"caller":"kubelet/config.go:360","msg":"Writing kubelet config to file..","path":"/etc/kubernetes/kubelet/config.json"}
{"level":"info","ts":1749381482.9234977,"caller":"kubelet/config.go:369","msg":"Enabling kubelet config drop-in dir.."}
{"level":"info","ts":1749381482.9235516,"caller":"kubelet/config.go:384","msg":"Writing user kubelet config to drop-in file..","path":"/etc/kubernetes/kubelet/config.json.d/00-nodeadm.conf"}
{"level":"info","ts":1749381482.9239564,"caller":"init/init.go:119","msg":"Configured daemon","name":"kubelet"}
{"level":"info","ts":1749381482.923976,"caller":"init/init.go:154","msg":"done!","duration":0.13580982}
```

`sudo cat /var/lib/nodeadm/config.json | jq .`

```
{
  "metadata": {
    "creationTimestamp": null
  },
  "spec": {
    "cluster": {
      "name": "hardik-eks",
      "apiServerEndpoint": "https://<redacted>.gr7.ap-south-1.eks.amazonaws.com",
      "certificateAuthority": "<redacted>",
      "cidr": "10.100.0.0/16"
    },
    "containerd": {},
    "instance": {
      "localStorage": {}
    },
    "kubelet": {
      "config": {
        "clusterDNS": [
          "10.100.0.10"
        ],
        "maxPods": 110,
        "registerWithTaints": [
          {
            "effect": "NoExecute",
            "key": "karpenter.sh/unregistered"
          }
        ]
      },
      "flags": [
        "--node-labels=\"karpenter.k8s.aws/ec2nodeclass=default,karpenter.sh/capacity-type=on-demand,karpenter.sh/nodepool=default\""
      ]
    }
  },
  "status": {
    "instance": {
      "id": "i-0f420ced8fd813248",
      "region": "ap-south-1",
      "type": "c6a.xlarge",
      "availabilityZone": "ap-south-1c",
      "mac": "06:ec:fe:1c:cc:c1",
      "privateDnsName": "ip-172-31-27-0.ap-south-1.compute.internal"
    },
    "default": {
      "sandboxImage": "localhost/kubernetes/pause"
    },
    "kubeletVersion": "v1.32.3"
  }
}
```


<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
