### PR TITLE
fix(ci): remove vpc-cni deployer flags

### DIFF
--- a/.github/actions/ci/kubetest2/action.yaml
+++ b/.github/actions/ci/kubetest2/action.yaml
@@ -38,7 +38,7 @@ runs:
             KUBETEST2_ARGS="--user-data-format=bootstrap.sh"
             ;;
           al2023)
-            KUBETEST2_ARGS="--addons=vpc-cni:latest --tune-vpc-cni --user-data-format=nodeadm"
+            KUBETEST2_ARGS="--user-data-format=nodeadm"
             ;;
           *)
             echo >&2 "unknown os_distro: ${{ inputs.os_distro }}"


### PR DESCRIPTION
**Description of changes:**

There's a bug in the latest VPC CNI version (v1.20.0) that is causing our CI to fail. We shouldn't need to bump the CNI version in our AL2023 jobs anymore, so let's just drop the flags.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
