### PR TITLE
fix(al2023): set correct SELinux context for binaries

### DIFF
--- a/templates/al2023/provisioners/install-nodeadm.sh
+++ b/templates/al2023/provisioners/install-nodeadm.sh
@@ -48,7 +48,7 @@ sudo nerdctl image prune --force
 
 # move the nodeadm binaries into bin folder
 sudo chmod a+x $PROJECT_DIR/_bin/*
-sudo mv \
+sudo mv --context \
   $PROJECT_DIR/_bin/nodeadm \
   $PROJECT_DIR/_bin/nodeadm-internal \
   /usr/bin/

--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -181,7 +181,7 @@ for binary in "${BINARIES[@]}"; do
   sudo sha256sum -c $binary.sha256
   sudo chmod +x $binary
   sudo chown root:root $binary
-  sudo mv $binary /usr/bin/
+  sudo mv --context $binary /usr/bin/
 done
 
 sudo rm ./*.sha256

--- a/templates/al2023/provisioners/validate-selinux.sh
+++ b/templates/al2023/provisioners/validate-selinux.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+set -o nounset
+
+validate_directory_selinux_contexts() {
+  local DIR=$1
+  echo "Validating SELinux contexts in $DIR"
+
+  unverified_files=$(matchpathcon -V $DIR/* | grep -v verified)
+
+  if [ -n "$unverified_files" ]; then
+    echo "$unverified_files"
+    unverified_files_count=$(echo "$unverified_files" | wc -l)
+    echo "Validation error: Found $unverified_files_count files with incorrect SELinux context in folder $DIR"
+    exit 1
+  fi
+  echo "Validated SELinux contexts in $DIR"
+}
+
+validate_directory_selinux_contexts /usr/bin

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -311,6 +311,11 @@
       "inline": [
         "sudo rm -rf {{user `working_dir`}}"
       ]
+    },
+    {
+      "type": "shell",
+      "remote_folder": "{{ user `remote_folder`}}",
+      "script": "{{template_dir}}/provisioners/validate-selinux.sh"
     }
   ],
   "post-processors": [


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change sets the correct SELinux context `bin_t` for the binaries to match the destination folder `/usr/bin`. It adds a validation script to ensure the build fails if any binary in `/usr/bin` does not have the correct context

From man page of `mv` command:
> -Z, --context
              set SELinux security context of destination file to default type

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

1. Tested on the node, with and without the `-Z` flag
2. Built an AMI with selinux set to enforcing.  `sudo sed -i -e 's/permissive/enforcing/g' /etc/selinux/config`. The instance created using this AMI had successful executions of the processes nodeadm-boot-hook(invokes nodeadm-internal), nodeadm-config(invokes nodeadm) and nodeadm-run(invokes nodeadm and kubelet). kubelet binary executed correctly as well
```
sh-5.2$ sudo journalctl -u nodeadm-boot-hook
Sep 27 07:40:02 localhost systemd[1]: Starting nodeadm-boot-hook.service - EKS Nodeadm Boot Hook...
Sep 27 07:40:04 localhost nodeadm-internal[1889]: {"level":"info","ts":1758958804.1110559,"caller":"boot-book/hook.go:58","msg":"Waiting for consistent network interfaces.."}
Sep 27 07:40:04 localhost nodeadm-internal[1889]: {"level":"info","ts":1758958804.1632168,"caller":"system/networking.go:83","msg":"checking link states..."}
Sep 27 07:40:04 localhost nodeadm-internal[1889]: {"level":"info","ts":1758958804.1723797,"caller":"system/networking.go:119","msg":"secondary link unmanaged","linkName":"lo"}
Sep 27 07:40:04 localhost nodeadm-internal[1889]: {"level":"info","ts":1758958804.17241,"caller":"system/networking.go:109","msg":"link configured","linkName":"ens5"}
Sep 27 07:40:04 localhost nodeadm-internal[1889]: {"level":"info","ts":1758958804.172424,"caller":"boot-book/hook.go:62","msg":"Completed boot hook!"}
Sep 27 07:40:04 localhost systemd[1]: nodeadm-boot-hook.service: Deactivated successfully.
Sep 27 07:40:04 localhost systemd[1]: Finished nodeadm-boot-hook.service - EKS Nodeadm Boot Hook.

sudo journalctl -u nodeadm-config
Sep 27 07:40:05 localhost nodeadm[1905]: {"level":"info","ts":1758958805.8629425,"caller":"init/init.go:104","msg":"Configuring daemon...","name":"kubelet"}
Sep 27 07:40:05 localhost nodeadm[1905]: {"level":"info","ts":1758958805.8637674,"caller":"kubelet/config.go:209","msg":"Setup IP for node","ip":"192.168.25.114"}
Sep 27 07:40:05 localhost nodeadm[1905]: {"level":"info","ts":1758958805.8644497,"caller":"kubelet/config.go:362","msg":"Writing kubelet config to file..","path":"/etc/kubernetes>
Sep 27 07:40:06 localhost nodeadm[1905]: {"level":"info","ts":1758958806.194612,"caller":"init/init.go:108","msg":"Configured daemon","name":"kubelet"}
Sep 27 07:40:06 localhost nodeadm[1905]: {"level":"info","ts":1758958806.1946585,"caller":"init/init.go:142","msg":"done!","duration":1.768108327}
Sep 27 07:40:06 localhost systemd[1]: nodeadm-config.service: Deactivated successfully.
Sep 27 07:40:06 localhost systemd[1]: Finished nodeadm-config.service - EKS Nodeadm Config.

sudo journalctl -u nodeadm-run
Sep 27 07:40:11 ip-192-168-25-114.us-west-2.compute.internal nodeadm[2049]: {"level":"info","ts":1758958811.9685662,"caller":"init/init.go:128","msg":"Ensuring daemon is running.>
Sep 27 07:40:12 ip-192-168-25-114.us-west-2.compute.internal nodeadm[2049]: {"level":"info","ts":1758958812.5331497,"caller":"init/init.go:132","msg":"Daemon is running","name":">
Sep 27 07:40:12 ip-192-168-25-114.us-west-2.compute.internal nodeadm[2049]: {"level":"info","ts":1758958812.5331862,"caller":"init/init.go:134","msg":"Running post-launch tasks..>
Sep 27 07:40:12 ip-192-168-25-114.us-west-2.compute.internal nodeadm[2049]: {"level":"info","ts":1758958812.5331979,"caller":"init/init.go:138","msg":"Finished post-launch tasks">
Sep 27 07:40:12 ip-192-168-25-114.us-west-2.compute.internal nodeadm[2049]: {"level":"info","ts":1758958812.5332084,"caller":"init/init.go:142","msg":"done!","duration":2.2031947>
Sep 27 07:40:12 ip-192-168-25-114.us-west-2.compute.internal systemd[1]: nodeadm-run.service: Deactivated successfully.
Sep 27 07:40:12 ip-192-168-25-114.us-west-2.compute.internal systemd[1]: Finished nodeadm-run.service - EKS Nodeadm Run.

sudo journalctl -u kubelet
Sep 27 07:40:12 ip-192-168-25-114.us-west-2.compute.internal systemd[1]: Starting kubelet.service - Kubernetes Kubelet...
Sep 27 07:40:12 ip-192-168-25-114.us-west-2.compute.internal systemd[1]: Started kubelet.service - Kubernetes Kubelet.
```


3. Attempted to build an AMI that included a file in `/usr/bin` with incorrect SELinux context. The build failed as expected
```
2025-09-27T00:04:53-07:00:     amazon-ebs: Validating SELinux contexts in /usr/bin
2025-09-27T00:04:53-07:00:     amazon-ebs: /usr/bin/kubelet has context unconfined_u:object_r:user_home_t:s0, should be system_u:object_r:bin_t:s0
2025-09-27T00:04:53-07:00:     amazon-ebs: Validation error: Found 1 files with incorrect SELinux context in folder /usr/bin
2025-09-27T00:04:53-07:00: ==> amazon-ebs: Provisioning step had errors: Running the cleanup provisioner, if present...
2025-09-27T00:04:53-07:00: ==> amazon-ebs: Terminating the source AWS instance...
``` 

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
