### PR TITLE
fix: restore default ec2 endpoint

### DIFF
--- a/doc/usage/al2.md
+++ b/doc/usage/al2.md
@@ -51,7 +51,6 @@
 | `volume_type` |  |
 | `working_dir` | Directory path for ephemeral resources on the builder instance |
 | `custom_endpoint_ec2` |  |
-| `aws_domain` |  |
 <!-- template-variable-table-boundary -->
 
 ---

--- a/doc/usage/al2023.md
+++ b/doc/usage/al2023.md
@@ -51,7 +51,6 @@
 | `volume_type` |  |
 | `working_dir` | Directory path for ephemeral resources on the builder instance |
 | `custom_endpoint_ec2` |  |
-| `aws_domain` |  |
 <!-- template-variable-table-boundary -->
 
 ## Accelerated images

--- a/templates/al2/template.json
+++ b/templates/al2/template.json
@@ -46,8 +46,7 @@
     "user_data_file": null,
     "volume_type": null,
     "working_dir": null,
-    "custom_endpoint_ec2": null,
-    "aws_domain": null
+    "custom_endpoint_ec2": null
   },
   "builders": [
     {

--- a/templates/al2/variables-default.json
+++ b/templates/al2/variables-default.json
@@ -39,6 +39,5 @@
     "user_data_file": null,
     "volume_type": "gp2",
     "working_dir": "{{user `remote_folder`}}/worker",
-    "aws_domain": "amazonaws.com",
-    "custom_endpoint_ec2": "https://ec2.{{user `aws_region`}}.{{user `aws_domain`}}"
+    "custom_endpoint_ec2": ""
 }

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -46,8 +46,7 @@
     "user_data_file": null,
     "volume_type": null,
     "working_dir": null,
-    "custom_endpoint_ec2": null,
-    "aws_domain": null
+    "custom_endpoint_ec2": null
   },
   "builders": [
     {

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -38,6 +38,5 @@
     "user_data_file": null,
     "volume_type": "gp3",
     "working_dir": "{{user `remote_folder`}}/worker",
-    "aws_domain": "amazonaws.com",
-    "custom_endpoint_ec2": "https://ec2.{{user `aws_region`}}.{{user `aws_domain`}}"
+    "custom_endpoint_ec2": ""
 }


### PR DESCRIPTION
**Issue #, if available:**
Resolves #2444 

**Description of changes:**
Partial revert of https://github.com/awslabs/amazon-eks-ami/commit/e733e0e15b80e33d157c728e3c6ad8369deb70db to allow the default EC2 endpoint to be used, unless a custom one is specified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
