### PR TITLE
fix(nodeadm): use aws retry and timeout definitions in ec2 waiter

### DIFF
--- a/nodeadm/internal/aws/ec2/instance_waiter.go
+++ b/nodeadm/internal/aws/ec2/instance_waiter.go
@@ -2,13 +2,12 @@ package ec2
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
-	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/middleware"
 	smithytime "github.com/aws/smithy-go/time"
 	smithywaiter "github.com/aws/smithy-go/waiter"
@@ -131,16 +130,13 @@ func (w *InstanceConditionWaiter) WaitForOutput(ctx context.Context, params *ec2
 		})
 
 		if err != nil {
-			retryable, retryErr := instanceRetryable(err)
-			if retryErr != nil {
-				return nil, retryErr
+			retryable, err := instanceRetryable(err)
+			if err != nil {
+				return nil, err
 			}
 			if !retryable {
 				return out, nil
 			}
-			zap.L().Warn("retryable error encountered",
-				zap.Error(err),
-			)
 		} else {
 			conditionMet, err := w.condition(out)
 			if err != nil {
@@ -173,17 +169,29 @@ func (w *InstanceConditionWaiter) WaitForOutput(ctx context.Context, params *ec2
 	return nil, fmt.Errorf("exceeded max wait time for InstanceCondition waiter")
 }
 
+var (
+	retryables = retry.IsErrorRetryables(append(
+		[]retry.IsErrorRetryable{
+			retry.RetryableErrorCode{
+				Codes: map[string]struct{}{"InvalidInstanceID.NotFound": {}},
+			},
+		},
+		retry.DefaultRetryables...,
+	))
+	timeouts = retry.IsErrorTimeouts(retry.DefaultTimeouts)
+)
+
 func instanceRetryable(err error) (bool, error) {
 	if err != nil {
-		var apiErr smithy.APIError
-		ok := errors.As(err, &apiErr)
-		if !ok {
-			return false, fmt.Errorf("expected err to be of type smithy.APIError, got %w", err)
-		}
-
-		if "InvalidInstanceID.NotFound" == apiErr.ErrorCode() {
+		if timeouts.IsErrorTimeout(err).Bool() {
+			zap.L().Warn("timeout error encountered", zap.Error(err))
 			return true, nil
 		}
+		if retryables.IsErrorRetryable(err).Bool() {
+			zap.L().Warn("retryable error encountered", zap.Error(err))
+			return true, nil
+		}
+		return false, nil
 	}
 
 	return true, nil


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

in https://github.com/awslabs/amazon-eks-ami/pull/2277 we've updated the functionality of the waiter to be a replacement for the default ec2 client retry mechanism, however it does not handle other generic cases such as network timeouts. 

This PR takes the default timeout and retry definitions from the AWS go SDK and uses them to decide whether the error is retryable by the waiter wrapper.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
