### PR TITLE
fix(nodeadm): improve error handling for install-nodeadm.sh

### DIFF
--- a/templates/al2023/provisioners/install-nodeadm.sh
+++ b/templates/al2023/provisioners/install-nodeadm.sh
@@ -4,6 +4,22 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
+# Check required variables
+if [ -z "$BUILD_IMAGE" ]; then
+  echo "Error: BUILD_IMAGE is required"
+  exit 1
+fi
+
+if [ -z "$AWS_REGION" ]; then
+  echo "Error: AWS_REGION is required"
+  exit 1
+fi
+
+if [ -z "$PROJECT_DIR" ]; then
+  echo "Error: PROJECT_DIR is required"
+  exit 1
+fi
+
 sudo systemctl start containerd
 
 # if the image is from an ecr repository then try authenticate first
@@ -25,8 +41,10 @@ sudo nerdctl run \
 # cleanup build image and snapshots
 sudo nerdctl rmi \
   --force \
-  $BUILD_IMAGE \
-  "$(sudo nerdctl images -a | grep none | awk '{ print $3 }')"
+  $BUILD_IMAGE
+
+# cleanup dangling images
+sudo nerdctl image prune --force
 
 # move the nodeadm binary into bin folder
 sudo chmod a+x \


### PR DESCRIPTION
**Issue #, if available:**

Fix #2404

**Description of changes:**

* Leverage `nerdctl` bulit-in mechanism to cleanup image but not handle by hand.
* Basic validation for the script inputs before actual run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

## Before

```
...
==> amazon-ebs: Untagged: public.ecr.aws/eks-distro-build-tooling/golang:1.24@sha256:33c19e0f650564a7ade227088ff27f0d0abeede1ff3d1a01ed3f83eebfc3768d
==> amazon-ebs: Deleted: sha256:...
==> amazon-ebs: Deleted: sha256:...
==> amazon-ebs: Deleted: sha256:...
==> amazon-ebs: FATA[0000] 1 errors:
==> amazon-ebs: filters: parse error: [name==66c8619930b9 >|
==> amazon-ebs: |< 66c8619930b9]: unexpected input:
==> amazon-ebs: : invalid argument: invalid argument
==> amazon-ebs: Provisioning step had errors: Running the cleanup provisioner, if present...
...
```

## After

```
==> amazon-ebs: Provisioning with shell script: /Users/kuole/personal/github/forks/amazon-eks-ami/templates/al2023/provisioners/install-nodeadm.sh
...
==> amazon-ebs: GOOS= go build -o /workdir/_bin/ ./cmd/...
==> amazon-ebs: Untagged: public.ecr.aws/eks-distro-build-tooling/golang:1.24@sha256:33c19e0f650564a7ade227088ff27f0d0abeede1ff3d1a01ed3f83eebfc3768d
==> amazon-ebs: Deleted: sha256:8950f7ce66298fd409c4af64b1b7dbb8e562b2d8cc53b3117596e30ef1a7d33c
==> amazon-ebs: Deleted: sha256:ff3bff54c5663fc0e68e127d4fc7853a1cbf651569374b87cbc2f62ce62a2db4
==> amazon-ebs: Deleted: sha256:109e6b9b5be8c4946209bffd3582375399e7fdfc5bc1c8b18c367430b4674fc6
==> amazon-ebs: Deleted: sha256:de3b158b9897435495abb07d46b3518b229f09d8b8a5f330af8c7c55bc321aa6
==> amazon-ebs: Deleted: sha256:2dc2cee773e6f0df84ebad933a3f18aca874da4bc2bdccc327debab149a4e3d2
==> amazon-ebs: Deleted Images:
==> amazon-ebs: Untagged: sha256:1f3a5962c3a7266f80f07341e1265e6f5981a253246708acae021319f4e2dbb7
==> amazon-ebs: deleted: sha256:8950f7ce66298fd409c4af64b1b7dbb8e562b2d8cc53b3117596e30ef1a7d33c
==> amazon-ebs: deleted: sha256:ff3bff54c5663fc0e68e127d4fc7853a1cbf651569374b87cbc2f62ce62a2db4
==> amazon-ebs: deleted: sha256:109e6b9b5be8c4946209bffd3582375399e7fdfc5bc1c8b18c367430b4674fc6
==> amazon-ebs: deleted: sha256:de3b158b9897435495abb07d46b3518b229f09d8b8a5f330af8c7c55bc321aa6
==> amazon-ebs: deleted: sha256:2dc2cee773e6f0df84ebad933a3f18aca874da4bc2bdccc327debab149a4e3d2
==> amazon-ebs:
==> amazon-ebs: Created symlink /etc/systemd/system/multi-user.target.wants/nodeadm-boot-hook.service → /etc/systemd/system/nodeadm-boot-hook.service.
==> amazon-ebs: Created symlink /etc/systemd/system/multi-user.target.wants/nodeadm-config.service → /etc/systemd/system/nodeadm-config.service.
==> amazon-ebs: Created symlink /etc/systemd/system/multi-user.target.wants/nodeadm-run.service → /etc/systemd/system/nodeadm-run.service.
==> amazon-ebs: Provisioning with shell script: /Users/kuole/personal/github/forks/amazon-eks-ami/templates/al2023/provisioners/cache-pause-container.sh
...
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
