### PR TITLE
Enable MutableCSINodeAllocatableCount in v1.34.0+

### DIFF
--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -213,6 +213,10 @@ func (ksc *kubeletConfig) withVersionToggles(cfg *api.NodeConfig) {
 	if semver.Compare(cfg.Status.KubeletVersion, "v1.33.0") >= 0 {
 		ksc.FeatureGates["DynamicResourceAllocation"] = true
 	}
+	// Enable MutableCSINodeAllocatableCount on 1.34+
+	if semver.Compare(cfg.Status.KubeletVersion, "v1.34.0") >= 0 {
+		ksc.FeatureGates["MutableCSINodeAllocatableCount"] = true
+	}
 }
 
 func (ksc *kubeletConfig) withCloudProvider(cfg *api.NodeConfig, flags map[string]string) {

--- a/nodeadm/internal/kubelet/config_test.go
+++ b/nodeadm/internal/kubelet/config_test.go
@@ -78,3 +78,28 @@ func TestProviderID(t *testing.T) {
 		// TODO assert that the --hostname-override == PrivateDnsName
 	}
 }
+
+func TestMutableCSINodeAllocatableCountFeatureGate(t *testing.T) {
+	tests := []struct {
+		kubeletVersion string
+		expected       bool
+	}{
+		{kubeletVersion: "v1.33.0", expected: false},
+		{kubeletVersion: "v1.34.0", expected: true},
+	}
+
+	for _, test := range tests {
+		kubeletConfig := defaultKubeletSubConfig()
+		nodeConfig := api.NodeConfig{
+			Status: api.NodeConfigStatus{
+				KubeletVersion: test.kubeletVersion,
+			},
+		}
+		kubeletConfig.withVersionToggles(&nodeConfig)
+		if test.expected {
+			assert.True(t, kubeletConfig.FeatureGates["MutableCSINodeAllocatableCount"])
+		} else {
+			assert.NotContains(t, kubeletConfig.FeatureGates, "MutableCSINodeAllocatableCount")
+		}
+	}
+}


### PR DESCRIPTION
**Description of changes:**

This PR enables MutableCSINodeAllocatableCount in v1.34.0+ by default.

See https://github.com/kubernetes/enhancements/issues/4876.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Added Unit Test.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
