### PR TITLE
feat(log-collector): collect systemd-network configs and unattended-upgrades

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -71,6 +71,7 @@ COMMON_DIRECTORIES=(
 COMMON_LOGS=(
   syslog
   messages
+  unattended-upgrades
   aws-routed-eni # eks
   containers     # eks
   pods           # eks
@@ -668,7 +669,32 @@ get_networking_info() {
     ethtool -S ${ifc} >> "${COLLECT_DIR}"/networking/ethtool.txt 2>&1
     echo -e "\n" >> "${COLLECT_DIR}"/networking/ethtool.txt
   done
+
+  get_systemd_network_config
   ok
+}
+
+get_systemd_network_config() {
+  # The possible locations of systemd-networkd configuration files
+  # https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html
+  folders=(
+    "/usr/lib/systemd/network"
+    "/etc/systemd/network"
+    "/run/systemd/network"
+    "/usr/local/lib/systemd/network"
+  )
+
+  mkdir -p "${COLLECT_DIR}"/networking/systemd-network
+
+  # Process each folder
+  for folder in "${folders[@]}"; do
+    [ ! -d "$folder" ] && continue
+    [ -z "$(ls -A "$folder")" ] && continue
+    for unit in "$folder"/*.*; do
+      [ ! -f "$unit" ] && continue
+      systemd-analyze cat-config "${unit}" > "${COLLECT_DIR}"/networking/systemd-network/$(basename "$unit") 2> /dev/null
+    done
+  done
 }
 
 get_cni_config() {


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws/amazon-vpc-cni-k8s/issues/2103

**Description of changes:**
Add this log collection to  better verify if [the known **systemd-udev** issue](https://github.com/aws/amazon-vpc-cni-k8s/blob/f6ed39b50840e7f6985f33113feeb8e7572bfb31/docs/troubleshooting.md#known-issues) occur

**Test**
The collected log looks like below
```
# /usr/lib/systemd/network/99-default.link
# SPDX-License-Identifier: MIT-0
#
# This config file is installed as part of systemd.
# It may be freely copied and edited (following the MIT No Attribution license).
#
# To make local modifications, one of the following methods may be used:
# 1. add a drop-in file that extends this file by creating the
#    /etc/systemd/network/99-default.link.d/ directory and creating a
#    new .conf file there.
# 2. copy this file into /etc/systemd/network or one of the other paths checked
#    by systemd-udevd and edit it there.
# This file should not be edited in place, because it'll be overwritten on upgrades.

[Match]
OriginalName=*

[Link]
NamePolicy=keep kernel database onboard slot path
AlternativeNamesPolicy=database onboard slot path
MACAddressPolicy=persistent

# /etc/systemd/network/99-default.link.d/99-no-policy.conf
# Ensure MACAddressPolicy=none, reinstalling systemd-udev writes /usr/lib/systemd/network/99-default.link
# with value set to persistent
# https://github.com/aws/amazon-vpc-cni-k8s/issues/2103#issuecomment-1321698870
[Link]
MACAddressPolicy=none
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.