### PR TITLE
fix: update wasm_exec.js path for Go 1.24 compatibility

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -15,7 +15,7 @@ jobs:
     - run: |
         pushd nodeadm && make wasm && popd
         mkdir -p ./site/assets/wasm && cp ./nodeadm/_bin/nodeadm.wasm ./site/assets/wasm/
-        mkdir -p ./site/assets/javascripts && cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" ./site/assets/javascripts/
+        mkdir -p ./site/assets/javascripts && cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" ./site/assets/javascripts/
     - run: pip install mkdocs mkdocs-material
       # use the --dirty flag so that we dont purge our custom assets
     - run: mkdocs gh-deploy --dirty --no-history --force


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
https://tip.golang.org/doc/go1.24
> The support files for WebAssembly have been moved to lib/wasm from misc/wasm.

This has caused the mkdocs job to fail for recent commits

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
The job succeeded in my fork as can be seen in the commit history. shows 1/1 pass vs 0/1 for previous commits
https://github.com/HusainZafar/amazon-eks-ami/commits/main/

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
