### PR TITLE
docs: update InstanceIdNodeName doc to recommend access entries

### DIFF
--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -74,7 +74,7 @@ There are several benefits of doing this:
 1. [Create a new worker node IAM role](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html#create-worker-node-role)
     - ⚠️ **Note**: you should create a new role when migrating an existing cluster to avoid authentication failures on existing nodes.
 2. Configure authorization for the role using username `system:node:{{SessionName}}`, for example by [creating an access entry](https://docs.aws.amazon.com/eks/latest/userguide/creating-access-entries.html) of type `EC2` for the new role:
-    -  ⚠️ **Note**: in some cases, this can be done [using the aws-auth ConfigMap](https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html#aws-auth-users) instead. This must be done using access entries if creating an [EKS Managed Node Group](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) with the role.
+    -  ⚠️ **Note**: you can still use the [legacy `aws-auth` ConfigMap](https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html#aws-auth-users) to grant access, but services like [EKS Managed Node Groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) will require the use of access entries.
 ```
 aws eks create-access-entry --cluster-name $CLUSTER_ARN --principal-arn $ROLE_CREATED_ABOVE --type EC2
 ```

--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -73,14 +73,12 @@ There are several benefits of doing this:
 ### To enable this feature, you will need to:
 1. [Create a new worker node IAM role](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html#create-worker-node-role)
     - ⚠️ **Note**: you should create a new role when migrating an existing cluster to avoid authentication failures on existing nodes.
-2. [Update the `aws-auth` ConfigMap with above created role](https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html#aws-auth-users). For example:
+2. Configure authorization for the role using username `system:node:{{SessionName}}`, for example by [creating an access entry](https://docs.aws.amazon.com/eks/latest/userguide/creating-access-entries.html) of type `EC2` for the new role:
+    -  ⚠️ **Note**: in some cases, this can be done [using the aws-auth ConfigMap](https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html#aws-auth-users) instead. This must be done using access entries if creating an [EKS Managed Node Group](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) with the role.
 ```
-- groups:
-  - system:bootstrappers
-  - system:nodes
-  rolearn: $ROLE_CREATED_ABOVE
-  username: system:node:{{SessionName}}
+aws eks create-access-entry --cluster-name $CLUSTER_ARN --principal-arn $ROLE_CREATED_ABOVE --type EC2
 ```
+
 3. Enable the feature gate in your user data:
 ```
 ---

--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -76,7 +76,10 @@ There are several benefits of doing this:
 2. Configure authorization for the role using username `system:node:{{SessionName}}`, for example by [creating an access entry](https://docs.aws.amazon.com/eks/latest/userguide/creating-access-entries.html) of type `EC2` for the new role:
     -  ⚠️ **Note**: you can still use the [legacy `aws-auth` ConfigMap](https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html#aws-auth-users) to grant access, but services like [EKS Managed Node Groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) will require the use of access entries.
 ```
-aws eks create-access-entry --cluster-name $CLUSTER_ARN --principal-arn $ROLE_CREATED_ABOVE --type EC2
+aws eks create-access-entry \
+  --cluster-name $CLUSTER_NAME \
+  --principal-arn $ROLE_CREATED_ABOVE \
+  --type EC2
 ```
 
 3. Enable the feature gate in your user data:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Managed Node Groups defaults to creating an `aws-auth` ConfigMap entry for `EC2PrivateDNSName` for any node group created with a Linux-based AMI type. This makes using access entries preferable, as a manually created access entry will always be respected. Access entries are also now [the recommended way](https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html) of managing authentication to the cluster


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
