### PR TITLE
fix(nvidia): downgrade to 570 driver

### DIFF
--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -20,7 +20,7 @@
     "kms_key_id": "",
     "launch_block_device_mappings_volume_size": "20",
     "nodeadm_build_image": "public.ecr.aws/eks-distro-build-tooling/golang:1.24",
-    "nvidia_driver_major_version": "575",
+    "nvidia_driver_major_version": "570",
     "nvidia_repository_url": null,
     "pause_container_image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.10",
     "remote_folder": "/tmp",


### PR DESCRIPTION
**Description of changes:**

The 575.x NVIDIA driver is not compatible with 6th-gen `g` instances (yet). We will downgrade to 570.x in the meantime.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
