### PR TITLE
chore(build/al2023): bump default nodeadm builder image to 1.24

### DIFF
--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -19,7 +19,7 @@
     "iam_instance_profile": "",
     "kms_key_id": "",
     "launch_block_device_mappings_volume_size": "20",
-    "nodeadm_build_image": "public.ecr.aws/eks-distro-build-tooling/golang:1.23",
+    "nodeadm_build_image": "public.ecr.aws/eks-distro-build-tooling/golang:1.24",
     "nvidia_driver_major_version": "570",
     "nvidia_repository_url": null,
     "pause_container_image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.10",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
https://github.com/awslabs/amazon-eks-ami/pull/2233 requires 1.24

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
