### PR TITLE
build(al2): unpin runc from .1 minor version

### DIFF
--- a/templates/al2/variables-default.json
+++ b/templates/al2/variables-default.json
@@ -25,7 +25,7 @@
     "pause_container_version": "3.10",
     "pull_cni_from_github": "true",
     "remote_folder": "/tmp",
-    "runc_version": "1.1.*",
+    "runc_version": "1.*",
     "security_group_id": "",
     "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
     "source_ami_id": "",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
runc 1.2.* is now available in the AL2 extras repo we source it from, unpinning the minor version will let us pick it up in our builds.

containerd has been testing with 1.2 since v1.7.24, xref https://github.com/containerd/containerd/blob/v1.7.24/script/setup/runc-version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
