### PR TITLE
WIP: feat(nodeadm): add support to configure http-proxy for al2023/nodeadm

### DIFF
--- a/nodeadm/api/v1alpha1/nodeconfig_types.go
+++ b/nodeadm/api/v1alpha1/nodeconfig_types.go
@@ -33,6 +33,7 @@ type NodeConfigSpec struct {
 	Containerd ContainerdOptions `json:"containerd,omitempty"`
 	Instance   InstanceOptions   `json:"instance,omitempty"`
 	Kubelet    KubeletOptions    `json:"kubelet,omitempty"`
+	Proxy      ProxyOptions      `json:"proxy,omitempty"`
 	// FeatureGates holds key-value pairs to enable or disable application features.
 	FeatureGates map[Feature]bool `json:"featureGates,omitempty"`
 }
@@ -85,6 +86,19 @@ type ContainerdOptions struct {
 // InstanceOptions determines how the node's operating system and devices are configured.
 type InstanceOptions struct {
 	LocalStorage LocalStorageOptions `json:"localStorage,omitempty"`
+}
+
+// ProxyOptions configures HTTP proxy settings for nodeadm's outbound network connections.
+// These settings are used when nodeadm makes AWS API calls during node initialization.
+type ProxyOptions struct {
+	// HTTPProxy specifies the HTTP proxy server URL for non-TLS requests.
+	HTTPProxy string `json:"httpProxy,omitempty"`
+
+	// HTTPSProxy specifies the HTTP proxy server URL for TLS requests.
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+
+	// NoProxy specifies hosts and domains that should bypass the proxy.
+	NoProxy []string `json:"noProxy,omitempty"`
 }
 
 // LocalStorageOptions control how [EC2 instance stores](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html)

--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -67,6 +67,10 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 	log.Info("Loaded configuration", zap.Reflect("config", nodeConfig))
 
+	// Set proxy environment variables early so all AWS SDK calls use them
+	log.Info("Configuring proxy environment variables..")
+	setProxyEnvironmentVariables(nodeConfig.Spec.Proxy)
+
 	log.Info("Enriching configuration..")
 	if err := enrichConfig(log, nodeConfig); err != nil {
 		return err

--- a/nodeadm/cmd/nodeadm/init/proxy_env.go
+++ b/nodeadm/cmd/nodeadm/init/proxy_env.go
@@ -1,0 +1,67 @@
+package init
+
+import (
+	"os"
+	"strings"
+
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+)
+
+// setProxyEnvironmentVariables configures HTTP_PROXY, HTTPS_PROXY, and NO_PROXY
+// environment variables based on the provided ProxyOptions.
+// This allows AWS SDK v2 to automatically use proxy configuration.
+func setProxyEnvironmentVariables(proxyOpts api.ProxyOptions) {
+	// Set HTTP_PROXY if configured
+	if proxyOpts.HTTPProxy != "" {
+		os.Setenv("HTTP_PROXY", proxyOpts.HTTPProxy)
+	}
+
+	// Set HTTPS_PROXY if configured
+	if proxyOpts.HTTPSProxy != "" {
+		os.Setenv("HTTPS_PROXY", proxyOpts.HTTPSProxy)
+	}
+
+	// Build NO_PROXY list from user-specified patterns
+	noProxyList := buildNoProxyList(proxyOpts.NoProxy)
+	if len(noProxyList) > 0 {
+		os.Setenv("NO_PROXY", strings.Join(noProxyList, ","))
+	}
+}
+
+// Create NO_PROXY list that includes:
+// 1. User-specified NoProxy patterns
+// 2. Standard localhost
+func buildNoProxyList(userNoProxy []string) []string {
+	noProxyList := []string{
+		"localhost",
+		"127.0.0.1",
+	}
+
+	for _, pattern := range userNoProxy {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+
+		exists := false
+		for _, existing := range noProxyList {
+			if existing == pattern {
+				exists = true
+				break
+			}
+		}
+
+		if !exists {
+			noProxyList = append(noProxyList, pattern)
+		}
+	}
+
+	return noProxyList
+}
+
+// This can be used for cleanup or testing purposes.
+func clearProxyEnvironmentVariables() {
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("NO_PROXY")
+}

--- a/nodeadm/internal/api/types.go
+++ b/nodeadm/internal/api/types.go
@@ -32,6 +32,7 @@ type NodeConfigSpec struct {
 	Containerd   ContainerdOptions `json:"containerd,omitempty"`
 	Instance     InstanceOptions   `json:"instance,omitempty"`
 	Kubelet      KubeletOptions    `json:"kubelet,omitempty"`
+	Proxy        ProxyOptions      `json:"proxy,omitempty"`
 	FeatureGates map[Feature]bool  `json:"featureGates,omitempty"`
 }
 
@@ -94,6 +95,12 @@ const (
 
 type InstanceOptions struct {
 	LocalStorage LocalStorageOptions `json:"localStorage,omitempty"`
+}
+
+type ProxyOptions struct {
+	HTTPProxy  string   `json:"httpProxy,omitempty"`
+	HTTPSProxy string   `json:"httpsProxy,omitempty"`
+	NoProxy    []string `json:"noProxy,omitempty"`
 }
 
 type LocalStorageOptions struct {

--- a/nodeadm/internal/api/validation.go
+++ b/nodeadm/internal/api/validation.go
@@ -1,6 +1,10 @@
 package api
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
 
 func ValidateNodeConfig(cfg *NodeConfig) error {
 	if cfg.Spec.Cluster.Name == "" {
@@ -20,5 +24,34 @@ func ValidateNodeConfig(cfg *NodeConfig) error {
 			return fmt.Errorf("CIDR is missing in cluster configuration")
 		}
 	}
+
+	// TODO: Add detailed proxy configuration validation
+	if err := validateProxyOptionsBasic(cfg.Spec.Proxy); err != nil {
+		return fmt.Errorf("proxy configuration validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// TODO: Expand this to include detailed URL validation, NoProxy pattern validation etc
+func validateProxyOptionsBasic(proxy ProxyOptions) error {
+	if proxy.HTTPProxy != "" {
+		if _, err := url.Parse(proxy.HTTPProxy); err != nil {
+			return fmt.Errorf("invalid HTTP_PROXY URL: %w", err)
+		}
+	}
+
+	if proxy.HTTPSProxy != "" {
+		if _, err := url.Parse(proxy.HTTPSProxy); err != nil {
+			return fmt.Errorf("invalid HTTPS_PROXY URL: %w", err)
+		}
+	}
+
+	for i, pattern := range proxy.NoProxy {
+		if strings.TrimSpace(pattern) == "" {
+			return fmt.Errorf("empty NO_PROXY pattern at index %d", i)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/amazon-eks-ami/issues/2128

**Description of changes:**
Nodeadm has two phases: 1. Config and 2. Run. Nodeadm has a set of outbound API calls (IMDS, AWS API calls) that could potentially need to be routed through a proxy. Currently, setting proxy configurations would happen after the config phase  in user-data. This PR adds support to configure http-proxy in `NodeConfigSpec`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

TODOs:

- [ ] Add test cases for init.go
- [ ] Add test cases for proxy_env.go
- [ ] Add test cases for validation.go

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
