### PR TITLE
Fix duplicate --max-pods arguments in KUBELET_EXTRA_ARGS

### DIFF
--- a/templates/al2/runtime/bootstrap.sh
+++ b/templates/al2/runtime/bootstrap.sh
@@ -615,6 +615,13 @@ Environment='KUBELET_ARGS=$KUBELET_ARGS'
 EOF
 
 if [[ -n "$KUBELET_EXTRA_ARGS" ]]; then
+  # Extract the last --max-pods value if present, then remove all --max-pods arguments
+  LAST_MAX_PODS=$(echo "$KUBELET_EXTRA_ARGS" | grep -oE -- '--max-pods=[0-9]+' | tail -1 || true)
+  KUBELET_EXTRA_ARGS=$(echo "$KUBELET_EXTRA_ARGS" | sed 's/--max-pods=[0-9]\+//g' | sed 's/  */ /g' | sed 's/^ *//' | sed 's/ *$//')
+  # Add back the last --max-pods value if it existed
+  if [[ ! -z "$LAST_MAX_PODS" ]]; then
+    KUBELET_EXTRA_ARGS="$LAST_MAX_PODS $KUBELET_EXTRA_ARGS"
+  fi
   cat << EOF > /etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf
 [Service]
 Environment='KUBELET_EXTRA_ARGS=$KUBELET_EXTRA_ARGS'

--- a/templates/test/cases/duplicate-max-pods.sh
+++ b/templates/test/cases/duplicate-max-pods.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "-> Should handle duplicate --max-pods arguments in KUBELET_EXTRA_ARGS"
+exit_code=0
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  --kubelet-extra-args '--node-labels=test=duplicate --max-pods=58 --max-pods=30' \
+  ipv4-cluster || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+KUBELET_EXTRA_ARGS_FILE=/etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf
+if [[ ! -f ${KUBELET_EXTRA_ARGS_FILE} ]]; then
+  echo "❌ Test Failed: ${KUBELET_EXTRA_ARGS_FILE} does not exist"
+  exit 1
+fi
+
+MAX_PODS_COUNT=$(grep -oE -- '--max-pods=[0-9]+' ${KUBELET_EXTRA_ARGS_FILE} | wc -l)
+if [[ ${MAX_PODS_COUNT} -ne 1 ]]; then
+  echo "❌ Test Failed: expected exactly 1 --max-pods argument but found ${MAX_PODS_COUNT}. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+if ! grep -q -- '--max-pods=30' ${KUBELET_EXTRA_ARGS_FILE}; then
+  echo "❌ Test Failed: expected --max-pods=30 (the last value) but not found. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+if ! grep -q -- '--node-labels=test=duplicate' ${KUBELET_EXTRA_ARGS_FILE}; then
+  echo "❌ Test Failed: expected --node-labels=test=duplicate to be preserved. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+echo "-> Should handle no --max-pods argument"
+exit_code=0
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  --kubelet-extra-args '--node-labels=test=no-max-pods' \
+  ipv4-cluster || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+KUBELET_EXTRA_ARGS_FILE=/etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf
+if [[ ! -f ${KUBELET_EXTRA_ARGS_FILE} ]]; then
+  echo "❌ Test Failed: ${KUBELET_EXTRA_ARGS_FILE} does not exist"
+  exit 1
+fi
+
+MAX_PODS_COUNT=$(grep -oE -- '--max-pods=[0-9]+' ${KUBELET_EXTRA_ARGS_FILE} | wc -l || true)
+if [[ ${MAX_PODS_COUNT} -ne 0 ]]; then
+  echo "❌ Test Failed: expected no --max-pods argument but found ${MAX_PODS_COUNT}. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+if ! grep -q -- '--node-labels=test=no-max-pods' ${KUBELET_EXTRA_ARGS_FILE}; then
+  echo "❌ Test Failed: expected --node-labels=test=no-max-pods to be preserved. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi


### PR DESCRIPTION
# De-duplicate `--max-pods` arguments passing in KUBELET_EXTRA_ARGS

## Description

Fixes duplicate `--max-pods` arguments being passed to kubelet when eksctl's deprecated `MaxPodsPerNode` setting is used with AL2 EKS AMIs.

## Problem

When using eksctl's deprecated `MaxPodsPerNode` setting, the bootstrap script receives `KUBELET_EXTRA_ARGS` with duplicate `--max-pods` flags:

```bash
KUBELET_EXTRA_ARGS=... --max-pods=58 --max-pods=30
```

This happens because:
1. Bootstrap script initially sets `--max-pods` 
2. eksctl appends another `--max-pods` via `makeMaxPodsScript()`
3. Result: confusing duplicate arguments (though kubelet uses the last value)

## Solution

Modified the bootstrap script to deduplicate `--max-pods` arguments before writing the kubelet service configuration:

- Extract the last `--max-pods` value if present
- Remove all `--max-pods` arguments from the string
- Add back only the last value found
- Preserve all other kubelet arguments

## Changes

- **templates/al2/runtime/bootstrap.sh**: Added deduplication logic in KUBELET_EXTRA_ARGS handling
- **templates/test/cases/duplicate-max-pods.sh**: Added test case to verify the fix

## Testing

```bash
% bash ./test/test-harness.sh -c test/cases/duplicate-max-pods.sh
[+] Building 0.3s (22/22) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                      0.0s
 => => transferring dockerfile: 1.18kB                                                                                                                                                    0.0s
 => [internal] load metadata for public.ecr.aws/amazonlinux/amazonlinux:2                                                                                                                 0.2s
 => [internal] load metadata for public.ecr.aws/aws-ec2/amazon-ec2-metadata-mock:v1.11.2                                                                                                  0.2s
 => [internal] load .dockerignore                                                                                                                                                         0.0s
...
...
=================================================================================================================
-> Executing Test Case: duplicate-max-pods.sh
✅ ✅ duplicate-max-pods.sh Tests Passed! ✅ ✅
=================================================================================================================
✅ ✅ All Tests Passed! ✅ ✅

cd templates/test
docker build -t eks-optimized-ami -f Dockerfile ../
docker run --rm eks-optimized-ami bash ./test-harness.sh -c cases/duplicate-max-pods.sh
```

## Impact

- **AL2 AMIs**: Fixed duplicate `--max-pods` issue
- **AL2023 AMIs**: No impact (uses nodeadm, not bootstrap.sh)
- **Backward compatibility**: Maintained - all existing functionality preserved

## Related Issues

- Addresses eksctl issue: https://github.com/eksctl-io/eksctl/issues/7946
- Fixes the root cause at the AMI level without requiring eksctl changes

## Checklist

- [x] Fix implemented in bootstrap script
- [x] Test case added and passes
- [x] No impact on AL2023 (uses different initialization)
- [x] Backward compatibility maintained
