### PR TITLE
[WIP] fix(build): correct al2023 arm64 nvidia repo url

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -82,10 +82,14 @@ sudo dnf -y install \
   kernel-headers-$(uname -r) \
   kernel-modules-extra-common-$(uname -r)
 
-# Install dkms dependency from amazonlinux
+# Install dkms dependency from amazonlinux repo
 sudo dnf -y install patch
-# Install dkms from the cuda repo
-sudo dnf -y --disablerepo="*" --enablerepo="cuda*" install dkms
+if is-isolated-partition; then
+  sudo dnf -y install dkms
+else
+  # Install dkms from the cuda repo
+  sudo dnf -y --disablerepo="*" --enablerepo="cuda*" install dkms
+fi
 
 function archive-open-kmods() {
   echo "Archiving open kmods"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Fixes the default nvidia arm64 repo URL link to point to the sbsa one. The current default installation logic looks for an amzn2023/aarch64 repository which doesn't exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
