### PR TITLE
chore(al2): add ecr account for us-isof-east-1

### DIFF
--- a/templates/al2/runtime/get-ecr-uri.sh
+++ b/templates/al2/runtime/get-ecr-uri.sh
@@ -48,6 +48,9 @@ else
     us-isof-south-1)
       acct="676585237158"
       ;;
+    us-isof-east-1)
+      acct="171035529773"
+      ;;
     af-south-1)
       acct="877085696533"
       ;;


### PR DESCRIPTION
**Issue #, if available:**

The us-isof-east-1 build prod account was missing. This could cause customers with explicit traffic deny in the region to not be able to spin up a nodegroup. This PR fixes that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

