### PR TITLE
Add soci snapshotter info to eks-log-collector

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -848,6 +848,26 @@ get_containerd_info() {
   fi
 
   ok
+
+  try "collect containerd snapshotter information"
+  get_soci_snapshotter_info
+
+  ok
+}
+
+get_soci_snapshotter_info() {
+  if ! systemctl is-active --quiet soci-snapshotter 2> /dev/null; then
+    return
+  fi
+
+  try "Collect soci snapshotter information"
+
+  mkdir -p "${COLLECT_DIR}"/containerd/soci-snapshotter
+  systemctl status soci-snapshotter > "${COLLECT_DIR}"/containerd/soci-snapshotter/soci-snapshotter-status.txt 2>&1
+  timeout 75 journalctl -u soci-snapshotter --since "${DAYS_10}" > "${COLLECT_DIR}"/containerd/soci-snapshotter/soci-snapshotter-log.txt 2>&1 || echo -e "\tTimed out, ignoring \"soci-snapshotter log output \" "
+  cp --force /etc/soci-snapshotter-grpc/config.toml "${COLLECT_DIR}"/containerd/soci-snapshotter/config.toml 2> /dev/null
+
+  ok
 }
 
 get_sandboxImage_info() {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
If containerd is setup to use soci snapshotter, collect the snapshotter related information as part of the eks-log-collector script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

```
# Output from the extracted zip file when soci-snapshotter was configured. Otherwise, this directory will not be created
> ls containerd/soci-snapshotter/
config.toml  soci-snapshotter-log.txt  soci-snapshotter-status.txt
```

When soci snapshotter is not used, the new changes are ignored 
```
Trying to Collect Containerd snapshotter information...
Trying to archive gathered information...
```
*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
