### PR TITLE
fix: pin kernel to good version

### DIFF
--- a/templates/al2/provisioners/upgrade-kernel.sh
+++ b/templates/al2/provisioners/upgrade-kernel.sh
@@ -5,8 +5,7 @@ set -o nounset
 set -o errexit
 
 if [[ -z "$KERNEL_VERSION" ]]; then
-  # TO-DO: change it back to 5.10 once kernel bug fixed
-  KERNEL_VERSION=5.10.239-236.958
+  KERNEL_VERSION=5.10
   echo "kernel_version is unset. Setting to $KERNEL_VERSION based on Kubernetes version $KUBERNETES_VERSION."
 fi
 

--- a/templates/al2/provisioners/upgrade-kernel.sh
+++ b/templates/al2/provisioners/upgrade-kernel.sh
@@ -5,7 +5,8 @@ set -o nounset
 set -o errexit
 
 if [[ -z "$KERNEL_VERSION" ]]; then
-  KERNEL_VERSION=5.10
+  # TO-DO: change it back to 5.10 once kernel bug fixed
+  KERNEL_VERSION=5.10.239-236.958
   echo "kernel_version is unset. Setting to $KERNEL_VERSION based on Kubernetes version $KUBERNETES_VERSION."
 fi
 

--- a/templates/al2/variables-default.json
+++ b/templates/al2/variables-default.json
@@ -28,7 +28,7 @@
     "remote_folder": "/tmp",
     "runc_version": "1.*",
     "security_group_id": "",
-    "source_ami_filter_name": "amzn2-ami-minimal-hvm-2.0.20250728.1-*",
+    "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
     "ssh_interface": "",

--- a/templates/al2/variables-default.json
+++ b/templates/al2/variables-default.json
@@ -28,7 +28,7 @@
     "remote_folder": "/tmp",
     "runc_version": "1.*",
     "security_group_id": "",
-    "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
+    "source_ami_filter_name": "amzn2-ami-minimal-hvm-2.0.20250728.1-*",
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
     "ssh_interface": "",

--- a/templates/al2/variables-default.json
+++ b/templates/al2/variables-default.json
@@ -19,7 +19,7 @@
     "docker_version": "none",
     "enable_fips": "false",
     "encrypted": "false",
-    "kernel_version": "",
+    "kernel_version": "5.10.239-236.958",
     "kms_key_id": "",
     "iam_instance_profile": "",
     "launch_block_device_mappings_volume_size": "4",

--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -47,7 +47,7 @@ fi
 ################################################################################
 
 # Update the OS to begin with to catch up to the latest packages.
-sudo dnf upgrade -y --releasever=latest
+sudo dnf update -y
 
 # Install necessary packages
 sudo dnf install -y \

--- a/templates/al2023/variables-1.28.json
+++ b/templates/al2023/variables-1.28.json
@@ -1,4 +1,4 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.8.20250721.2-kernel-6.1-*",
     "containerd_version": "1.7.27"
 }

--- a/templates/al2023/variables-1.29.json
+++ b/templates/al2023/variables-1.29.json
@@ -1,4 +1,4 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.8.20250721.2-kernel-6.1-*",
     "containerd_version": "1.7.27"
 }

--- a/templates/al2023/variables-1.30.json
+++ b/templates/al2023/variables-1.30.json
@@ -1,4 +1,4 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.8.20250721.2-kernel-6.1-*",
     "containerd_version": "1.7.27"
 }

--- a/templates/al2023/variables-1.31.json
+++ b/templates/al2023/variables-1.31.json
@@ -1,4 +1,4 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.8.20250721.2-kernel-6.1-*",
     "containerd_version": "1.7.27"
 }

--- a/templates/al2023/variables-1.32.json
+++ b/templates/al2023/variables-1.32.json
@@ -1,4 +1,4 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.8.20250721.2-kernel-6.1-*",
     "containerd_version": "1.7.27"
 }

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -27,7 +27,7 @@
     "remote_folder": "/tmp",
     "runc_version": "*",
     "security_group_id": "",
-    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.12-*",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.8.20250721.2-kernel-6.12-*",
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
     "ssh_interface": "",


### PR DESCRIPTION
**Issue #, if available:**
* Pin kernel to good version to unblock our ami releasing. Good kernel version refer https://github.com/awslabs/amazon-eks-ami/releases/tag/v20250804
* TO-DO: revert this PR once new kernel released with fix. But don't revert back `sudo dnf upgrade -y --releasever=latest` chang. In this case, seems install latest pkg might always introduce some unstable pkg at first place which is risky