### PR TITLE
feat(nodeadm): add custom image credential provider support

### DIFF
--- a/nodeadm/api/v1alpha1/nodeconfig_types.go
+++ b/nodeadm/api/v1alpha1/nodeconfig_types.go
@@ -68,6 +68,12 @@ type KubeletOptions struct {
 	// Flags are [command-line `kubelet` arguments](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/).
 	// that will be appended to the defaults.
 	Flags []string `json:"flags,omitempty"`
+
+	// ImageCredentialProviderConfig is a custom Go template to configure
+	// the image credential provider. If not set, a default template is used.
+	// The template is rendered with the ConfigApiVersion, EcrProviderName
+	// and ProviderApiVersion variables.
+	ImageCredentialProviderConfig string `json:"imageCredentialProviderConfig,omitempty"`
 }
 
 // ContainerdOptions are additional parameters passed to `containerd`.

--- a/nodeadm/doc/api.md
+++ b/nodeadm/doc/api.md
@@ -86,6 +86,7 @@ _Appears in:_
 | --- | --- |
 | `config` _object (keys:string, values:[RawExtension](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#rawextension-runtime-pkg))_ | Config is a [`KubeletConfiguration`](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/)<br />that will be merged with the defaults. |
 | `flags` _string array_ | Flags are [command-line `kubelet` arguments](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/).<br />that will be appended to the defaults. |
+| `imageCredentialProviderConfig` _string_ | ImageCredentialProviderConfig is a custom Go template to configure<br />the image credential provider. If not set, a default template is used.<br />The template is rendered with the ConfigApiVersion, EcrProviderName<br />and ProviderApiVersion variables. |
 
 #### LocalStorageOptions
 

--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -132,3 +132,48 @@ spec:
             soft: 1024
             hard: 1024
 ```
+
+---
+
+## Using a custom image credential provider
+
+You can use a custom image credential provider by specifying the `imageCredentialProviderConfig` field in the `KubeletOptions` section of your `NodeConfig`. This allows you to define how image credentials are fetched for your workloads.
+
+Refer to the [Kubelet Credential Provider documentation](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/#configure-a-kubelet-credential-provider) for the format of the file.
+
+```yaml
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  kubelet:
+    imageCredentialProviderConfig: |
+      {
+        "apiVersion": "{{.ConfigApiVersion}}",
+        "kind": "CredentialProviderConfig",
+        "providers": [
+          {
+            "name": "{{.EcrProviderName}}",
+            "matchImages": [
+              "*.dkr.ecr.*.amazonaws.com",
+              "*.dkr-ecr.*.on.aws",
+              "*.dkr.ecr.*.amazonaws.com.cn",
+              "*.dkr-ecr.*.on.amazonwebservices.com.cn",
+              "*.dkr.ecr-fips.*.amazonaws.com",
+              "*.dkr-ecr-fips.*.on.aws",
+              "*.dkr.ecr.*.c2s.ic.gov",
+              "*.dkr.ecr.*.sc2s.sgov.gov",
+              "*.dkr.ecr.*.cloud.adc-e.uk",
+              "*.dkr.ecr.*.csp.hci.ic.gov"
+            ],
+            "defaultCacheDuration": "12h",
+            "apiVersion": "{{.ProviderApiVersion}}"
+          },
+          {
+            "name": "custom",
+            "matchImages": ["custom-registry.example.com"],
+            "defaultCacheDuration": "12h",
+            "apiVersion": "{{.ProviderApiVersion}}"
+          }
+        ]
+      }
+```

--- a/nodeadm/internal/api/bridge/zz_generated.conversion.go
+++ b/nodeadm/internal/api/bridge/zz_generated.conversion.go
@@ -183,6 +183,7 @@ func Convert_api_InstanceOptions_To_v1alpha1_InstanceOptions(in *api.InstanceOpt
 func autoConvert_v1alpha1_KubeletOptions_To_api_KubeletOptions(in *v1alpha1.KubeletOptions, out *api.KubeletOptions, s conversion.Scope) error {
 	out.Config = *(*api.InlineDocument)(unsafe.Pointer(&in.Config))
 	out.Flags = *(*api.KubeletFlags)(unsafe.Pointer(&in.Flags))
+	out.ImageCredentialProviderConfig = in.ImageCredentialProviderConfig
 	return nil
 }
 
@@ -194,6 +195,7 @@ func Convert_v1alpha1_KubeletOptions_To_api_KubeletOptions(in *v1alpha1.KubeletO
 func autoConvert_api_KubeletOptions_To_v1alpha1_KubeletOptions(in *api.KubeletOptions, out *v1alpha1.KubeletOptions, s conversion.Scope) error {
 	out.Config = *(*map[string]runtime.RawExtension)(unsafe.Pointer(&in.Config))
 	out.Flags = *(*[]string)(unsafe.Pointer(&in.Flags))
+	out.ImageCredentialProviderConfig = in.ImageCredentialProviderConfig
 	return nil
 }
 

--- a/nodeadm/internal/api/types.go
+++ b/nodeadm/internal/api/types.go
@@ -73,6 +73,11 @@ type KubeletOptions struct {
 	// amended to the generated defaults, and therefore will act as overrides
 	// https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
 	Flags KubeletFlags `json:"flags,omitempty"`
+	// ImageCredentialProviderConfig is a custom Go template to configure
+	// the image credential provider. If not set, a default template is used.
+	// The template is rendered with the ConfigApiVersion, EcrProviderName
+	// and ProviderApiVersion variables.
+	ImageCredentialProviderConfig string `json:"imageCredentialProviderConfig,omitempty"`
 }
 
 // InlineDocument is an alias to a dynamically typed map. This allows using

--- a/nodeadm/internal/kubelet/image-credential-provider_test.go
+++ b/nodeadm/internal/kubelet/image-credential-provider_test.go
@@ -1,0 +1,124 @@
+package kubelet
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	templatedDefaultCredentialProvider = `{
+  "apiVersion": "kubelet.config.k8s.io/v1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "true",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr-ecr.*.on.aws",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr-ecr.*.on.amazonwebservices.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr-ecr-fips.*.on.aws",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov",
+        "*.dkr.ecr.*.cloud.adc-e.uk",
+        "*.dkr.ecr.*.csp.hci.ic.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1"
+    }
+  ]
+}`
+	customCredentialProvider = `{
+  "apiVersion": "{{.ConfigApiVersion}}",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "custom",
+      "matchImages": [
+        "custom-registry.example.com"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "{{.ProviderApiVersion}}"
+    }
+  ]
+}
+`
+	customTemplatedCredentialProvider = `{
+  "apiVersion": "kubelet.config.k8s.io/v1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "custom",
+      "matchImages": [
+        "custom-registry.example.com"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1"
+    }
+  ]
+}
+`
+)
+
+func TestWriteImageCredentialProviderConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	originalImageCredentialProviderConfigPath := imageCredentialProviderConfigPath
+	t.Cleanup(func() {
+		imageCredentialProviderConfigPath = originalImageCredentialProviderConfigPath
+	})
+
+	t.Setenv(ecrCredentialProviderBinPathEnvironmentName, "/usr/bin/true")
+
+	imageCredentialProviderConfigPath = path.Join(tempDir, "image-credential-provider-config.json")
+	k := kubelet{
+		flags: make(map[string]string),
+	}
+	err := k.writeImageCredentialProviderConfig(&api.NodeConfig{
+		Spec: api.NodeConfigSpec{
+			Kubelet: api.KubeletOptions{},
+		},
+		Status: api.NodeConfigStatus{
+			KubeletVersion: "v1.27.0",
+		},
+	})
+	assert.NoError(t, err)
+	assert.FileExists(t, imageCredentialProviderConfigPath)
+	templatedConfig, err := os.ReadFile(imageCredentialProviderConfigPath)
+	assert.NoError(t, err)
+	assert.JSONEq(t, templatedDefaultCredentialProvider, string(templatedConfig))
+}
+
+func TestWriteCustomImageCredentialProviderConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	originalImageCredentialProviderConfigPath := imageCredentialProviderConfigPath
+	t.Cleanup(func() {
+		imageCredentialProviderConfigPath = originalImageCredentialProviderConfigPath
+	})
+
+	t.Setenv(ecrCredentialProviderBinPathEnvironmentName, "/usr/bin/true")
+
+	imageCredentialProviderConfigPath = path.Join(tempDir, "image-credential-provider-config.json")
+	k := kubelet{
+		flags: make(map[string]string),
+	}
+	err := k.writeImageCredentialProviderConfig(&api.NodeConfig{
+		Spec: api.NodeConfigSpec{
+			Kubelet: api.KubeletOptions{
+				ImageCredentialProviderConfig: customCredentialProvider,
+			},
+		},
+		Status: api.NodeConfigStatus{
+			KubeletVersion: "v1.27.0",
+		},
+	})
+	assert.NoError(t, err)
+	assert.FileExists(t, imageCredentialProviderConfigPath)
+	templatedConfig, err := os.ReadFile(imageCredentialProviderConfigPath)
+	assert.NoError(t, err)
+	assert.JSONEq(t, customTemplatedCredentialProvider, string(templatedConfig))
+}

--- a/nodeadm/test/e2e/cases/image-credential-provider/config-custom.yaml
+++ b/nodeadm/test/e2e/cases/image-credential-provider/config-custom.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: my-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+    imageCredentialProviderConfig: |
+      {
+        "apiVersion": "{{.ConfigApiVersion}}",
+        "kind": "CredentialProviderConfig",
+        "providers": [
+          {
+            "name": "{{.EcrProviderName}}",
+            "matchImages": [
+              "*.dkr.ecr.*.amazonaws.com",
+              "*.dkr-ecr.*.on.aws",
+              "*.dkr.ecr.*.amazonaws.com.cn",
+              "*.dkr-ecr.*.on.amazonwebservices.com.cn",
+              "*.dkr.ecr-fips.*.amazonaws.com",
+              "*.dkr-ecr-fips.*.on.aws",
+              "*.dkr.ecr.*.c2s.ic.gov",
+              "*.dkr.ecr.*.sc2s.sgov.gov",
+              "*.dkr.ecr.*.cloud.adc-e.uk",
+              "*.dkr.ecr.*.csp.hci.ic.gov"
+            ],
+            "defaultCacheDuration": "12h",
+            "apiVersion": "{{.ProviderApiVersion}}"
+          },
+          {
+            "name": "custom-provider",
+            "matchImages": ["custom-registry.example.com"],
+            "defaultCacheDuration": "12h",
+            "apiVersion": "{{.ProviderApiVersion}}"
+          }
+        ]
+      }

--- a/nodeadm/test/e2e/cases/image-credential-provider/expected-image-credential-provider-config-127-custom.json
+++ b/nodeadm/test/e2e/cases/image-credential-provider/expected-image-credential-provider-config-127-custom.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "kubelet.config.k8s.io/v1",
+  "kind": "CredentialProviderConfig",
+  "providers": [
+    {
+      "name": "ecr-credential-provider",
+      "matchImages": [
+        "*.dkr.ecr.*.amazonaws.com",
+        "*.dkr-ecr.*.on.aws",
+        "*.dkr.ecr.*.amazonaws.com.cn",
+        "*.dkr-ecr.*.on.amazonwebservices.com.cn",
+        "*.dkr.ecr-fips.*.amazonaws.com",
+        "*.dkr-ecr-fips.*.on.aws",
+        "*.dkr.ecr.*.c2s.ic.gov",
+        "*.dkr.ecr.*.sc2s.sgov.gov",
+        "*.dkr.ecr.*.cloud.adc-e.uk",
+        "*.dkr.ecr.*.csp.hci.ic.gov"
+      ],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1"
+    },
+    {
+      "name": "custom-provider",
+      "matchImages": ["custom-registry.example.com"],
+      "defaultCacheDuration": "12h",
+      "apiVersion": "credentialprovider.kubelet.k8s.io/v1"
+    }
+  ]
+}

--- a/nodeadm/test/e2e/cases/image-credential-provider/run.sh
+++ b/nodeadm/test/e2e/cases/image-credential-provider/run.sh
@@ -20,3 +20,7 @@ mock::kubelet 1.27.0
 nodeadm init --skip run --config-source file://config.yaml
 
 assert::json-files-equal /etc/eks/image-credential-provider/config.json expected-image-credential-provider-config-127.json
+
+nodeadm init --skip run --config-source file://config-custom.yaml
+
+assert::json-files-equal /etc/eks/image-credential-provider/config.json expected-image-credential-provider-config-127-custom.json


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

In a process where extra credential providers binaries are added, this enable users, instead of overriding the `image-credential-provider-config` flag themselves, to pass a custom CredentialProviderConfig directly.

Let me know what you think,

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

Adding extra tests to verify what gets written as well as an extra e2e test.

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
