### PR TITLE
chore(al2023): update kernel package names

### DIFF
--- a/templates/al2023/provisioners/install-neuron-driver.sh
+++ b/templates/al2023/provisioners/install-neuron-driver.sh
@@ -29,9 +29,14 @@ metadata_expire=0" | sudo tee /etc/yum.repos.d/neuron.repo
 ################################################################################
 ### Install packages ###########################################################
 ################################################################################
-
+KERNEL_PACKAGE="kernel"
+if [[ "$(uname -r)" == 6.12.* ]]; then
+  KERNEL_PACKAGE="kernel6.12"
+fi
 sudo dnf -y install \
-  kernel-devel-$(uname -r) \
-  kernel-headers-$(uname -r)
+  "${KERNEL_PACKAGE}-devel" \
+  "${KERNEL_PACKAGE}-headers"
+
+sudo dnf versionlock 'kernel*'
 
 sudo dnf install -y aws-neuronx-dkms aws-neuronx-tools

--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -70,16 +70,17 @@ sudo mv ${WORKING_DIR}/gpu/kmod-util /usr/bin/
 sudo mkdir -p /etc/dkms
 echo "MAKE[0]=\"'make' -j$(grep -c processor /proc/cpuinfo) module\"" | sudo tee /etc/dkms/nvidia.conf
 
+KERNEL_PACKAGE="kernel"
 if [[ "$(uname -r)" == 6.12.* ]]; then
-  sudo dnf -y install kernel6.12-modules-extra-$(uname -r)
-else
-  sudo dnf -y install kernel-modules-extra-$(uname -r)
+  KERNEL_PACKAGE="kernel6.12"
 fi
-
 sudo dnf -y install \
-  kernel-devel-$(uname -r) \
-  kernel-headers-$(uname -r) \
-  kernel-modules-extra-common-$(uname -r)
+  "${KERNEL_PACKAGE}-devel" \
+  "${KERNEL_PACKAGE}-headers" \
+  "${KERNEL_PACKAGE}-modules-extra" \
+  "${KERNEL_PACKAGE}-modules-extra-common"
+
+sudo dnf versionlock 'kernel*'
 
 # Install dkms dependency from amazonlinux repo
 sudo dnf -y install patch

--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -66,6 +66,19 @@ sudo dnf install -y \
   pigz \
   python3-dnf-plugin-versionlock
 
+# we need to handle different kernel packages depending on the namespace
+# associated with the minor version.
+KERNEL_PACKAGE="kernel"
+if [[ "$(uname -r)" == 6.12.* ]]; then
+  KERNEL_PACKAGE="kernel6.12"
+fi
+sudo dnf -y install \
+  "${KERNEL_PACKAGE}-devel" \
+  "${KERNEL_PACKAGE}-headers"
+
+# versionlock kernel packages so they remain consistent.
+sudo dnf versionlock 'kernel*'
+
 ################################################################################
 ### Networking #################################################################
 ################################################################################


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

The latest AL2023 release changes include the rename of all kernel 6.12 packages to the namespace package `kernel6.12`. This PR updates all locations that we install previous non-namespaced kernel packages.

It additionally install `kernel-devel` and `kernel-headers` in all variants of the AL2023 variety.

* https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes-2023.8.20250721.html#release-summary-2023.8.20250721
* https://docs.aws.amazon.com/linux/al2023/ug/kernel-update.html



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
