### PR TITLE
fix(al2023): reload networkd and verify configurations

### DIFF
--- a/nodeadm/internal/system/networking.go
+++ b/nodeadm/internal/system/networking.go
@@ -4,16 +4,32 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"text/template"
+	"time"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/aws/imds"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
 	"go.uber.org/zap"
 )
 
+type NetworkctlInterface struct {
+	Name                string `json:"Name"`
+	AdministrativeState string `json:"AdministrativeState"`
+}
+
+type NetworkctlList struct {
+	Interfaces []NetworkctlInterface `json:"Interfaces"`
+}
+
 const (
+	networkDeviceDir   = "/sys/class/net"
+	macAddressFileName = "address"
 	// the ephemeral networkd config directory, reset on reboot
 	administrationNetworkDir = "/run/systemd/network"
 	// the name of ec2 network configuration setup by amazon-ec2-net-utils:
@@ -39,34 +55,41 @@ var (
 // To address this issue temporarily, we use drop-ins to alter configuration of `80-ec2.network` after boot to make it match against primary ENI only.
 // TODO: there are limitations on current solutions as well, and we should figure long term solution for this:
 //  1. the altNames for ENIs(a new feature in AL2023) were setup by amazon-ec2-net-utils via udev rules, but it's disabled by eks.
-//
-// Returns true if the applied configuration requires a reload/restart of systemd-networkd
-func EnsureEKSNetworkConfiguration() (bool, error) {
+func EnsureEKSNetworkConfiguration() error {
 	primaryENIMac, err := imds.GetProperty(context.TODO(), "mac")
 	if err != nil {
-		return false, fmt.Errorf("failed to get MAC from IMDS: %w", err)
+		return fmt.Errorf("failed to get MAC from IMDS: %w", err)
 	}
 	networkCfgDropInDir := fmt.Sprintf("%s/%s.d", administrationNetworkDir, ec2NetworkConfigurationName)
 	eksPrimaryENIOnlyConfPathName := fmt.Sprintf("%s/%s", networkCfgDropInDir, eksPrimaryENIOnlyConfName)
 	if exists, err := util.IsFilePathExists(eksPrimaryENIOnlyConfPathName); err != nil {
-		return false, fmt.Errorf("failed to check eks_primary_eni_only network configuration existance: %w", err)
+		return fmt.Errorf("failed to check eks_primary_eni_only network configuration existance: %w", err)
 	} else if exists {
 		zap.L().Info("eks_primary_eni_only network configuration already exists, skipping configuration")
-		return false, nil
+		return nil
 	}
-
 	eksPrimaryENIOnlyConfContent, err := generateEKSPrimaryENIOnlyConfiguration(primaryENIMac)
 	if err != nil {
-		return false, fmt.Errorf("failed to generate eks_primary_eni_only network configuration: %w", err)
+		return fmt.Errorf("failed to generate eks_primary_eni_only network configuration: %w", err)
 	}
 	zap.L().Info("writing eks_primary_eni_only network configuration")
 	if err := os.MkdirAll(networkCfgDropInDir, networkConfDropInDirPerms); err != nil {
-		return false, fmt.Errorf("failed to create network configuration drop-in directory %s: %w", networkCfgDropInDir, err)
+		return fmt.Errorf("failed to create network configuration drop-in directory %s: %w", networkCfgDropInDir, err)
 	}
 	if err := os.WriteFile(eksPrimaryENIOnlyConfPathName, eksPrimaryENIOnlyConfContent, networkConfFilePerms); err != nil {
-		return false, fmt.Errorf("failed to write eks_primary_eni_only network configuration: %w", err)
+		return fmt.Errorf("failed to write eks_primary_eni_only network configuration: %w", err)
 	}
-	return true, nil
+	if err := reloadNetworkConfigurations(); err != nil {
+		return fmt.Errorf("failed to reload network configurations: %w", err)
+	}
+	primaryLinkName, err := getLinkNameByMacAddress(primaryENIMac)
+	if err != nil {
+		return fmt.Errorf("failed to determine the name of primary link: %w", err)
+	}
+	if err := ensurePrimaryOnlyConfiguration(primaryLinkName); err != nil {
+		return fmt.Errorf("failed to ensure primary ENI only configuration: %w", err)
+	}
+	return nil
 }
 
 // eksPrimaryENIOnlyTemplateVars holds the variables for eksPrimaryENIOnlyConfTemplate
@@ -85,4 +108,81 @@ func generateEKSPrimaryENIOnlyConfiguration(primaryENIMac string) ([]byte, error
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func reloadNetworkConfigurations() error {
+	cmd := exec.Command("networkctl", "reload")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func getLinkNameByMacAddress(macAddress string) (string, error) {
+	entries, err := os.ReadDir(networkDeviceDir)
+	if err != nil {
+		return "", err
+	}
+	for _, entry := range entries {
+		linkName := entry.Name()
+		interfaceDir := filepath.Join(networkDeviceDir, linkName)
+		currentAddressesFile := filepath.Join(interfaceDir, macAddressFileName)
+		// #nosec G304 // variable read from target directory
+		currentAddressBytes, err := os.ReadFile(currentAddressesFile)
+		if err != nil {
+			zap.L().Info("skipping interface because of an error reading address file", zap.String("linkName", linkName), zap.Error(err))
+			continue
+		}
+		currentAddress := strings.TrimSpace(string(currentAddressBytes))
+		if currentAddress != macAddress {
+			continue
+		}
+		return linkName, nil
+	}
+	return "", fmt.Errorf("could not find interface with MAC address %q", macAddress)
+}
+
+func ensurePrimaryOnlyConfiguration(primaryLinkName string) error {
+	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
+	defer cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+			var primaryConfigured bool
+			var rawListOutput bytes.Buffer
+			var networkctlOutput NetworkctlList
+			secondariesUnmanaged := true // assume no secondaries unless we find one
+			zap.L().Info("checking link states...")
+			cmd := exec.CommandContext(ctx, "networkctl", "list", "--json=pretty")
+			cmd.Stdout = &rawListOutput
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return err
+			}
+			if err := json.Unmarshal(rawListOutput.Bytes(), &networkctlOutput); err != nil {
+				return err
+			}
+			for _, link := range networkctlOutput.Interfaces {
+				if link.Name == primaryLinkName {
+					if link.AdministrativeState == "configured" {
+						zap.L().Info("primary link configured", zap.String("linkName", link.Name))
+						primaryConfigured = true
+					} else {
+						zap.L().Info("primary link not yet configured", zap.String("linkName", link.Name), zap.String("linkState", link.AdministrativeState))
+					}
+				} else {
+					if link.AdministrativeState != "unmanaged" {
+						secondariesUnmanaged = false
+						zap.L().Info("secondary link not yet unmanaged", zap.String("linkName", link.Name), zap.String("linkState", link.AdministrativeState))
+					} else {
+						zap.L().Info("secondary link unmanaged", zap.String("linkName", link.Name))
+					}
+				}
+			}
+			if primaryConfigured && secondariesUnmanaged {
+				return nil
+			}
+		}
+	}
 }

--- a/nodeadm/test/e2e/cases/nodeadm-boot-hook-timeout/run.sh
+++ b/nodeadm/test/e2e/cases/nodeadm-boot-hook-timeout/run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source /helpers.sh
+
+mock::aws
+mock::networkctl
+wait::dbus-ready
+
+mkdir -p /mock/config
+
+NETWORKCTL_MOCK_LIST_FILE="/mock/config/networkctl-list.json"
+# Start with 2 pending interfaces
+jq '.' << EOF > $NETWORKCTL_MOCK_LIST_FILE
+{
+    "Interfaces": [
+        {
+            "Name": "eth0",
+            "AdministrativeState": "pending"
+        },
+        {
+            "Name": "lo",
+            "AdministrativeState": "pending"
+        }
+    ]
+}
+EOF
+
+START_TIME=$(date +%s)
+
+nodeadm-internal boot-hook &
+NODEADM_PID=$!
+
+NOW=$(date +%s)
+while [[ "$((NOW - START_TIME))" -le "120" ]]; do
+  if ! ps -p "$NODEADM_PID" > /dev/null; then
+    if [[ $((NOW - START_TIME)) -lt "60" ]]; then
+      echo "nodeadm-boot-hook should have reconciled for at least a minute but exited prematurely!"
+      exit 1
+    else
+      echo "nodeadm exited"
+      exit 0
+    fi
+  fi
+  sleep 1
+  NOW=$(date +%s)
+done
+
+if kill -0 "$NODEADM_PID" &> /dev/null; then
+  echo "nodeadm-boot-hook hung for more than 2 minutes!"
+  exit 1
+fi

--- a/nodeadm/test/e2e/cases/nodeadm-boot-hook/expected-10-eks_primary_eni_only.conf
+++ b/nodeadm/test/e2e/cases/nodeadm-boot-hook/expected-10-eks_primary_eni_only.conf
@@ -1,2 +1,0 @@
-[Match]
-PermanentMACAddress=0e:49:61:0f:c3:11

--- a/nodeadm/test/e2e/cases/nodeadm-boot-hook/run.sh
+++ b/nodeadm/test/e2e/cases/nodeadm-boot-hook/run.sh
@@ -7,8 +7,81 @@ set -o pipefail
 source /helpers.sh
 
 mock::aws
+mock::networkctl
 wait::dbus-ready
+
+mkdir -p /mock/config
+
+export NETWORKCTL_MOCK_LIST_FILE="/mock/config/networkctl-list.json"
+
+# Start with 2 pending interfaces
+jq '.' << EOF > $NETWORKCTL_MOCK_LIST_FILE
+{
+    "Interfaces": [
+        {
+            "Name": "eth0",
+            "AdministrativeState": "pending"
+        },
+        {
+            "Name": "lo",
+            "AdministrativeState": "pending"
+        }
+    ]
+}
+EOF
+
+declare -a POSSIBLE_STATES=("missing" "off" "no-carrier" "dormant" "degraded-carrier" "carrier" "degraded" "enslaved" "routable" "pending" "initialized" "configuring" "configured" "unmanaged" "failed" "linger")
+
+(
+  # test all invalid combinations
+  for PRIMARY_STATE in "${POSSIBLE_STATES[@]}"; do
+    if [[ "$PRIMARY_STATE" == "configured" ]]; then
+      continue
+    fi
+    mock::set-link-state "eth0" "$PRIMARY_STATE"
+    for SECONDARY_STATE in "${POSSIBLE_STATES[@]}"; do
+      if [[ "$PRIMARY_STATE" == "unmanaged" ]]; then
+        continue
+      fi
+      mock::set-link-state "lo" "$SECONDARY_STATE"
+    done
+    # some wait time larger than the boot hook's reconcile time
+    # to make it likely that the state is actually caught
+    sleep 0.1
+  done
+
+  # set to valid states
+  mock::set-link-state "eth0" "configured"
+  mock::set-link-state "lo" "unmanaged"
+) &
 
 nodeadm-internal boot-hook
 
-assert::files-equal /run/systemd/network/80-ec2.network.d/10-eks_primary_eni_only.conf expected-10-eks_primary_eni_only.conf
+ACTUAL_NETWORK_STATE=$(mktemp)
+networkctl list --json=pretty > "$ACTUAL_NETWORK_STATE"
+
+EXPECTED_NETWORK_STATE=$(mktemp)
+jq '.' << EOF > $EXPECTED_NETWORK_STATE
+{
+    "Interfaces": [
+        {
+            "Name": "eth0",
+            "AdministrativeState": "configured"
+        },
+        {
+            "Name": "lo",
+            "AdministrativeState": "unmanaged"
+        }
+    ]
+}
+EOF
+
+assert::files-equal $ACTUAL_NETWORK_STATE $EXPECTED_NETWORK_STATE
+
+EXPECTED_CONFIG_FILE=$(mktemp)
+cat << EOF > $EXPECTED_CONFIG_FILE
+[Match]
+PermanentMACAddress=$(cat /sys/class/net/eth0/address)
+EOF
+
+assert::files-equal /run/systemd/network/80-ec2.network.d/10-eks_primary_eni_only.conf $EXPECTED_CONFIG_FILE

--- a/nodeadm/test/e2e/infra/Dockerfile
+++ b/nodeadm/test/e2e/infra/Dockerfile
@@ -7,7 +7,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 ARG CONTAINERD_VERSION
 RUN yum install -y --allowerasing curl && yum clean all
 RUN dnf -y update && \
-    dnf -y install systemd jq python3 awscli nmap-ncat iptables tar && \
+    dnf -y install systemd jq python3 awscli nmap-ncat iptables tar procps && \
     dnf clean all
 # TO-DO: install containerd v2 from AL repo as well once it is available
 RUN if [[ "$CONTAINERD_VERSION" == *".*" ]]; then \
@@ -45,10 +45,14 @@ COPY test/e2e/infra/systemd/kubelet.service /usr/lib/systemd/system/kubelet.serv
 COPY test/e2e/infra/systemd/containerd.service /usr/lib/systemd/system/containerd.service
 COPY test/e2e/infra/mock/ /sys_devices_system_mock/
 COPY test/e2e/helpers.sh /helpers.sh
+COPY test/e2e/infra/mock/system/ /
 
 RUN mkdir -p /etc/eks/image-credential-provider/
 RUN touch /etc/eks/image-credential-provider/ecr-credential-provider
 ENV CPU_DIR /sys_devices_system_mock/cpu
 ENV NODE_DIR /sys_devices_system_mock/node
+
+RUN mkdir -p /mock/bin
+ENV PATH "/mock/bin/:$PATH"
 
 ENTRYPOINT ["/usr/lib/systemd/systemd","--system"]

--- a/nodeadm/test/e2e/infra/mock/system/networkctl-mock
+++ b/nodeadm/test/e2e/infra/mock/system/networkctl-mock
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $1 == "list" ]]; then
+  LOCKFILE=${NETWORKCTL_MOCK_LOCK_FILE:-"/mock/config/networkctl-list.lock"}
+  CONFIG_FILE=${NETWORKCTL_MOCK_LIST_FILE:-"/mock/config/networkctl-list.json"}
+  flock "$LOCKFILE" -c "cat $CONFIG_FILE"
+else
+  # pass through other arguments to real networkctl. implement mocks as needed
+  /usr/bin/networkctl "$@"
+fi

--- a/nodeadm/test/e2e/run.sh
+++ b/nodeadm/test/e2e/run.sh
@@ -44,6 +44,7 @@ function runTest() {
     -d \
     --rm \
     --privileged \
+    --mac-address 0e:49:61:0f:c3:11 \
     $MOUNT_FLAGS \
     -v "$PWD/$CASE_DIR":/test-case \
     "$image")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Switches back to a `networkctl reload` call in `nodeadm-boot-hook` as first introduced in https://github.com/awslabs/amazon-eks-ami/pull/2324. https://github.com/awslabs/amazon-eks-ami/pull/2397 has switched this out in favor of a `systemctl restart systemd-networkd`, with the aim of forcing synchronicity of the link reconfiguration to avoid a race condition where later `nodeadm` phases would fail to make outbound network calls. The `restart` had the unintended consequence of leaving routes configured for unmanaged links, which caused a period of network unreachability following `nodeadm` success, until the respective DHCP leases eventually expired.

This PR uses `networkctl reload` combined with `list` in order to ensure that only the primary interface is configured and all others become unmanaged. This is intended to supplement what `systemd-networkd-wait-online` will check after completion of `nodeadm-boot-hook`. `wait-online` only checks that all links are in a final state, i.e. `degraded`, `unmanaged`, or `configured`. This service more specifically checks that the primary link is `configured` and all other links are `unmanaged`, as is the intention of our systemd drop-in configuration. This should guarantee the desired outcome and a safe networking environment since, from testing, `systemd-networkd` will not mark a `configured` link as `unmanaged` until after it has removed all its routes (this is also why `wait-online` is insufficient for the use-case). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

Ran 740 `p4d.24xlarge` with 4 EFA + ENA interfaces configured (one on each network card) using the 1.33 AMI built from the CI run to make sure they always join the cluster and become ready. In specific, I spun up an ASG of 4 p4d.24xlarge and ran a pod that deleted any node that took less than 15 minutes to become ready (measured from instance launch time). Failed instances would therefore be leftover, but in this case every instance launched was ready in time to be cleaned up.

In testing, the boot hook consistently took under 3 seconds to execute (including polling the link states).

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
