### PR TITLE
revert(nodeadm): undo retry changes for ec2 instance waiter

### DIFF
--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -2,12 +2,17 @@ package init
 
 import (
 	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 	"k8s.io/utils/strings/slices"
-	"time"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/aws/imds"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/cli"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/configprovider"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/containerd"
@@ -152,7 +157,18 @@ func enrichConfig(log *zap.Logger, cfg *api.NodeConfig) error {
 	cfg.Status.KubeletVersion = kubeletVersion
 	log.Info("Fetched kubelet version", zap.String("version", kubeletVersion))
 	log.Info("Fetching instance details..")
-	instanceDetails, err := api.GetInstanceDetails(context.TODO(), cfg.Spec.FeatureGates)
+	awsConfig, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithClientLogMode(aws.LogRetries),
+		config.WithEC2IMDSRegion(func(o *config.UseEC2IMDSRegion) {
+			// Use our pre-configured IMDS client to avoid hitting common retry
+			// issues with the default config.
+			o.Client = imds.Client
+		}),
+	)
+	if err != nil {
+		return err
+	}
+	instanceDetails, err := api.GetInstanceDetails(context.TODO(), cfg.Spec.FeatureGates, ec2.NewFromConfig(awsConfig))
 	if err != nil {
 		return err
 	}

--- a/nodeadm/internal/api/status.go
+++ b/nodeadm/internal/api/status.go
@@ -28,7 +28,7 @@ func GetInstanceDetails(ctx context.Context, featureGates map[Feature]bool) (*In
 
 	var privateDNSName string
 	if !IsFeatureEnabled(InstanceIdNodeName, featureGates) {
-		privateDNSName, err = getPrivateDNSName(ctx, instanceIdenitityDocument.InstanceID)
+		privateDNSName, err = getPrivateDNSName(instanceIdenitityDocument.InstanceID)
 		if err != nil {
 			return nil, err
 		}
@@ -47,8 +47,8 @@ func GetInstanceDetails(ctx context.Context, featureGates map[Feature]bool) (*In
 const privateDNSNameAvailableTimeout = 3 * time.Minute
 
 // GetPrivateDNSName returns this instance's private DNS name as reported by the EC2 API, waiting until it's available if necessary.
-func getPrivateDNSName(ctx context.Context, instanceID string) (string, error) {
-	awsConfig, err := config.LoadDefaultConfig(ctx,
+func getPrivateDNSName(instanceID string) (string, error) {
+	awsConfig, err := config.LoadDefaultConfig(context.TODO(),
 		config.WithEC2IMDSRegion(func(o *config.UseEC2IMDSRegion) {
 			// Use our pre-configured IMDS client to avoid hitting common retry
 			// issues with the default config.
@@ -61,7 +61,7 @@ func getPrivateDNSName(ctx context.Context, instanceID string) (string, error) {
 	w := ec2extra.NewInstanceConditionWaiter(awsConfig, privateDNSNameAvailable, func(opts *ec2extra.InstanceConditionWaiterOptions) {
 		opts.LogWaitAttempts = true
 	})
-	out, err := w.WaitForOutput(ctx, &ec2.DescribeInstancesInput{InstanceIds: []string{instanceID}}, privateDNSNameAvailableTimeout)
+	out, err := w.WaitForOutput(context.TODO(), &ec2.DescribeInstancesInput{InstanceIds: []string{instanceID}}, privateDNSNameAvailableTimeout)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Eliminating any source of issues from retry logic changes until we can fully test the behavior with different api responses.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
