### PR TITLE
fix(nodeadm): increase retries for AWS API calls

### DIFF
--- a/nodeadm/internal/api/status.go
+++ b/nodeadm/internal/api/status.go
@@ -43,7 +43,7 @@ func GetInstanceDetails(ctx context.Context, featureGates map[Feature]bool, ec2C
 	}, nil
 }
 
-const privateDNSNameAvailableTimeout = 3 * time.Minute
+const privateDNSNameAvailableTimeout = 10 * time.Minute
 
 // GetPrivateDNSName returns this instance's private DNS name as reported by the EC2 API, waiting until it's available if necessary.
 func getPrivateDNSName(ec2Client *ec2.Client, instanceID string) (string, error) {

--- a/nodeadm/test/e2e/cases/aws-api-connection-timeout/config.yaml
+++ b/nodeadm/test/e2e/cases/aws-api-connection-timeout/config.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16

--- a/nodeadm/test/e2e/cases/aws-api-connection-timeout/run.sh
+++ b/nodeadm/test/e2e/cases/aws-api-connection-timeout/run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+wait::dbus-ready
+
+# IMDS should be available, but the AWS API should be a void
+mock::imds
+mock::connection-timeout-server 5000
+mock::kubelet 1.29.0
+
+DEFAULT_MAX_ATTEMPTS=3
+CONNECTION_TIMEOUT=30
+
+# ensure the max retry attempts can be overridden with the standard env var
+# we have to test with values that are different from the default
+MAX_ATTEMPTS_VALUES=(1 2)
+
+for MAX_ATTEMPTS_VALUE in "${MAX_ATTEMPTS_VALUES[@]}"; do
+  if [ "$MAX_ATTEMPTS_VALUE" = "$DEFAULT_MAX_ATTEMPTS" ]; then
+    echo "We can't test with a value ($MAX_ATTEMPTS_VALUE) that is the same as the default!"
+    exit 1
+  fi
+  echo "testing with MAX_ATTEMPTS=${MAX_ATTEMPTS_VALUE}"
+  START=$(date +%s)
+  AWS_MAX_ATTEMPTS=${MAX_ATTEMPTS_VALUE} nodeadm init --development --skip run --config-source file://config.yaml || true
+  END=$(date +%s)
+  SECONDS_ELAPSED=$((END - START))
+  LOWER_BOUND=$((MAX_ATTEMPTS_VALUE * CONNECTION_TIMEOUT))
+  UPPER_BOUND=$((LOWER_BOUND + 5))
+  echo "MAX_ATTEMPTS=${MAX_ATTEMPTS_VALUE} SECONDS_ELAPSED=${SECONDS_ELAPSED}, LOWER_BOUND=${LOWER_BOUND}, UPPER_BOUND=${UPPER_BOUND}"
+  if ! ((SECONDS_ELAPSED >= LOWER_BOUND && SECONDS_ELAPSED <= UPPER_BOUND)); then
+    echo "The observed AWS SDK retry behavior did not fall within the expected range!"
+    exit 1
+  fi
+done
+
+# now, we need to make sure that if no override is specified,
+# we use our increased number of attempts instead of the default
+
+nodeadm init --development --skip run --config-source file://config.yaml &
+NODEADM_PID=$!
+
+sleep $((CONNECTION_TIMEOUT * (DEFAULT_MAX_ATTEMPTS + 1)))
+
+if ! kill -0 "$NODEADM_PID" &> /dev/null; then
+  echo "nodeadm was not still running after waiting out the default retry period; this means our retry config is not working as intended!"
+  exit 1
+fi

--- a/nodeadm/test/e2e/cases/imds-timeouts/run.sh
+++ b/nodeadm/test/e2e/cases/imds-timeouts/run.sh
@@ -10,7 +10,7 @@ wait::dbus-ready
 mock::kubelet 1.29.0
 
 # configure without launching the imds mock service
-IMDS_MOCK_ONLY_CONFIGURE=true mock::aws
+ENABLE_IMDS_MOCK=false mock::aws
 
 if nodeadm init --skip run; then
   echo "bootstrap should not succeed when EC2 IMDS APIs are not reachable."
@@ -19,5 +19,5 @@ fi
 
 # start the imds mock part way into the initialization to mimic
 # delayed availability of IMDS
-{ sleep 10 && AWS_MOCK_ONLY_CONFIGURE=true mock::aws; } &
+{ sleep 10 && ENABLE_AWS_MOCK=false mock::aws; } &
 nodeadm init --skip run

--- a/nodeadm/test/e2e/helpers.sh
+++ b/nodeadm/test/e2e/helpers.sh
@@ -100,17 +100,64 @@ function wait::dbus-ready() {
   wait::path-exists /run/systemd/private
 }
 
-function mock::aws() {
-  local CONFIG_PATH=${1:-/etc/aemm-default-config.json}
-  [ "${IMDS_MOCK_ONLY_CONFIGURE:-}" = "true" ] || imds-mock --config-file $CONFIG_PATH &
-  export AWS_EC2_METADATA_SERVICE_ENDPOINT=http://localhost:1338
-  [ "${AWS_MOCK_ONLY_CONFIGURE:-}" = "true" ] || $HOME/.local/bin/moto_server -p5000 &
-  export AWS_ACCESS_KEY_ID='testing'
-  export AWS_SECRET_ACCESS_KEY='testing'
-  export AWS_SECURITY_TOKEN='testing'
-  export AWS_SESSION_TOKEN='testing'
-  export AWS_REGION=us-east-1
-  export AWS_ENDPOINT_URL=http://localhost:5000
-  # ensure that our instance exists in the API
-  aws ec2 run-instances
+function wait::server-responding() {
+  if [ "$#" -ne 3 ]; then
+    echo "usage: $0 HOST PORT TIMEOUT_SECONDS"
+    return 1
+  fi
+  HOST=${1}
+  PORT=${2}
+  TIMEOUT_SECONDS=${3}
+  SLEEP_SECONDS=1
+  START=$(date +%s)
+  while ! nc -z "$HOST" "$PORT"; do
+    NOW=$(date +%s)
+    ELAPSED=$((NOW - START))
+    if [ "$ELAPSED" -ge "$TIMEOUT_SECONDS" ]; then
+      echo "ERROR: server did not respond on $HOST:$PORT within $TIMEOUT_SECONDS second(s)"
+      return 1
+    fi
+    sleep "$SLEEP_SECONDS"
+  done
+  return 0
 }
+
+function mock::imds() {
+  local CONFIG_PATH=${1:-/etc/aemm-default-config.json}
+  imds-mock --config-file $CONFIG_PATH &
+  wait::server-responding localhost 1338 10
+}
+
+function mock::aws() {
+  if [ "${ENABLE_IMDS_MOCK:-true}" = "true" ]; then
+    mock::imds ${1:-}
+  fi
+  if [ "${ENABLE_AWS_MOCK:-true}" = "true" ]; then
+    $HOME/.local/bin/moto_server -p5000 &
+    wait::server-responding localhost 5000 10
+    # ensure that our instance exists in the API
+    aws ec2 run-instances
+  fi
+}
+
+function mock::connection-timeout-server() {
+  if [ "$#" -ne 1 ]; then
+    echo "usage: $0 PORT"
+    return 1
+  fi
+  iptables -A INPUT -p tcp --dport ${1} -j DROP
+}
+
+# common environment variables
+export AWS_ACCESS_KEY_ID='testing'
+export AWS_SECRET_ACCESS_KEY='testing'
+export AWS_SECURITY_TOKEN='testing'
+export AWS_SESSION_TOKEN='testing'
+export AWS_REGION=us-east-1
+
+# this is set regardless of whether the mock AWS API is started
+# because we don't want to inadvertently send requests to the real AWS API
+export AWS_ENDPOINT_URL=http://localhost:5000
+
+# do the same for IMDS, for good measure
+export AWS_EC2_METADATA_SERVICE_ENDPOINT=http://localhost:1338

--- a/nodeadm/test/e2e/infra/Dockerfile
+++ b/nodeadm/test/e2e/infra/Dockerfile
@@ -5,7 +5,7 @@ RUN mv /bin/cmd /imds-mock
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN dnf -y update && \
-    dnf -y install systemd containerd jq python3 awscli && \
+    dnf -y install systemd containerd jq python3 awscli nmap-ncat iptables && \
     dnf clean all
 RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \

--- a/nodeadm/test/e2e/run.sh
+++ b/nodeadm/test/e2e/run.sh
@@ -19,7 +19,9 @@ echo "done! Test image: $TEST_IMAGE"
 
 FAILED="false"
 
-for CASE_DIR in $(ls -d test/e2e/cases/*); do
+CASE_PREFIX=${1:-}
+
+for CASE_DIR in $(ls -d test/e2e/cases/${CASE_PREFIX}*); do
   CASE_NAME=$(basename $CASE_DIR)
   printf "🧪 Testing $CASE_NAME..."
   CONTAINER_ID=$(docker run \


### PR DESCRIPTION
**Description of changes:**

The default retryer only makes 3 attempts, with a max delay of 20 seconds between attempts (per the exponential delay policy). Connections will time out after 30 seconds. This PR increases the retries significantly, because a failure in these API calls leads to a terminal node.

We do not override the entire `Retryer`, and instead only override the max attempt count. This allows a user to override the value using the standard environment variable `AWS_MAX_ATTEMPTS`, if push comes to shove.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
