### PR TITLE
feat: run shellcheck on all shell files

### DIFF
--- a/.github/workflows/ci-auto.yaml
+++ b/.github/workflows/ci-auto.yaml
@@ -6,13 +6,17 @@ on:
       - reopened
       - synchronize
 jobs:
-  lint:
+  lint-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - run: make lint-docs
+  lint-code:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
     - run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-    - run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
-    - run: make lint
+    - run: make lint-code
   templates-test:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,13 @@ fmt: ## Format the source files
 	hack/shfmt --write
 
 .PHONY: lint
-lint: lint-docs ## Check the source files for syntax and format issues
+lint: lint-docs lint-code
+  # Convenience target to run all lints. This is not run during presubmits, add new checks in lint-docs or lint-code.
+
+.PHONY: lint-code
+lint-code: ## Check the source files for syntax and format issues
 	hack/shfmt --diff
-	hack/shellcheck --format gcc --severity error $(shell find $(MAKEFILE_DIR) -type f -name '*.sh' -not -path '*/nodeadm/vendor/*')
+	hack/shellcheck --format gcc --severity error
 	hack/lint-space-errors.sh
 
 .PHONY: test

--- a/hack/findshell.sh
+++ b/hack/findshell.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Finds shell scripts to run presubmits against.
+
+has_shell_shebang() {
+  local file="$1"
+
+  if grep -I -q -z -E '^#!.*(/|env )(bash|sh)' "$file"; then
+    return 0
+  fi
+
+  return 1
+}
+
+dir=$1
+find "$dir" -type f -print0 | while IFS= read -r -d '' file; do
+
+  if [[ "$file" == *"nodeadm/vendor"* ]]; then
+    continue
+  fi
+
+  if [[ "$file" == *".git/hooks"* ]]; then
+    continue
+  fi
+
+  if [[ "$file" == *.sh ]] || has_shell_shebang "$file"; then
+    echo "$file"
+  fi
+done

--- a/hack/shellcheck
+++ b/hack/shellcheck
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# shellcheck wrapper
+# wrapper for shellcheck
 
 set -o nounset
 
 WORKDIR=$(realpath .)
+FILES=$(hack/findshell.sh ${WORKDIR})
 SHELLCHECK_COMMAND=$(which shellcheck 2> /dev/null)
 if [ -z "$SHELLCHECK_COMMAND" ]; then
   SHELLCHECK_COMMAND="docker run --rm -v $WORKDIR:$WORKDIR -w $WORKDIR koalaman/shellcheck:stable"
 fi
-$SHELLCHECK_COMMAND $@
+$SHELLCHECK_COMMAND $* $FILES

--- a/hack/shfmt
+++ b/hack/shfmt
@@ -15,4 +15,4 @@ fi
 
 FILES=$(${SHFMT_COMMAND} --find --language-dialect auto "${WORKDIR}" | grep -v "nodeadm/vendor/")
 
-${SHFMT_COMMAND} ${FLAGS} $@ ${FILES}
+${SHFMT_COMMAND} ${FLAGS} "$@" ${FILES}

--- a/templates/shared/runtime/bin/setup-local-disks
+++ b/templates/shared/runtime/bin/setup-local-disks
@@ -269,14 +269,14 @@ fi
 case "${DISK_SETUP}" in
   "raid0")
     maybe_raid 0
-    echo "Successfully setup RAID-0 consisting of ${EPHEMERAL_DISKS[@]}"
+    echo "Successfully setup RAID-0 consisting of " "${EPHEMERAL_DISKS[@]}"
     ;;
   "raid10")
     maybe_raid 10
-    echo "Successfully setup RAID-10 consisting of ${EPHEMERAL_DISKS[@]}"
+    echo "Successfully setup RAID-10 consisting of " "${EPHEMERAL_DISKS[@]}"
     ;;
   "mount")
     maybe_mount
-    echo "Successfully setup disk mounts consisting of ${EPHEMERAL_DISKS[@]}"
+    echo "Successfully setup disk mounts consisting of " "${EPHEMERAL_DISKS[@]}"
     ;;
 esac

--- a/templates/test/mocks/aws
+++ b/templates/test/mocks/aws
@@ -5,11 +5,11 @@ SCRIPTPATH="$(
   pwd -P
 )"
 
-echo >&2 "mocking 'aws $@'"
+echo >&2 "mocking 'aws $*'"
 
 AWS_MOCK_FAIL=${AWS_MOCK_FAIL:-false}
 if [ "$AWS_MOCK_FAIL" = "true" ]; then
-  echo >&2 "failing mocked 'aws $@'"
+  echo >&2 "failing mocked 'aws $*'"
   exit 1
 fi
 
@@ -38,14 +38,14 @@ fi
 if [[ $1 == "eks" ]]; then
   if [[ $2 == "describe-cluster" ]]; then
     # Assuming all the cluster name for the test cases would be "ipv4-cluster"
-    if [[ $(echo $@ | grep "ipv4-cluster") ]]; then
+    if [[ $(echo "$@" | grep "ipv4-cluster") ]]; then
       if [[ -f "${SCRIPTPATH}/describe-cluster/ipv4-cluster.txt" ]]; then
         cat "${SCRIPTPATH}/describe-cluster/ipv4-cluster.txt"
         exit 0
       fi
     fi
     # Assuming all the cluster name for the test cases would be "ipv6-cluster"
-    if [[ $(echo $@ | grep "ipv6-cluster") ]]; then
+    if [[ $(echo "$@" | grep "ipv6-cluster") ]]; then
       if [[ -f "${SCRIPTPATH}/describe-cluster/ipv6-cluster.txt" ]]; then
         cat "${SCRIPTPATH}/describe-cluster/ipv6-cluster.txt"
         exit 0

--- a/templates/test/mocks/iptables-save
+++ b/templates/test/mocks/iptables-save
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo >&2 "mocking 'iptables-save $@'"
+echo >&2 "mocking 'iptables-save $*'"

--- a/templates/test/mocks/kubelet
+++ b/templates/test/mocks/kubelet
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-echo >&2 "mocking 'kubelet $@'"
+echo >&2 "mocking 'kubelet $*'"
 
 # The only use of kubelet directly is to get the Kubernetes version,
 # so we'll set a default here to avoid test failures, and you can

--- a/templates/test/mocks/mount
+++ b/templates/test/mocks/mount
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-echo >&2 "mocking 'mount $@'"
+echo >&2 "mocking 'mount $*'"
 
 echo 'sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
 proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)

--- a/templates/test/mocks/sudo
+++ b/templates/test/mocks/sudo
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-echo >&2 "mocking 'sudo $@'"
+echo >&2 "mocking 'sudo $*'"
 exec "$@"

--- a/templates/test/mocks/systemctl
+++ b/templates/test/mocks/systemctl
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo >&2 "mocking 'systemctl $@'"
+echo >&2 "mocking 'systemctl $*'"


### PR DESCRIPTION
* Update existing shellcheck workflow to find all shell files, not just those ending in .sh
* Fix existing shellcheck errors.
* Split lint step into two separate steps since the lint-docs step is slow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->