### PR TITLE
fix(al2023): fix dkms path, nvidia-open installation for isolated par…

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -111,15 +111,20 @@ function archive-open-kmods() {
   # The DKMS package name differs between the RPM and the dkms.conf in the OSS kmod sources
   # TODO: can be removed if this is merged: https://github.com/NVIDIA/open-gpu-kernel-modules/pull/567
 
-  # The open kernel module name changed from nvidia-open to nvidia in 570.148.08
-  # Remove and re-add dkms module with the correct name. This maintains the current install and archive behavior
-  NVIDIA_OPEN_VERSION=$(kmod-util module-version nvidia)
-  sudo dkms remove "nvidia/$NVIDIA_OPEN_VERSION" --all
-  sudo sed -i 's/PACKAGE_NAME="nvidia"/PACKAGE_NAME="nvidia-open"/' /usr/src/nvidia-$NVIDIA_OPEN_VERSION/dkms.conf
-  sudo mv /usr/src/nvidia-$NVIDIA_OPEN_VERSION /usr/src/nvidia-open-$NVIDIA_OPEN_VERSION
-  sudo dkms add -m nvidia-open -v $NVIDIA_OPEN_VERSION
-  sudo dkms build -m nvidia-open -v $NVIDIA_OPEN_VERSION
-  sudo dkms install -m nvidia-open -v $NVIDIA_OPEN_VERSION
+  if is-isolated-partition; then
+    NVIDIA_OPEN_VERSION=$(kmod-util module-version nvidia-open)
+    sudo sed -i 's/PACKAGE_NAME="nvidia"/PACKAGE_NAME="nvidia-open"/g' /var/lib/dkms/nvidia-open/$NVIDIA_OPEN_VERSION/source/dkms.conf
+  else
+    # The open kernel module name changed from nvidia-open to nvidia in 570.148.08
+    # Remove and re-add dkms module with the correct name. This maintains the current install and archive behavior
+    NVIDIA_OPEN_VERSION=$(kmod-util module-version nvidia)
+    sudo dkms remove "nvidia/$NVIDIA_OPEN_VERSION" --all
+    sudo sed -i 's/PACKAGE_NAME="nvidia"/PACKAGE_NAME="nvidia-open"/' /usr/src/nvidia-$NVIDIA_OPEN_VERSION/dkms.conf
+    sudo mv /usr/src/nvidia-$NVIDIA_OPEN_VERSION /usr/src/nvidia-open-$NVIDIA_OPEN_VERSION
+    sudo dkms add -m nvidia-open -v $NVIDIA_OPEN_VERSION
+    sudo dkms build -m nvidia-open -v $NVIDIA_OPEN_VERSION
+    sudo dkms install -m nvidia-open -v $NVIDIA_OPEN_VERSION
+  fi
 
   sudo kmod-util archive nvidia-open
 

--- a/templates/al2023/runtime/gpu/kmod-util
+++ b/templates/al2023/runtime/gpu/kmod-util
@@ -4,8 +4,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# dkms may not be on the PATH
-DKMS=/usr/bin/dkms
+# dkms may not be on the PATH. Discover the path from known paths
+DKMS=""
+for path in /usr/bin/dkms /usr/sbin/dkms; do
+  if [ -x "$path" ]; then
+    DKMS=$path
+    break
+  fi
+done
+
 DKMS_ARCHIVE_DIR=/var/lib/dkms-archive
 
 function log() {


### PR DESCRIPTION
…tition

**Issue #, if available:**

**Description of changes:**
Isolated partition uses the older version of dkms and NVIDIA driver. Added partition based logic to install the nvidia-open modules. For dkms, the path will be discovered from known paths to avoid adding a partition based check

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
