### PR TITLE
fix(build/al2023): start with latest release version

### DIFF
--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -47,7 +47,7 @@ fi
 ################################################################################
 
 # Update the OS to begin with to catch up to the latest packages.
-sudo dnf update -y
+sudo dnf upgrade -y --releasever=latest
 
 # Install necessary packages
 sudo dnf install -y \


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
AL2023, by default, locks packages visible to a given AMI release by associating all `dnf` operations with a namesake repository ([ref](https://docs.aws.amazon.com/linux/al2023/ug/deterministic-upgrades-usage.html#using-a-deterministic-upgraded-system)). This is done by a `releasever` variable in the repo URL, e.g. `https://al2023-repos-$awsregion-de612dc2.s3$dualstack.$awsregion.$awsdomain/core/mirrors/$releasever/debuginfo/$basearch/$mirrorlist`. If `/etc/dnf/vars/releasever` is empty (as it is by default), `dnf` attempts to resolve the value by checking the installed version of one of several known marker packages, in this case `system-release` ([1](https://github.com/rpm-software-management/dnf/blob/b7eb2e399c42d10444f7d045689fd50f91cf72db/dnf/const.py.in#L25) -> [2](https://github.com/rpm-software-management/dnf/blob/b7eb2e399c42d10444f7d045689fd50f91cf72db/dnf/rpm/__init__.py#L44)). 

AL2023 AMIs release versions include that package with the same version, and each repository includes that package at the same version as in the repository URL. Using `releasever=latest` indicates to use the lastest package repository, which includes the latest version of `system-release`. A generic `dnf upgrade` on that package repo closes the loop by installing a newer version of `system-release`, causing all future `dnf` operations to be bound to that new version by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
