### PR TITLE
fix(nodeadm): resolve config race with systemd-networkd

### DIFF
--- a/nodeadm/cmd/nodeadm-internal/boot-hook/boot_hook.go
+++ b/nodeadm/cmd/nodeadm-internal/boot-hook/boot_hook.go
@@ -5,8 +5,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/cli"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/daemon"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/system"
 )
+
+const SystemdNetworkdDaemonName = "systemd-networkd"
 
 type bootHookCmd struct {
 	cmd *flaggy.Subcommand
@@ -25,10 +28,24 @@ func (c *bootHookCmd) Flaggy() *flaggy.Subcommand {
 }
 
 func (c *bootHookCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
-	log.Info("Configuring Network Interfaces..")
-	if err := system.EnsureEKSNetworkConfiguration(); err != nil {
+	log.Info("Creating daemon manager..")
+	daemonManager, err := daemon.NewDaemonManager()
+	if err != nil {
 		return err
 	}
+	defer daemonManager.Close()
+
+	log.Info("Configuring systemd-networkd..")
+
+	if requiresRestart, err := system.EnsureEKSNetworkConfiguration(); err != nil {
+		return err
+	} else if requiresRestart {
+		log.Info("Restarting systemd-networkd..")
+		if err := daemonManager.RestartDaemon(SystemdNetworkdDaemonName); err != nil {
+			return err
+		}
+	}
+
 	log.Info("Completed boot hook!")
 	return nil
 }

--- a/nodeadm/internal/system/networking.go
+++ b/nodeadm/internal/system/networking.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"os/exec"
 	"text/template"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/aws/imds"
@@ -15,7 +14,6 @@ import (
 )
 
 const (
-	networkingAspectName = "networking"
 	// the ephemeral networkd config directory, reset on reboot
 	administrationNetworkDir = "/run/systemd/network"
 	// the name of ec2 network configuration setup by amazon-ec2-net-utils:
@@ -41,35 +39,34 @@ var (
 // To address this issue temporarily, we use drop-ins to alter configuration of `80-ec2.network` after boot to make it match against primary ENI only.
 // TODO: there are limitations on current solutions as well, and we should figure long term solution for this:
 //  1. the altNames for ENIs(a new feature in AL2023) were setup by amazon-ec2-net-utils via udev rules, but it's disabled by eks.
-func EnsureEKSNetworkConfiguration() error {
+//
+// Returns true if the applied configuration requires a reload/restart of systemd-networkd
+func EnsureEKSNetworkConfiguration() (bool, error) {
 	primaryENIMac, err := imds.GetProperty(context.TODO(), "mac")
 	if err != nil {
-		return fmt.Errorf("failed to get MAC from IMDS: %w", err)
+		return false, fmt.Errorf("failed to get MAC from IMDS: %w", err)
 	}
 	networkCfgDropInDir := fmt.Sprintf("%s/%s.d", administrationNetworkDir, ec2NetworkConfigurationName)
 	eksPrimaryENIOnlyConfPathName := fmt.Sprintf("%s/%s", networkCfgDropInDir, eksPrimaryENIOnlyConfName)
 	if exists, err := util.IsFilePathExists(eksPrimaryENIOnlyConfPathName); err != nil {
-		return fmt.Errorf("failed to check eks_primary_eni_only network configuration existance: %w", err)
+		return false, fmt.Errorf("failed to check eks_primary_eni_only network configuration existance: %w", err)
 	} else if exists {
 		zap.L().Info("eks_primary_eni_only network configuration already exists, skipping configuration")
-		return nil
+		return false, nil
 	}
 
 	eksPrimaryENIOnlyConfContent, err := generateEKSPrimaryENIOnlyConfiguration(primaryENIMac)
 	if err != nil {
-		return fmt.Errorf("failed to generate eks_primary_eni_only network configuration: %w", err)
+		return false, fmt.Errorf("failed to generate eks_primary_eni_only network configuration: %w", err)
 	}
 	zap.L().Info("writing eks_primary_eni_only network configuration")
 	if err := os.MkdirAll(networkCfgDropInDir, networkConfDropInDirPerms); err != nil {
-		return fmt.Errorf("failed to create network configuration drop-in directory %s: %w", networkCfgDropInDir, err)
+		return false, fmt.Errorf("failed to create network configuration drop-in directory %s: %w", networkCfgDropInDir, err)
 	}
 	if err := os.WriteFile(eksPrimaryENIOnlyConfPathName, eksPrimaryENIOnlyConfContent, networkConfFilePerms); err != nil {
-		return fmt.Errorf("failed to write eks_primary_eni_only network configuration: %w", err)
+		return false, fmt.Errorf("failed to write eks_primary_eni_only network configuration: %w", err)
 	}
-	if err := reloadNetworkConfigurations(); err != nil {
-		return fmt.Errorf("failed to reload network configurations: %w", err)
-	}
-	return nil
+	return true, nil
 }
 
 // eksPrimaryENIOnlyTemplateVars holds the variables for eksPrimaryENIOnlyConfTemplate
@@ -88,11 +85,4 @@ func generateEKSPrimaryENIOnlyConfiguration(primaryENIMac string) ([]byte, error
 		return nil, err
 	}
 	return buf.Bytes(), nil
-}
-
-func reloadNetworkConfigurations() error {
-	cmd := exec.Command("networkctl", "reload")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
 }

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-boot-hook.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-boot-hook.service
@@ -4,6 +4,13 @@ Documentation=https://github.com/awslabs/amazon-eks-ami
 # this unit must precede all other nodeadm units because it sets the
 # expectation for OS networking.
 Before=nodeadm-config.service
+# must follow networkd as it requires network availability for reading
+# interface information from IMDS. Assumes the IMDS client used will
+# retry enough to capture eventual network readiness
+After=systemd-networkd.service
+# precede systemd-networkd-wait-online so future nodeadm services can rely on
+# that service as a source of truth on the configurations made by this service
+Before=systemd-networkd-wait-online.service
 
 [Service]
 Type=oneshot

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-config.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-config.service
@@ -4,6 +4,7 @@ Documentation=https://github.com/awslabs/amazon-eks-ami
 # run before cloud-init, then user can still execute their
 # own workflows from ec2 userdata cloud-init scripts
 Before=cloud-init.service
+After=systemd-networkd-wait-online.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Enforces a necessary ordering between the `nodeadm` phases as they relate to the networking components. Ensures that `nodeadm-boot-hook` runs before `systemd-networkd-wait-online` so that service can be used by later `nodeadm` phases as a source of truth on `nodeadm`'s desired network configuration. Restarts instead of reloading `systemd-networkd` to force synchronicity, the latter leaves open the possibility of routes being created/destroyed during `nodeadm-config` or later services.

The forced ordering may increase boot times by a few seconds, but it's a worthwhile trade-off for the time being to ensure network stability during the various `nodeadm` phases. In the future, we can potentially look to cut this down by either finding a way to discover the primary network interface without a network call (and therefore start the boot hook before networkd). We may also be able to save a little bit of time by making a reload call instead of a restart and waiting until the status matches the desired, but there does not seem to be a clean way to do this at the moment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
