### PR TITLE
fix(al2023): use repo for dkms install based on architecture

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -34,24 +34,27 @@ echo "Installing NVIDIA ${NVIDIA_DRIVER_MAJOR_VERSION} drivers..."
 ################################################################################
 ### Add repository #############################################################
 ################################################################################
-# Determine the domain based on the region
-if is-isolated-partition; then
-  sudo dnf install -y nvidia-release
-  sudo sed -i 's/$dualstack//g' /etc/yum.repos.d/amazonlinux-nvidia.repo
-
-  rpm_install "opencl-filesystem-1.0-5.el7.noarch.rpm" "ocl-icd-2.2.12-1.el7.x86_64.rpm"
-
-else
+function get_cuda_al2023_x86_repo() {
   if [[ $AWS_REGION == cn-* ]]; then
     DOMAIN="nvidia.cn"
   else
     DOMAIN="nvidia.com"
   fi
 
+  echo "https://developer.download.${DOMAIN}/compute/cuda/repos/amzn2023/x86_64/cuda-amzn2023.repo"
+}
+
+# Determine the domain based on the region
+if is-isolated-partition; then
+  sudo dnf install -y nvidia-release
+  sudo sed -i 's/$dualstack//g' /etc/yum.repos.d/amazonlinux-nvidia.repo
+
+  rpm_install "opencl-filesystem-1.0-5.el7.noarch.rpm" "ocl-icd-2.2.12-1.el7.x86_64.rpm"
+else
   if [ -n "${NVIDIA_REPOSITORY:-}" ]; then
     sudo dnf config-manager --add-repo ${NVIDIA_REPOSITORY}
   else
-    sudo dnf config-manager --add-repo https://developer.download.${DOMAIN}/compute/cuda/repos/amzn2023/$(uname -m)/cuda-amzn2023.repo
+    sudo dnf config-manager --add-repo $(get_cuda_al2023_x86_repo)
   fi
 
   # update all current .repo sources to enable gpgcheck
@@ -78,10 +81,23 @@ sudo dnf -y install \
   kernel-headers-$(uname -r) \
   kernel-modules-extra-common-$(uname -r)
 
-# Install dkms dependency from amazonlinux
+# Install dkms dependency from amazonlinux repo
 sudo dnf -y install patch
-# Install dkms from the cuda repo
-sudo dnf -y --disablerepo="*" --enablerepo="cuda*" install dkms
+
+if is-isolated-partition; then
+  sudo dnf -y install dkms
+else
+  # Install dkms from the cuda repo
+  if [[ "$(uname -m)" == "x86_64" ]]; then
+    sudo dnf -y --disablerepo="*" --enablerepo="cuda*" install dkms
+  else
+    sudo dnf -y remove dkms
+    sudo dnf config-manager --add-repo $(get_cuda_al2023_x86_repo)
+    sudo dnf -y --disablerepo="*" --enablerepo="cuda*" install dkms
+    sudo dnf config-manager --set-disabled cuda-amzn2023-x86_64
+    sudo rm /etc/yum.repos.d/cuda-amzn2023.repo
+  fi
+fi
 
 function archive-open-kmods() {
   echo "Archiving open kmods"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
For x86_64, continue using the CUDA repo to install dkms refer: https://github.com/awslabs/amazon-eks-ami/pull/2284
For others, use amazonlinux since the CUDA repo does not have dkms resulting in AMI build failures

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
