### PR TITLE
fix: remove comma delimited configs and cleanup test harness

### DIFF
--- a/nodeadm/test/e2e/cases/config-cache/run.sh
+++ b/nodeadm/test/e2e/cases/config-cache/run.sh
@@ -16,7 +16,7 @@ assert::json-files-equal <(jq .spec /run/eks/nodeadm/config.json) cached-config-
 
 # assert that nodeadm does not crash and should load an existing cache. we dont
 # need any phase to go with this because the parsing happens first.
-nodeadm init --skip config,run --config-cache /run/eks/nodeadm/config.json
+nodeadm init --skip config --skip run --config-cache /run/eks/nodeadm/config.json
 assert::json-files-equal <(jq .spec /run/eks/nodeadm/config.json) cached-config-1.json
 
 # trigger changes by writing out a new drop-in
@@ -39,17 +39,17 @@ EOF
 
 # assert that if nodeadm tries to use the drop-in directory without the base
 # config from IMDS, then the verification should fail even if we have a cache.
-if nodeadm init --skip config,run --config-source file:///etc/eks/nodeadm.d --config-cache /run/eks/nodeadm/config.json; then
+if nodeadm init --skip config --skip run --config-source file:///etc/eks/nodeadm.d --config-cache /run/eks/nodeadm/config.json; then
   echo "running nodeadm with only a partial drop-in NodeConfig as the source should not work!"
   exit 1
 fi
 
 # with a fixed config-source, assert that nodeadm generates a new cache config.
-nodeadm init --skip config,run --config-source imds://user-data,file:///etc/eks/nodeadm.d --config-cache /run/eks/nodeadm/config.json
+nodeadm init --skip config --skip run --config-source imds://user-data --config-source file:///etc/eks/nodeadm.d --config-cache /run/eks/nodeadm/config.json
 assert::json-files-equal <(jq .spec /run/eks/nodeadm/config.json) cached-config-2.json
 
 # cleanup the drop-ins, and assert that if no config could be resolved through a
 # chain, then the cache should get used (this scenario is ideally for
 # nodeadm-run.service using a cached config from nodeadm-config.service).
 rm /etc/eks/nodeadm.d/*
-nodeadm init --skip config,run --config-source file:///etc/eks/nodeadm.d --config-cache /run/eks/nodeadm/config.json
+nodeadm init --skip config --skip run --config-source file:///etc/eks/nodeadm.d --config-cache /run/eks/nodeadm/config.json

--- a/nodeadm/test/e2e/cases/config-provider-chain/run.sh
+++ b/nodeadm/test/e2e/cases/config-provider-chain/run.sh
@@ -20,4 +20,3 @@ cp config.yaml $CONFIG_DIR/config.yaml
 # assert all forms of inputting the chain are valid
 nodeadm init --skip run --config-source file://$CONFIG_DIR
 nodeadm init --skip run --config-source file://config.yaml --config-source file://$CONFIG_DIR
-nodeadm init --skip run --config-source file://config.yaml,file://$CONFIG_DIR

--- a/nodeadm/test/e2e/run.sh
+++ b/nodeadm/test/e2e/run.sh
@@ -6,19 +6,10 @@ set -o pipefail
 
 cd "$(dirname $0)/../.."
 
-declare MOUNT_FLAGS=""
 declare -A MOUNT_TARGETS=(
   ['nodeadm']=$PWD/_bin/nodeadm
   ['nodeadm-internal']=$PWD/_bin/nodeadm-internal
 )
-
-for binary in "${!MOUNT_TARGETS[@]}"; do
-  if [ ! -f "${MOUNT_TARGETS[$binary]}" ]; then
-    echo >&2 "error: you must build nodeadm (run \`make\`) before you can run the e2e tests!"
-    exit 1
-  fi
-  MOUNT_FLAGS+=" -v ${MOUNT_TARGETS[$binary]}:/usr/local/bin/$binary"
-done
 
 # build image
 printf "🛠️ Building test infra image with containerd v1..."
@@ -32,34 +23,54 @@ echo "done! Test image with containerd v2: $CONTAINERD_V2_IMAGE"
 FAILED="false"
 
 function runTest() {
-  local case_name=$1
+  local case_dir=$1
   local image=$2
-  if [[ $image == "$CONTAINERD_V1_IMAGE" ]]; then
-    printf "🧪 Testing %s with containerd v1 image..." "$case_name"
+
+  local case_name
+  case_name=$(basename "$case_dir")
+
+  if [ $image = "$CONTAINERD_V1_IMAGE" ]; then
+    echo -n "🧪 Testing $case_name with containerd v1 image..."
   else
-    printf "🧪 Testing %s with containerd v2 image..." "$case_name"
+    echo -n "🧪 Testing $case_name with containerd v2 image..."
   fi
 
-  # NOTE: we force the mac address of the container to be the one from the
-  # ec2-metadata-mock to make expectations match.
-  CONTAINER_ID=$(docker run \
-    -d \
-    --rm \
-    --privileged \
-    --mac-address 0e:49:61:0f:c3:11 \
-    $MOUNT_FLAGS \
-    -v "$PWD/$CASE_DIR":/test-case \
-    "$image")
+  local workdir=/test-case
+  local docker_args=(
+    --detach
+    --rm
+    --privileged
+    # NOTE: we force the mac address of the container to be the one from the
+    # ec2-metadata-mock to make expectations match.
+    --mac-address "$(jq -r '.metadata.values.mac' $case_dir/../../infra/aemm-default-config.json)"
+    --workdir "$workdir"
+    --volume "$(pwd)/$case_dir:$workdir"
+  )
 
-  LOG_FILE=$(mktemp)
-  if docker exec "$CONTAINER_ID" bash -c "cd /test-case && ./run.sh" > "$LOG_FILE" 2>&1; then
+  for binary in "${!MOUNT_TARGETS[@]}"; do
+    if [ ! -f "${MOUNT_TARGETS[$binary]}" ]; then
+      echo >&2 "error: you must build nodeadm (run \`make\`) before you can run the e2e tests!"
+      exit 1
+    fi
+    docker_args+=(--volume "${MOUNT_TARGETS[$binary]}:/usr/local/bin/$binary")
+  done
+
+  local containerd_id
+  containerd_id=$(docker run "${docker_args[@]}" "$image")
+
+  local logfile
+  logfile=$(mktemp)
+
+  if docker exec "$containerd_id" ./run.sh > "$logfile" 2>&1; then
     echo "passed! ✅"
   else
     echo "failed! ❌"
-    cat "$LOG_FILE"
+    cat "$logfile"
     FAILED="true"
   fi
-  docker kill "$CONTAINER_ID" > /dev/null 2>&1
+
+  # killing a container should not take more than 5 seconds.
+  timeout 5 docker kill "$containerd_id" > /dev/null 2>&1
 }
 
 # Run tests
@@ -67,12 +78,12 @@ CASE_PREFIX=${1:-}
 for CASE_DIR in test/e2e/cases/${CASE_PREFIX}*; do
   CASE_NAME=$(basename "$CASE_DIR")
   if [[ "$CASE_NAME" == containerdv2-* ]]; then
-    runTest "$CASE_NAME" "$CONTAINERD_V2_IMAGE"
+    runTest "$CASE_DIR" "$CONTAINERD_V2_IMAGE"
     continue
   elif [[ "$CASE_NAME" == containerd-* ]]; then
-    runTest "$CASE_NAME" "$CONTAINERD_V2_IMAGE"
+    runTest "$CASE_DIR" "$CONTAINERD_V2_IMAGE"
   fi
-  runTest "$CASE_NAME" "$CONTAINERD_V1_IMAGE"
+  runTest "$CASE_DIR" "$CONTAINERD_V1_IMAGE"
 done
 
 if [ "$FAILED" = "true" ]; then

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-run.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-run.service
@@ -8,7 +8,7 @@ Requires=nodeadm-config.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/nodeadm init --skip config --config-source imds://user-data,file:///etc/eks/nodeadm.d/ --config-cache /run/eks/nodeadm/config.json
+ExecStart=/usr/bin/nodeadm init --skip config --config-source imds://user-data --config-source file:///etc/eks/nodeadm.d/ --config-cache /run/eks/nodeadm/config.json
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

There is a bug with comma delimited string slice parsing not working in the test harness despite working outside and on local machines, so this PR updates the tests and expectations.

additional test harness cleanup -
* standardize local variables
* prefer long-name of flags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
