### PR TITLE
Collecting all datastores in the folder for ipamd

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -581,8 +581,12 @@ get_ipamd_info() {
   fi
 
   try "collect L-IPAMD checkpoint"
-  if [[ -f /var/run/aws-node/ipam.json ]]; then
-    cp /var/run/aws-node/ipam.json "${COLLECT_DIR}"/ipamd/ipam.json
+  if [[ -d /var/run/aws-node/ ]]; then
+    for file in /var/run/aws-node/*; do
+      if [[ -f "$file" ]]; then
+        cp "$file" "${COLLECT_DIR}"/ipamd/$(basename "$file")
+      fi
+    done
   fi
 
   ok


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
With Multi-NIC support, we now store datastores for each managed network card. This collects all the ipamd*.json files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
Tested on a instance, it was able to collect the files

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
