### PR TITLE
WIP: load ip_tables and iptable_nat for AMIs with kernel 6.12

### DIFF
--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -111,6 +111,15 @@ cat << EOF | sudo tee /etc/systemd/network/99-default.link.d/99-no-policy.conf
 MACAddressPolicy=none
 EOF
 
+if [[ "$(uname -r)" == 6.12.* ]]; then
+  # Create module loading configuration for iptable_nat on kernel 6.12
+  cat << EOF | sudo tee -a /etc/modules-load.d/iptables.conf
+ip_tables
+iptable_nat
+EOF
+fi
+
+
 ################################################################################
 ### SSH ########################################################################
 ################################################################################


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/amazon-eks-ami/issues/2354

**Description of changes:**
The dependency for `iptable_nat` module changes across kernel versions (kernel 6.1 to kernel 6.12). On kernel 6.12, it depends on `ip_tables` and `nf_nat` modules but on kernel 6.1 its only dependency is `nf_nat`. In both kernels `nf_nat` is loaded but newer dependent kernel module are not.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
