### PR TITLE
Pin NVIDIA Driver version for Isolated regions

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -205,7 +205,7 @@ sudo dnf -y install "nvidia-imex-${NVIDIA_DRIVER_MAJOR_VERSION}.*"
 if is-isolated-partition; then
   sudo dnf -y install nvidia-container-toolkit
   sudo dnf -y install "nvidia-persistenced-${NVIDIA_DRIVER_MAJOR_VERSION}.*"
-  sudo dnf -y install "nvidia-driver-*${NVIDIA_DRIVER_MAJOR_VERSION}.*"
+  sudo dnf -y install "nvidia-driver-cuda-${NVIDIA_DRIVER_MAJOR_VERSION}.*"
 else
   sudo dnf -y install nvidia-container-toolkit
 fi


### PR DESCRIPTION
**Issue #, if available:**

AL repos are making 580 available. EKS at this point in time is not ready for 580. We need to ensure Isolated regions stay at 570 otherwise we run into driver errors. Pinning both the fabric-manager and the nvidia-driver just for isolated regions.

For Isolated regions, this will only install the necessary packages of `nvidia-driver-cuda` and `nvidia-driver-cuda-libs` with the correct version. They are needed for `nvidia-smi` to function correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

