### PR TITLE
feat(al2/bootstrap): add dedicated flag for max pods

### DIFF
--- a/templates/al2/runtime/bootstrap.sh
+++ b/templates/al2/runtime/bootstrap.sh
@@ -33,6 +33,7 @@ function print_help {
   echo "--ip-family Specify ip family of the cluster"
   echo "--kubelet-extra-args Extra arguments to add to the kubelet. Useful for adding labels or taints."
   echo "--local-disks Setup instance storage NVMe disks in raid0 or mount the individual disks for use by pods <mount | raid0 | raid10>"
+  echo "--max-pods-value Specify an exact value of max pods to use for kubelet, prioritized over all other related settings if provided."
   echo "--mount-bpf-fs Mount a bpffs at /sys/fs/bpf (default: true)"
   echo "--pause-container-account The AWS account (number) to pull the pause container from"
   echo "--pause-container-version The tag of the pause container"
@@ -166,6 +167,12 @@ while [[ $# -gt 0 ]]; do
     --mount-bpf-fs)
       MOUNT_BPF_FS=$2
       log "INFO: --mount-bpf-fs='${MOUNT_BPF_FS}'"
+      shift
+      shift
+      ;;
+    --max-pods-value)
+      MAX_PODS_VALUE=$2
+      log "INFO: --max-pods-value='${MAX_PODS_VALUE}'"
       shift
       shift
       ;;
@@ -517,6 +524,7 @@ fi
 MAX_PODS_FILE="/etc/eks/eni-max-pods.txt"
 set +o pipefail
 MAX_PODS=$(cat $MAX_PODS_FILE | awk "/^${INSTANCE_TYPE:-unset}/"' { print $2 }')
+MAX_PODS=${MAX_PODS_VALUE:-$MAX_PODS}
 set -o pipefail
 if [ -z "$MAX_PODS" ] || [ -z "$INSTANCE_TYPE" ]; then
   log "INFO: No entry for type '$INSTANCE_TYPE' in $MAX_PODS_FILE. Will attempt to auto-discover value."


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Creates a new CLI flag for setting max pods. This is mainly to handle the case where a user wants to customize max pods independent of what we would set (including if they want to use the existing max-pods-calculator.sh) and ensure that the system reserved logic gets updated accordingly.

Memory reserved is calculated as a linear function of max pods (11 * maxPods + 255). If max pods is passed in kubelet-extra-args, we still calculate memory reserved based on the default maxPods value -- either retrieved from eni-max-pods.txt, or computed from equivalently computed from DescribeInstanceType call if that's not set. It's messy to try to parse the flag out of that list of flags, so this instead adds a flag to better capture the functionality, and also makes it opt-in to avoid a shift in functionality for users who might have indirectly come to rely on the omission.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
