### PR TITLE
build(al2023): install nvlsm and dependencies globally

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -180,14 +180,11 @@ archive-proprietary-kmod
 ################################################################################
 # https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#systems-using-fourth-generation-nvswitches
 
-# TODO: install unconditionally once availability is guaranteed
-if ! is-isolated-partition; then
-  echo "ib_umad" | sudo tee -a /etc/modules-load.d/ib-umad.conf
-  sudo dnf -y install \
-    libibumad \
-    infiniband-diags \
-    nvlsm
-fi
+echo "ib_umad" | sudo tee -a /etc/modules-load.d/ib-umad.conf
+sudo dnf -y install \
+  libibumad \
+  infiniband-diags \
+  nvlsm
 
 ################################################################################
 ### Prepare for nvidia init ####################################################


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Install nvlsm unconditionally so that it's always available in case it's needed.

Not sure exactly when this was added, but it's been in the AL nvidia repositories for a while, e.g.
```
$ dnf install nvlsm --releasever=2023.7.20250609
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
