### PR TITLE
chore(build,al2023): default to containerd-2.1 for 1.32+

### DIFF
--- a/templates/al2023/variables-1.32.json
+++ b/templates/al2023/variables-1.32.json
@@ -1,5 +1,4 @@
 {
     "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
-    "containerd_version": "1.7.*",
     "nvidia_driver_major_version": "570"
 }

--- a/templates/al2023/variables-1.33.json
+++ b/templates/al2023/variables-1.33.json
@@ -1,3 +1,0 @@
-{
-    "containerd_version": "1.7.*"
-}

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -10,7 +10,7 @@
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
-    "containerd_version": "2.*",
+    "containerd_version": "2.1.*",
     "install_containerd_from_s3": "false",
     "creator": "{{env `USER`}}",
     "enable_accelerator": "",


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/amazon-eks-ami/issues/2470

**Description of changes:**

Remove the containerd override for 1.32 and 1.33 to use `containerd` 2.1 there as well 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](../doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
