### PR TITLE
fix: use gp2 suffix to match source AMI for AL2

### DIFF
--- a/templates/al2/variables-default.json
+++ b/templates/al2/variables-default.json
@@ -28,7 +28,7 @@
     "remote_folder": "/tmp",
     "runc_version": "1.*",
     "security_group_id": "",
-    "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",
+    "source_ami_filter_name": "amzn2-ami-minimal-hvm-*-gp2",
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
     "ssh_interface": "",


### PR DESCRIPTION
**Issue #, if available:**
`Dry-run Github release` failed due to the following error message.

```
2025/10/02 16:40:52 inconsistent source_ami_name for key AL2_ARM_64 across versions: expected amzn2-ami-minimal-hvm-2.0.20250929.1-arm64-gp2 but found amzn2-ami-minimal-hvm-2.0.20250929.1-arm64-ebs for 1.29
```

Both `amzn2-ami-minimal-hvm-2.0.20250929.1-arm64-gp2` and `amzn2-ami-minimal-hvm-2.0.20250929.1-arm64-ebs` can match the source_ami_filter_name `amzn2-ami-minimal-hvm-*`.

**Description of changes:**
Add `-gp2` suffix to source_ami_filter_name to uniquely identify the source AMI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
