### PR TITLE
fix(al2023/nvidia): rename nvidia driver based on version

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -112,20 +112,15 @@ function archive-open-kmods() {
   # The DKMS package name differs between the RPM and the dkms.conf in the OSS kmod sources
   # TODO: can be removed if this is merged: https://github.com/NVIDIA/open-gpu-kernel-modules/pull/567
 
-  if is-isolated-partition; then
-    NVIDIA_OPEN_VERSION=$(kmod-util module-version nvidia-open)
-    sudo sed -i 's/PACKAGE_NAME="nvidia"/PACKAGE_NAME="nvidia-open"/g' /var/lib/dkms/nvidia-open/$NVIDIA_OPEN_VERSION/source/dkms.conf
-  else
-    # The open kernel module name changed from nvidia-open to nvidia in 570.148.08
-    # Remove and re-add dkms module with the correct name. This maintains the current install and archive behavior
-    NVIDIA_OPEN_VERSION=$(kmod-util module-version nvidia)
-    sudo dkms remove "nvidia/$NVIDIA_OPEN_VERSION" --all
-    sudo sed -i 's/PACKAGE_NAME="nvidia"/PACKAGE_NAME="nvidia-open"/' /usr/src/nvidia-$NVIDIA_OPEN_VERSION/dkms.conf
-    sudo mv /usr/src/nvidia-$NVIDIA_OPEN_VERSION /usr/src/nvidia-open-$NVIDIA_OPEN_VERSION
-    sudo dkms add -m nvidia-open -v $NVIDIA_OPEN_VERSION
-    sudo dkms build -m nvidia-open -v $NVIDIA_OPEN_VERSION
-    sudo dkms install -m nvidia-open -v $NVIDIA_OPEN_VERSION
-  fi
+  # The open kernel module name changed from nvidia-open to nvidia in 570.148.08
+  # Remove and re-add dkms module with the correct name. This maintains the current install and archive behavior
+  NVIDIA_OPEN_VERSION=$(kmod-util module-version nvidia)
+  sudo dkms remove "nvidia/$NVIDIA_OPEN_VERSION" --all
+  sudo sed -i 's/PACKAGE_NAME="nvidia"/PACKAGE_NAME="nvidia-open"/' /usr/src/nvidia-$NVIDIA_OPEN_VERSION/dkms.conf
+  sudo mv /usr/src/nvidia-$NVIDIA_OPEN_VERSION /usr/src/nvidia-open-$NVIDIA_OPEN_VERSION
+  sudo dkms add -m nvidia-open -v $NVIDIA_OPEN_VERSION
+  sudo dkms build -m nvidia-open -v $NVIDIA_OPEN_VERSION
+  sudo dkms install -m nvidia-open -v $NVIDIA_OPEN_VERSION
 
   sudo kmod-util archive nvidia-open
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This took a bit of tinkering around to get working, so here's a summary. `kmod-nvidia-open-dkms`, which is installed directly in isolated partitions, has a post-install script for dkms to load the module:
```
$ rpm -q --scripts   kmod-nvidia-open-dkms-3:570.172.08-1.amzn2023.noarch
postinstall scriptlet (using /bin/sh):
dkms add -m nvidia -v 570.172.08 -q --rpm_safe_upgrade || :
# Rebuild and make available for the currently running kernel
dkms build -m nvidia -v 570.172.08 -q || :
dkms install -m nvidia -v 570.172.08 -q --force || :
preuninstall scriptlet (using /bin/sh):
# Remove all versions from DKMS registry
dkms remove -m nvidia -v 570.172.08 -q --all --rpm_safe_upgrade || :
```
As is already stated in a comment in the code, the name of this module changed from `nvidia-open` to `nvidia`, as seen in the install script on an older version:
```
$ rpm -q --scripts   kmod-nvidia-open-dkms-3:570.133.20-1.amzn2023.noarch
postinstall scriptlet (using /bin/sh):
dkms add -m nvidia-open -v 570.133.20 -q --rpm_safe_upgrade || :
# Rebuild and make available for the currently running kernel
dkms build -m nvidia-open -v 570.133.20 -q || :
dkms install -m nvidia-open -v 570.133.20 -q --force || :
preuninstall scriptlet (using /bin/sh):
# Remove all versions from DKMS registry
dkms remove -m nvidia-open -v 570.133.20 -q --all --rpm_safe_upgrade || :
```

The logic for this is the same regardless of whether installing the nvidia-open module or this package directly, because doing a module install for `nvidia-driver:<version>-open` also installs this package:
```
dnf module info nvidia-driver:570-open | grep '570.172.08'
                 : For the full product support list, please consult the release notes for driver version 570.172.08.
                 : cuda-drivers-fabricmanager-0:570.172.08-1.x86_64
                 : cuda-drivers-fabricmanager-570-0:570.172.08-1.x86_64
                 : kmod-nvidia-open-dkms-3:570.172.08-1.amzn2023.noarch
                 : libnvidia-cfg-3:570.172.08-1.amzn2023.x86_64
                 : libnvidia-ml-3:570.172.08-1.amzn2023.x86_64
                 : libnvidia-nscq-570-0:570.172.08-1.x86_64
                 : libnvsdm-570-0:570.172.08-1.x86_64
                 : nvidia-driver-cuda-3:570.172.08-1.amzn2023.x86_64
                 : nvidia-driver-cuda-libs-3:570.172.08-1.amzn2023.x86_64
                 : nvidia-fabric-manager-0:570.172.08-1.x86_64
                 : nvidia-fabric-manager-devel-0:570.172.08-1.x86_64
                 : nvidia-imex-570-0:570.172.08-1.x86_64
                 : nvidia-kmod-common-3:570.172.08-1.amzn2023.noarch
                 : nvidia-modprobe-3:570.172.08-1.amzn2023.x86_64
                 : nvidia-open-3:570.172.08-1.amzn2023.noarch
                 : nvidia-persistenced-3:570.172.08-1.amzn2023.x86_64
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
