### PR TITLE
feat(nodeadm): enable verbose SDK logging in development mode

### DIFF
--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -68,7 +68,7 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	log.Info("Loaded configuration", zap.Reflect("config", nodeConfig))
 
 	log.Info("Enriching configuration..")
-	if err := enrichConfig(log, nodeConfig); err != nil {
+	if err := enrichConfig(log, nodeConfig, opts); err != nil {
 		return err
 	}
 
@@ -146,7 +146,7 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 
 // Various initializations and verifications of the NodeConfig and
 // perform in-place updates when allowed by the user
-func enrichConfig(log *zap.Logger, cfg *api.NodeConfig) error {
+func enrichConfig(log *zap.Logger, cfg *api.NodeConfig, opts *cli.GlobalOptions) error {
 	log.Info("Fetching kubelet version..")
 	kubeletVersion, err := kubelet.GetKubeletVersion()
 	if err != nil {
@@ -155,8 +155,14 @@ func enrichConfig(log *zap.Logger, cfg *api.NodeConfig) error {
 	cfg.Status.KubeletVersion = kubeletVersion
 	log.Info("Fetched kubelet version", zap.String("version", kubeletVersion))
 	log.Info("Fetching instance details..")
+	awsClientLogMode := aws.LogRetries
+	if opts.DevelopmentMode {
+		// SDK v2 log modes are just bitwise operations, toggle all bits for maximum verbosity
+		// https://github.com/aws/aws-sdk-go-v2/blob/838fb872e9701fc62b7b86164389791f5313bfcb/aws/logging.go#L18
+		awsClientLogMode = aws.ClientLogMode((1 << 64) - 1)
+	}
 	awsConfig, err := config.LoadDefaultConfig(context.TODO(),
-		config.WithClientLogMode(aws.LogRetries),
+		config.WithClientLogMode(awsClientLogMode),
 		config.WithEC2IMDSRegion(func(o *config.UseEC2IMDSRegion) {
 			// Use our pre-configured IMDS client to avoid hitting common retry
 			// issues with the default config.


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add a verbose log mode which toggles all bits, indicating that the SDK should enable every log verbosity.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
