### PR TITLE
chore: unmark InstanceIdNodeName as experimental

### DIFF
--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -62,7 +62,7 @@ spec:
 The configuration objects will be merged in the order they appear in the MIME multi-part document, meaning the value in the lattermost configuration object will take precedence.
 
 ---
-## Using instance ID as node name (experimental)
+## Using instance ID as node name
 
 When the `InstanceIdNodeName` feature gate is enabled, `nodeadm` will use the EC2 instance's ID (e.g. `i-abcdefg1234`) as the name of the `Node` object created by `kubelet`, instead of the EC2 instance's private DNS Name (e.g. `ip-192-168-1-1.ec2.internal`).
 There are several benefits of doing this:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Remove the classification of `InstanceIdNodeName` as experimental from the `nodeadm` docs, this pattern is used in Auto and the changes required to use this are well-documented.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
