### PR TITLE
feat(nodeadm): enable DRA for 1.33+

### DIFF
--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -229,6 +229,11 @@ func (ksc *kubeletConfig) withVersionToggles(cfg *api.NodeConfig, flags map[stri
 		ksc.KubeAPIQPS = ptr.Int(10)
 		ksc.KubeAPIBurst = ptr.Int(20)
 	}
+
+	// EKS enables DRA on 1.33+
+	if semver.Compare(cfg.Status.KubeletVersion, "v1.33.0") >= 0 {
+		ksc.FeatureGates["DynamicResourceAllocation"] = true
+	}
 }
 
 func (ksc *kubeletConfig) withCloudProvider(cfg *api.NodeConfig, flags map[string]string) {


### PR DESCRIPTION
**Description of changes:**

This opens the `DynamicResourceAllocation` feature gate for Kubernetes 1.33 and above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
