### PR TITLE
feat(al2023): Use restorecon to configure security context for binaries

### DIFF
--- a/templates/al2023/provisioners/configure-selinux.sh
+++ b/templates/al2023/provisioners/configure-selinux.sh
@@ -18,4 +18,5 @@ validate_directory_selinux_contexts() {
   echo "Validated SELinux contexts in $DIR"
 }
 
+sudo restorecon -R -v /usr/bin
 validate_directory_selinux_contexts /usr/bin

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -315,7 +315,7 @@
     {
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
-      "script": "{{template_dir}}/provisioners/validate-selinux.sh"
+      "script": "{{template_dir}}/provisioners/configure-selinux.sh"
     }
   ],
   "post-processors": [


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Continuation of PR https://github.com/awslabs/amazon-eks-ami/pull/2406 to reconfigure SE Linux context for all binaries in `/usr/bin`. This is needed for AL2023 GPU AMIs which introduce additional binaries (such as `kmod-util` and `gpu-ami-util`).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**
1. Built an al2023 accelerated AMI:
 ```bash
make -d k8s=1.33 os_distro=al2023 enable_accelerator=nvidia enable_efa=false
```

2. confirmed from the build-logs that new binaries are relabeled and the validation for SELinux context passes:
```bash
2025-10-01T22:44:49Z: ==> amazon-ebs: Provisioning with shell script: /home/shvbsle/workplace/amazon-eks-ami/templates/al2023/provisioners/configure-selinux.sh
2025-10-01T22:44:50Z: ==> amazon-ebs: Relabeled /usr/bin/gpu-ami-util from unconfined_u:object_r:user_tmp_t:s0 to unconfined_u:object_r:bin_t:s0
2025-10-01T22:44:50Z: ==> amazon-ebs: Relabeled /usr/bin/kmod-util from unconfined_u:object_r:user_tmp_t:s0 to unconfined_u:object_r:bin_t:s0
2025-10-01T22:44:50Z: ==> amazon-ebs: Validating SELinux contexts in /usr/bin
2025-10-01T22:44:50Z: ==> amazon-ebs: Validated SELinux contexts in /usr/bin
2025-10-01T22:44:50Z: ==> amazon-ebs: Stopping the source instance...
2025-10-01T22:44:50Z: ==> amazon-ebs: Stopping instance
2025-10-01T22:44:50Z: ==> amazon-ebs: Waiting for the instance to stop...
2025-10-01T22:45:21Z: ==> amazon-ebs: Creating AMI amazon-eks-al2023-nvidia-node-1.33-v20251001 from instance i-007b4a5055a115312
2025-10-01T22:45:21Z: ==> amazon-ebs: Attaching run tags to AMI...
```

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
