### PR TITLE
feat(nodeadm) add SOCI snapshotter support

### DIFF
--- a/nodeadm/api/v1alpha1/nodeconfig_types.go
+++ b/nodeadm/api/v1alpha1/nodeconfig_types.go
@@ -129,10 +129,16 @@ const (
 )
 
 // Feature specifies which feature gate should be toggled
-// +kubebuilder:validation:Enum={InstanceIdNodeName}
+// +kubebuilder:validation:Enum={InstanceIdNodeName,AggressiveImagePull}
 type Feature string
 
 const (
 	// InstanceIdNodeName will use EC2 instance ID as node name
 	InstanceIdNodeName Feature = "InstanceIdNodeName"
+
+	// AggressiveImagePull enables a parallel image pull for container
+	// images. This will use more instance CPU and Memory during image pull, but
+	// may result in faster image pull times. This flag will be ignored on
+	// instances with memory and vCPU below a certain threshold.
+	AggressiveImagePull Feature = "AggressiveImagePull"
 )

--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -89,8 +89,8 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 
 	daemons := []daemon.Daemon{
-		containerd.NewContainerdDaemon(daemonManager),
-		kubelet.NewKubeletDaemon(daemonManager),
+		containerd.NewContainerdDaemon(daemonManager, system.SysfsResources{}),
+		kubelet.NewKubeletDaemon(daemonManager, system.SysfsResources{}),
 	}
 
 	if !slices.Contains(c.skipPhases, configPhase) {

--- a/nodeadm/doc/api.md
+++ b/nodeadm/doc/api.md
@@ -62,7 +62,7 @@ _Appears in:_
 - [NodeConfigSpec](#nodeconfigspec)
 
 .Validation:
-- Enum: [InstanceIdNodeName]
+- Enum: [InstanceIdNodeName AggressiveImagePull]
 
 #### InstanceOptions
 

--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -102,7 +102,7 @@ This has the benefit of potentially decreasing image pull time, at the cost of i
 
 ### To enable this feature:
 1. Ensure your instance type is a larger instance type. Currently we recommend a 2xlarge instance or larger, but that value may change.
-2. Make sure your workloads can tolerate the increased CPU and memory usage during image pull.
+2. Make sure your workloads can tolerate the increased CPU and memory usage during image pull. This makes the most sense when you need to pull a very large container image early in a node's lifecycle, before other workloads are running.
 3. Enable the feature gate in your user data:
 ```
 ---

--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -92,6 +92,28 @@ spec:
 ```
 
 ---
+## Enabling aggressive image pull (experimental)
+
+When the `AggressiveImagePull` feature gate is enabled, `nodeadm` will configure the container runtime to pull and unpack container images in parallel.
+
+This has the benefit of potentially decreasing image pull time, at the cost of increased CPU and memory usage during image pull.
+
+⚠️ **Note**: This flag will be ignored on instance sizes below a certain vCPU and memory threshold.
+
+### To enable this feature:
+1. Ensure your instance type is a larger instance type. Currently we recommend a 2xlarge instance or larger, but that value may change.
+2. Make sure your workloads can tolerate the increased CPU and memory usage during image pull.
+3. Enable the feature gate in your user data:
+```
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  featureGates:
+    AggressiveImagePull: true
+```
+
+---
 
 ## Configuring `containerd`
 

--- a/nodeadm/internal/api/featuregates.go
+++ b/nodeadm/internal/api/featuregates.go
@@ -14,6 +14,12 @@ var featureVerifiers = map[Feature]func(Feature, map[Feature]bool) bool{
 	// InstanceIdNodeNameGate controls whether to use instance ID as the node's name.
 	// By default, this feature is disabled, and the private DNS Name will be used.
 	InstanceIdNodeName: DefaultFalse,
+
+	// AggressiveImagePull enables a parallel image pull for container
+	// images. This will use more instance CPU and Memory during image pull, but
+	// may result in faster image pull times. This flag will be ignored on
+	// instances with memory and vCPU below a certain threshold.
+	AggressiveImagePull: DefaultFalse,
 }
 
 func IsFeatureEnabled(feature Feature, featureGates map[Feature]bool) bool {

--- a/nodeadm/internal/api/types.go
+++ b/nodeadm/internal/api/types.go
@@ -122,4 +122,6 @@ type Feature string
 const (
 	// InstanceIdNodeName will use EC2 instance ID as node name
 	InstanceIdNodeName Feature = "InstanceIdNodeName"
+
+	AggressiveImagePull Feature = "AggressiveImagePull"
 )

--- a/nodeadm/internal/containerd/base_runtime_spec.go
+++ b/nodeadm/internal/containerd/base_runtime_spec.go
@@ -34,5 +34,5 @@ func writeBaseRuntimeSpec(cfg *api.NodeConfig) error {
 		}
 		baseRuntimeSpecData = string(mergedBaseRuntimeSpecData)
 	}
-	return util.WriteFileWithDir(containerdBaseRuntimeSpecFile, []byte(baseRuntimeSpecData), containerdConfigPerm)
+	return util.WriteFileWithDir(containerdBaseRuntimeSpecFile, []byte(baseRuntimeSpecData), configPerm)
 }

--- a/nodeadm/internal/containerd/config.template.toml
+++ b/nodeadm/internal/containerd/config.template.toml
@@ -8,6 +8,10 @@ address = "/run/containerd/containerd.sock"
 [plugins."io.containerd.grpc.v1.cri".containerd]
 default_runtime_name = "{{.RuntimeName}}"
 discard_unpacked_layers = true
+{{- if .UseSOCISnapshotter}}
+snapshotter = "soci"
+disable_snapshot_annotations = false
+{{- end}}
 
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "{{.SandboxImage}}"
@@ -27,3 +31,13 @@ SystemdCgroup = true
 [plugins."io.containerd.grpc.v1.cri".cni]
 bin_dir = "/opt/cni/bin"
 conf_dir = "/etc/cni/net.d"
+
+{{if .UseSOCISnapshotter}}
+[proxy_plugins.soci]
+type = "snapshot"
+address = "/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"
+
+[proxy_plugins.soci.exports]
+root = "/var/lib/soci-snapshotter-grpc"
+
+{{- end}}

--- a/nodeadm/internal/containerd/config2.template.toml
+++ b/nodeadm/internal/containerd/config2.template.toml
@@ -7,6 +7,10 @@ address = "/run/containerd/containerd.sock"
 
 [plugins.'io.containerd.cri.v1.images']
 discard_unpacked_layers = true
+{{- if .UseSOCISnapshotter}}
+snapshotter = "soci"
+disable_snapshot_annotations = false
+{{- end}}
 
 [plugins.'io.containerd.cri.v1.images'.pinned_images]
 sandbox = "{{.SandboxImage}}"
@@ -31,3 +35,13 @@ SystemdCgroup = true
 [plugins.'io.containerd.cri.v1.runtime'.cni]
 bin_dir = "/opt/cni/bin"
 conf_dir = "/etc/cni/net.d"
+
+{{if .UseSOCISnapshotter}}
+[proxy_plugins.soci]
+type = "snapshot"
+address = "/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"
+
+[proxy_plugins.soci.exports]
+root = "/var/lib/soci-snapshotter-grpc"
+
+{{- end}}

--- a/nodeadm/internal/containerd/containerd_config_test.go
+++ b/nodeadm/internal/containerd/containerd_config_test.go
@@ -1,0 +1,202 @@
+package containerd
+
+import (
+	"testing"
+
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/system"
+	"github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerdConfigWithUserConfigAndAggressiveImagePullFeature(t *testing.T) {
+	cfg := &api.NodeConfig{
+		Spec: api.NodeConfigSpec{
+			FeatureGates: map[api.Feature]bool{
+				api.AggressiveImagePull: true,
+			},
+			Containerd: api.ContainerdOptions{
+				Config: api.ContainerdConfig(`
+[plugins.'io.containerd.grpc.v1.cri'.registry.mirrors]
+"docker.io" = ["https://my-custom-mirror.example.com"]
+`),
+			},
+		},
+	}
+	resources := system.FakeResources{Cpu: 8, Memory: 16 * 1024 * 1024 * 1024}
+	template, err := getConfigTemplateVersion(cfg, false)
+	assert.NoError(t, err)
+	containerdConfig, err := generateContainerdConfig(cfg, resources, template)
+	assert.NoError(t, err)
+	containerdConfig, err = combineContainerdConfigs(containerdConfig, cfg.Spec.Containerd.Config)
+	assert.NoError(t, err)
+
+	// Parse the containerdConfig
+	var configMap map[string]any
+	err = toml.Unmarshal(containerdConfig, &configMap)
+	assert.NoError(t, err)
+
+	plugins, ok := configMap["plugins"].(map[string]any)
+	assert.True(t, ok)
+	criPlugin, ok := plugins["io.containerd.grpc.v1.cri"].(map[string]any)
+	assert.True(t, ok)
+
+	// Verify user config
+	registry, ok := criPlugin["registry"].(map[string]any)
+	assert.True(t, ok)
+
+	mirrors, ok := registry["mirrors"].(map[string]any)
+	assert.True(t, ok)
+
+	dockerMirrors, ok := mirrors["docker.io"].([]any)
+	assert.True(t, ok)
+	assert.ElementsMatch(t, []any{"https://my-custom-mirror.example.com"}, dockerMirrors, "User config was not merged correctly with the containerd config")
+
+	// Verify containerd snapshotter
+	containerdSettings, ok := criPlugin["containerd"].(map[string]any)
+	assert.True(t, ok)
+	assert.Equal(t, "soci", containerdSettings["snapshotter"], "Snapshotter config was not merged correctly with the containerd config")
+}
+
+func TestContainerdConfig(t *testing.T) {
+	tests := []struct {
+		cfg               *api.NodeConfig
+		resources         system.Resources
+		isContainerdV2    bool
+		expectSOCIEnabled bool
+	}{
+		{
+			cfg:            &api.NodeConfig{},
+			resources:      system.FakeResources{Cpu: 8, Memory: 16 * 1024 * 1024 * 1024},
+			isContainerdV2: false,
+			// Flag not enabled
+			expectSOCIEnabled: false,
+		},
+		{
+			cfg: &api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					FeatureGates: map[api.Feature]bool{
+						api.AggressiveImagePull: true,
+					},
+				},
+			},
+			resources:      system.FakeResources{Cpu: 4, Memory: 16 * 1024 * 1024 * 1024},
+			isContainerdV2: false,
+			// Cpu too low
+			expectSOCIEnabled: false,
+		},
+		{
+			cfg: &api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					FeatureGates: map[api.Feature]bool{
+						api.AggressiveImagePull: true,
+					},
+				},
+			},
+			resources:      system.FakeResources{Cpu: 8, Memory: 7 * 1024 * 1024 * 1024},
+			isContainerdV2: false,
+			// Memory too low
+			expectSOCIEnabled: false,
+		},
+		{
+			cfg: &api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					FeatureGates: map[api.Feature]bool{
+						api.AggressiveImagePull: true,
+					},
+				},
+			},
+			resources:         system.FakeResources{Cpu: 8, Memory: 16 * 1024 * 1024 * 1024},
+			isContainerdV2:    false,
+			expectSOCIEnabled: true,
+		},
+		{
+			cfg:            &api.NodeConfig{},
+			resources:      system.FakeResources{Cpu: 8, Memory: 16 * 1024 * 1024 * 1024},
+			isContainerdV2: true,
+			// Flag not enabled
+			expectSOCIEnabled: false,
+		},
+		{
+			cfg: &api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					FeatureGates: map[api.Feature]bool{
+						api.AggressiveImagePull: true,
+					},
+				},
+			},
+			resources:      system.FakeResources{Cpu: 4, Memory: 16 * 1024 * 1024 * 1024},
+			isContainerdV2: true,
+			// Cpu too low
+			expectSOCIEnabled: false,
+		},
+		{
+			cfg: &api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					FeatureGates: map[api.Feature]bool{
+						api.AggressiveImagePull: true,
+					},
+				},
+			},
+			resources:      system.FakeResources{Cpu: 8, Memory: 7 * 1024 * 1024 * 1024},
+			isContainerdV2: true,
+			// Memory too low
+			expectSOCIEnabled: false,
+		},
+		{
+			cfg: &api.NodeConfig{
+				Spec: api.NodeConfigSpec{
+					FeatureGates: map[api.Feature]bool{
+						api.AggressiveImagePull: true,
+					},
+				},
+			},
+			resources:         system.FakeResources{Cpu: 8, Memory: 16 * 1024 * 1024 * 1024},
+			isContainerdV2:    true,
+			expectSOCIEnabled: true,
+		},
+	}
+
+	for _, test := range tests {
+		template, err := getConfigTemplateVersion(test.cfg, test.isContainerdV2)
+		assert.NoError(t, err)
+		containerdConfig, err := generateContainerdConfig(test.cfg, test.resources, template)
+		assert.NoError(t, err)
+
+		var configMap map[string]any
+		err = toml.Unmarshal(containerdConfig, &configMap)
+		assert.NoError(t, err)
+
+		var containerdSettings map[string]any
+		if test.isContainerdV2 {
+			plugins, ok := configMap["plugins"].(map[string]any)
+			assert.True(t, ok)
+			containerdSettings, ok = plugins["io.containerd.cri.v1.images"].(map[string]any)
+			assert.True(t, ok)
+		} else {
+			plugins, ok := configMap["plugins"].(map[string]any)
+			assert.True(t, ok)
+			criPlugin, ok := plugins["io.containerd.grpc.v1.cri"].(map[string]any)
+			assert.True(t, ok)
+			containerdSettings, ok = criPlugin["containerd"].(map[string]any)
+			assert.True(t, ok)
+
+		}
+
+		if test.expectSOCIEnabled {
+			proxyPlugins, ok := configMap["proxy_plugins"].(map[string]any)
+			assert.True(t, ok)
+			soci, ok := proxyPlugins["soci"].(map[string]any)
+			assert.True(t, ok)
+			assert.Equal(t, "snapshot", soci["type"], "incorrect type for proxy_plugin ")
+
+			assert.Equal(t, "soci", containerdSettings["snapshotter"], "incorrect snapshotter configuration")
+		} else {
+			snapshotter, exists := containerdSettings["snapshotter"]
+			if exists {
+				assert.NotEqual(t, "soci", snapshotter, "snapshotter should not be set to soci when feature is disabled")
+			}
+		}
+	}
+
+}

--- a/nodeadm/internal/containerd/snapshotter/soci-snapshotter.config.toml
+++ b/nodeadm/internal/containerd/snapshotter/soci-snapshotter.config.toml
@@ -1,0 +1,21 @@
+debug = false
+
+[content_store]
+type = 'containerd'
+
+[cri_keychain]
+enable_keychain = true
+image_service_path = '/run/containerd/containerd.sock'
+
+[pull_modes.parallel_pull_unpack]
+enable = true
+concurrent_download_chunk_size = "16mb"
+discard_unpacked_layers = true
+max_concurrent_downloads = -1
+max_concurrent_downloads_per_image = 32
+max_concurrent_unpacks = -1
+max_concurrent_unpacks_per_image = 12
+
+[pull_modes.parallel_pull_unpack.decompress_streams."gzip"]
+path = '/usr/bin/unpigz'
+args = ['-d', '-c']

--- a/nodeadm/internal/kubelet/daemon.go
+++ b/nodeadm/internal/kubelet/daemon.go
@@ -3,6 +3,7 @@ package kubelet
 import (
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/daemon"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/system"
 )
 
 const KubeletDaemonName = "kubelet"
@@ -11,15 +12,17 @@ var _ daemon.Daemon = &kubelet{}
 
 type kubelet struct {
 	daemonManager daemon.DaemonManager
+	resources     system.Resources
 	// environment variables to write for kubelet
 	environment map[string]string
 	// kubelet config flags without leading dashes
 	flags map[string]string
 }
 
-func NewKubeletDaemon(daemonManager daemon.DaemonManager) daemon.Daemon {
+func NewKubeletDaemon(daemonManager daemon.DaemonManager, resources system.Resources) daemon.Daemon {
 	return &kubelet{
 		daemonManager: daemonManager,
+		resources:     resources,
 		environment:   make(map[string]string),
 		flags:         make(map[string]string),
 	}

--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -250,6 +250,23 @@ sudo chmod +x $ECR_CREDENTIAL_PROVIDER_BINARY
 sudo mkdir -p /etc/eks/image-credential-provider
 sudo mv $ECR_CREDENTIAL_PROVIDER_BINARY /etc/eks/image-credential-provider/
 
+###############################################################################
+### SOCI Snapshotter ##########################################################
+###############################################################################
+
+# dnf will still try to install containerd from Amazon Linux as a dependency,
+# and it will break because we explicitly exclude it in favor of our manual
+# version in order to version lock it. dnf doesn't recognize the locally
+# installed version.
+# Use `--disableexcludes=all` to allow downloading containerd RPM (but not installing it).
+# TODO consider installing a stub package that provides containerd so that we can
+# do this the normal way with dnf.
+SOCI_RPM_DIR=$(mktemp -d)
+sudo dnf install -y --downloadonly --downloaddir="${SOCI_RPM_DIR}" --disableexcludes=all soci-snapshotter
+# This will break if we need other deps besides containerd.
+sudo rpm -i --nodeps "${SOCI_RPM_DIR}/soci-snapshotter*.rpm"
+sudo systemctl enable soci-snapshotter.socket
+
 ################################################################################
 ### SSM Agent ##################################################################
 ################################################################################

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/soci-snapshotter.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/soci-snapshotter.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=soci snapshotter containerd plugin
+Documentation=https://github.com/awslabs/soci-snapshotter
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/soci-snapshotter-grpc --address fd://
+Restart=no
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/soci-snapshotter.socket
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/soci-snapshotter.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=soci snapshotter containerd plugin (socket)
+Documentation=https://github.com/awslabs/soci-snapshotter
+
+[Socket]
+ListenStream=/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Add a feature flag to NodeConfig that allows enabling the parallel SOCI snapshotter when pulling images. This may result in faster image pulls on large instances, at the cost of higher CPU and memory usage.

See also #2305 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

* Unit testing
* Build and run AMI in cluster, pull large image

Co-authored-by: husaiz <husaiz@amazon.com>