### PR TITLE
Fix duplicate `--max-pods` arguments in KUBELET_EXTRA_ARGS

### DIFF
--- a/templates/al2/runtime/bootstrap.sh
+++ b/templates/al2/runtime/bootstrap.sh
@@ -615,6 +615,13 @@ Environment='KUBELET_ARGS=$KUBELET_ARGS'
 EOF
 
 if [[ -n "$KUBELET_EXTRA_ARGS" ]]; then
+  # Extract the last --max-pods value if present, then remove all --max-pods arguments
+  LAST_MAX_PODS=$(echo "$KUBELET_EXTRA_ARGS" | grep -oE -- '--max-pods=[0-9]+' | tail -1 || true)
+  KUBELET_EXTRA_ARGS=$(echo "$KUBELET_EXTRA_ARGS" | sed 's/--max-pods=[0-9]\+//g' | sed 's/  */ /g' | sed 's/^ *//' | sed 's/ *$//')
+  # Add back the last --max-pods value if it existed
+  if [[ ! -z "$LAST_MAX_PODS" ]]; then
+    KUBELET_EXTRA_ARGS="$LAST_MAX_PODS $KUBELET_EXTRA_ARGS"
+  fi
   cat << EOF > /etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf
 [Service]
 Environment='KUBELET_EXTRA_ARGS=$KUBELET_EXTRA_ARGS'

--- a/templates/test/cases/duplicate-max-pods.sh
+++ b/templates/test/cases/duplicate-max-pods.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "-> Should handle single --max-pods arguments in KUBELET_EXTRA_ARGS"
+exit_code=0
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  --kubelet-extra-args '--node-labels=test=no-duplicate --max-pods=58' \
+  ipv4-cluster || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+KUBELET_EXTRA_ARGS_FILE=/etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf
+if [[ ! -f ${KUBELET_EXTRA_ARGS_FILE} ]]; then
+  echo "❌ Test Failed: ${KUBELET_EXTRA_ARGS_FILE} does not exist"
+  exit 1
+fi
+
+MAX_PODS_COUNT=$(grep -oE -- '--max-pods=[0-9]+' ${KUBELET_EXTRA_ARGS_FILE} | wc -l)
+if [[ ${MAX_PODS_COUNT} -ne 1 ]]; then
+  echo "❌ Test Failed: expected exactly 1 --max-pods argument but found ${MAX_PODS_COUNT}. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+if ! grep -q -- '--max-pods=58' ${KUBELET_EXTRA_ARGS_FILE}; then
+  echo "❌ Test Failed: expected --max-pods=58 (the last value) but not found. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+if ! grep -q -- '--node-labels=test=no-duplicate' ${KUBELET_EXTRA_ARGS_FILE}; then
+  echo "❌ Test Failed: expected --node-labels=test=no-duplicate to be preserved. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+echo "-> Should handle duplicate --max-pods arguments in KUBELET_EXTRA_ARGS"
+exit_code=0
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  --kubelet-extra-args '--node-labels=test=duplicate --max-pods=58 --max-pods=30' \
+  ipv4-cluster || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+KUBELET_EXTRA_ARGS_FILE=/etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf
+if [[ ! -f ${KUBELET_EXTRA_ARGS_FILE} ]]; then
+  echo "❌ Test Failed: ${KUBELET_EXTRA_ARGS_FILE} does not exist"
+  exit 1
+fi
+
+MAX_PODS_COUNT=$(grep -oE -- '--max-pods=[0-9]+' ${KUBELET_EXTRA_ARGS_FILE} | wc -l)
+if [[ ${MAX_PODS_COUNT} -ne 1 ]]; then
+  echo "❌ Test Failed: expected exactly 1 --max-pods argument but found ${MAX_PODS_COUNT}. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+if ! grep -q -- '--max-pods=30' ${KUBELET_EXTRA_ARGS_FILE}; then
+  echo "❌ Test Failed: expected --max-pods=30 (the last value) but not found. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+if ! grep -q -- '--node-labels=test=duplicate' ${KUBELET_EXTRA_ARGS_FILE}; then
+  echo "❌ Test Failed: expected --node-labels=test=duplicate to be preserved. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+echo "-> Should handle no --max-pods argument"
+exit_code=0
+/etc/eks/bootstrap.sh \
+  --b64-cluster-ca dGVzdA== \
+  --apiserver-endpoint http://my-api-endpoint \
+  --kubelet-extra-args '--node-labels=test=no-max-pods' \
+  ipv4-cluster || exit_code=$?
+
+if [[ ${exit_code} -ne 0 ]]; then
+  echo "❌ Test Failed: expected a zero exit code but got '${exit_code}'"
+  exit 1
+fi
+
+KUBELET_EXTRA_ARGS_FILE=/etc/systemd/system/kubelet.service.d/30-kubelet-extra-args.conf
+if [[ ! -f ${KUBELET_EXTRA_ARGS_FILE} ]]; then
+  echo "❌ Test Failed: ${KUBELET_EXTRA_ARGS_FILE} does not exist"
+  exit 1
+fi
+
+MAX_PODS_COUNT=$(grep -oE -- '--max-pods=[0-9]+' ${KUBELET_EXTRA_ARGS_FILE} | wc -l || true)
+if [[ ${MAX_PODS_COUNT} -ne 0 ]]; then
+  echo "❌ Test Failed: expected no --max-pods argument but found ${MAX_PODS_COUNT}. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi
+
+if ! grep -q -- '--node-labels=test=no-max-pods' ${KUBELET_EXTRA_ARGS_FILE}; then
+  echo "❌ Test Failed: expected --node-labels=test=no-max-pods to be preserved. Found: $(cat ${KUBELET_EXTRA_ARGS_FILE})"
+  exit 1
+fi


### PR DESCRIPTION
**Issue #:** [eksctl#7946](https://github.com/eksctl-io/eksctl/issues/7946)

**Description of changes:**


- Deduplicate `--max-pods` arguments before writing kubelet config
- Keep only the last `--max-pods` value while preserving other args
- Ensure with/without/duplicate `--max-pods` passing would work
- Add test case to verify the fix



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

```bash
% bash test-harness.sh -c cases/duplicate-max-pods.sh
[+] Building 2.4s (22/22) FINISHED
...
=================================================================================================================
-> Executing Test Case: duplicate-max-pods.sh
✅ ✅ duplicate-max-pods.sh Tests Passed! ✅ ✅
=================================================================================================================
✅ ✅ All Tests Passed! ✅ ✅
```


*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
