### PR TITLE
fix: store networkd dropins under /run

### DIFF
--- a/nodeadm/internal/system/networking.go
+++ b/nodeadm/internal/system/networking.go
@@ -17,8 +17,8 @@ import (
 
 const (
 	networkingAspectName = "networking"
-	// The local administration network directory for systemd.network
-	administrationNetworkDir = "/etc/systemd/network"
+	// the ephemeral networkd config directory, reset on reboot
+	administrationNetworkDir = "/run/systemd/network"
 	// the name of ec2 network configuration setup by amazon-ec2-net-utils:
 	// https://github.com/amazonlinux/amazon-ec2-net-utils/blob/c6626fb5cd094bbfeb62c456fe088011dbab3f95/systemd/network/80-ec2.network
 	ec2NetworkConfigurationName = "80-ec2.network"

--- a/nodeadm/test/e2e/cases/nodeadm-boot-hook/run.sh
+++ b/nodeadm/test/e2e/cases/nodeadm-boot-hook/run.sh
@@ -11,4 +11,4 @@ wait::dbus-ready
 
 nodeadm-internal boot-hook
 
-assert::files-equal /etc/systemd/network/80-ec2.network.d/10-eks_primary_eni_only.conf expected-10-eks_primary_eni_only.conf
+assert::files-equal /run/systemd/network/80-ec2.network.d/10-eks_primary_eni_only.conf expected-10-eks_primary_eni_only.conf


### PR DESCRIPTION
**Description of changes:**

Stores the `networkd` dropin created by `nodeadm` in the `/run` tree, which is a `tmpfs`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
