### PR TITLE
fix(al2023/neuron): provide neuron driver v2.21.x on inf1

### DIFF
--- a/templates/al2023/provisioners/install-neuron-driver.sh
+++ b/templates/al2023/provisioners/install-neuron-driver.sh
@@ -37,4 +37,76 @@ sudo dnf -y install \
 
 sudo dnf versionlock 'kernel*'
 
-sudo dnf install -y aws-neuronx-dkms aws-neuronx-tools
+################################################################################
+### Install helpers ############################################################
+################################################################################
+
+sudo mv ${WORKING_DIR}/gpu/kmod-util /usr/bin/
+
+################################################################################
+### Archive 2.21 driver ########################################################
+################################################################################
+
+# Install and archive v2.21.x of the neuron driver as a legacy driver for inf1 support
+# https://awsdocs-neuron.readthedocs-hosted.com/en/latest/about-neuron/announcements/neuron2.x/announce-eos-neuron-driver-support-inf1.html
+sudo dnf install -y aws-neuronx-dkms-2.21*
+LEGACY_VERSION=$(kmod-util module-version aws-neuronx)
+
+sudo dkms remove "aws-neuronx/$LEGACY_VERSION" --all
+# Rename to aws-neuronx-legacy so the correct version can be easily loaded at runtime
+sudo sed -i 's/PACKAGE_NAME=.*/PACKAGE_NAME="aws-neuronx-legacy"/' /usr/src/aws-neuronx-${LEGACY_VERSION}/dkms.conf
+sudo mv /usr/src/aws-neuronx-${LEGACY_VERSION} /usr/src/aws-neuronx-legacy-${LEGACY_VERSION}
+# Disable "dkms autoinstall" from loading this module, this avoids automatic loading on boot by dkms.service
+# and allows neuron-kmod-load.service to always load the correct version for the machine instead
+sudo sed -i s/^AUTOINSTALL=.*/AUTOINSTALL=no/g /usr/src/aws-neuronx-legacy-${LEGACY_VERSION}/dkms.conf
+sudo dkms add -m aws-neuronx-legacy -v $LEGACY_VERSION
+sudo dkms build -m aws-neuronx-legacy -v $LEGACY_VERSION
+sudo dkms install -m aws-neuronx-legacy -v $LEGACY_VERSION
+
+# Archive, remove, and uninstall the driver
+sudo kmod-util archive aws-neuronx-legacy
+sudo kmod-util remove aws-neuronx-legacy
+sudo dnf remove -y aws-neuronx-dkms
+
+################################################################################
+### Archive new driver #########################################################
+################################################################################
+
+# This one should be installed last because it's what most and all new instance types
+# will use, so we kepe it loaded to offer boot time optimization for most uses
+sudo dnf install -y aws-neuronx-dkms
+DRIVER_VERSION=$(kmod-util module-version aws-neuronx)
+
+# Disable "dkms autoinstall" from loading this module, this avoids automatic loading on boot by dkms.service
+# and allows neuron-kmod-load.service to always load the correct version for the machine instead
+sudo sed -i s/^AUTOINSTALL=.*/AUTOINSTALL=no/g "/var/lib/dkms/aws-neuronx/${DRIVER_VERSION}/source/dkms.conf"
+
+# Archive but do not remove the driver
+sudo kmod-util archive aws-neuronx
+
+# Versionlock the new one to avoid unintentional installs of the driver
+sudo dnf versionlock aws-neuronx-dkms
+
+################################################################################
+### Install other dependencies #################################################
+################################################################################
+
+sudo dnf install -y aws-neuronx-tools
+
+################################################################################
+### Prepare for boot ###########################################################
+################################################################################
+
+# Disable automatic module loading by systemd based on the modules load config file
+# Writing an empty configuration ensures that even a lower priority config (e.g. in /usr/lib) is not picked up
+sudo rm -f /etc/modules-load.d/neuron.conf
+sudo ln -s /dev/null /etc/modules-load.d/neuron.conf
+
+sudo mv ${WORKING_DIR}/gpu/neuron-kmod-load.sh /etc/eks/
+sudo mv ${WORKING_DIR}/gpu/neuron-kmod-load.service /etc/systemd/system/neuron-kmod-load.service
+sudo systemctl daemon-reload
+sudo systemctl enable neuron-kmod-load.service
+
+# The postremove script used by the neuron module calls rmmod instead of the standard modrobe -r,
+# which can causes the module to still show up in lsmod and fail later checks in the validate.sh provisioner
+sudo rmmod neuron

--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -62,6 +62,20 @@ if sudo ip link | grep nerdctl0; then
   exit 1
 fi
 
+################################
+### modules ####################
+################################
+
+# Ensure that no module that we expect to manage through a systemd-modules-load file
+if grep --recursive --silent --word-regexp 'neuron' {/etc,/run,/usr/local/lib,/usr/lib}/modules-load.d/; then
+  # Note: this checks /run even though /run would not be present on the final instance, based on the assumption
+  # that whatever wrote it to /run might re-write it on instance boot
+  echo "Neuron module would be autoloaded by systemd-modules-load!"
+  exit 1
+  # TODO: make this check more rigorous if needed. This could more robustly check priorities to see if a configuration
+  # in /usr/lib is actually overridden by an equivalently named file in /etc, for example
+fi
+
 #############################
 ### dkms ####################
 #############################

--- a/templates/al2023/runtime/gpu/kmod-util
+++ b/templates/al2023/runtime/gpu/kmod-util
@@ -29,12 +29,16 @@ function load() {
   local MODULE_NAME="${1}"
   log "unpacking: ${MODULE_NAME}"
   local MODULE_ARCHIVE="${DKMS_ARCHIVE_DIR}/${MODULE_NAME}/*.tar.gz"
-  ${DKMS} ldtarball ${MODULE_ARCHIVE}
+  if ! ${DKMS} ldtarball ${MODULE_ARCHIVE}; then
+    # It may be meaningful to call load even when the module is already in-tree,
+    # since a module cannot be added twice but the modprobe only occurs on install
+    echo "WARNING: failed to load ${MODULE_NAME}"
+  fi
   log "unpacked: ${MODULE_NAME}"
   log "installing: ${MODULE_NAME}"
   local MODULE_VERSION
   MODULE_VERSION=$(module-version "${MODULE_NAME}")
-  ${DKMS} install -m "${MODULE_NAME}" -v "${MODULE_VERSION}"
+  ${DKMS} install --force -m "${MODULE_NAME}" -v "${MODULE_VERSION}"
   log "installed: ${MODULE_NAME}"
 }
 

--- a/templates/al2023/runtime/gpu/neuron-kmod-load.service
+++ b/templates/al2023/runtime/gpu/neuron-kmod-load.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Loading Neuron kernel modules
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/etc/eks/neuron-kmod-load.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/al2023/runtime/gpu/neuron-kmod-load.sh
+++ b/templates/al2023/runtime/gpu/neuron-kmod-load.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+readonly AMAZON_VENDOR_CODE="1d0f"
+# Based on https://github.com/aws-neuron/aws-neuron-driver/blob/fca19f7df31b44cbbffaf121230a66df6f59d118/neuron_device.h#L36-L39
+readonly INF1_DEVICE_IDS=("7064" "7065" "7066" "7067")
+
+NEURON_MODULE_NAME="aws-neuronx"
+
+for DEVICE_ID in "${INF1_DEVICE_IDS[@]}"; do
+  MATCHED_DEVICES=$(lspci -d "${AMAZON_VENDOR_CODE}:${DEVICE_ID}" | wc -l)
+  if [[ "$MATCHED_DEVICES" -gt 0 ]]; then
+    NEURON_MODULE_NAME="aws-neuronx-legacy"
+    break
+  fi
+done
+
+echo $NEURON_MODULE_NAME
+
+# For backwards compatibility, continue loading module unconditionally for now.
+# TODO: determine if this should be loaded only on instances with neuron devices, more similar to nvidia driver handling
+kmod-util load "$NEURON_MODULE_NAME"
+
+# The neuron dkms module has a post install script that includes writing a modules-load configuration, we disable
+# automatic module loading by systemd based on the modules load config file to help ensure that it is always this
+# service that causes the module to be loaded. Writing an empty configuration ensures that even a lower priority
+# config of the same name (e.g. in /usr/lib) is not picked up
+sudo rm -f /etc/modules-load.d/neuron.conf
+sudo ln -s /dev/null /etc/modules-load.d/neuron.conf

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -250,7 +250,8 @@
       "script": "{{template_dir}}/provisioners/install-neuron-driver.sh",
       "environment_vars": [
         "AWS_REGION={{user `aws_region`}}",
-        "ENABLE_ACCELERATOR={{user `enable_accelerator`}}"
+        "ENABLE_ACCELERATOR={{user `enable_accelerator`}}",
+        "WORKING_DIR={{user `working_dir`}}"
       ]
     },
     {


### PR DESCRIPTION
**Issue #, if available:**

N/A but related PR: https://github.com/awslabs/amazon-eks-ami/pull/2579

**Description of changes:**

This updates how the `neuron` driver is loaded so that a `v2.21.x` driver version is always loaded on `inf1` instance types, since this is the last major version that supports them: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/about-neuron/announcements/neuron2.x/announce-eos-neuron-driver-support-inf1.html. The newest version is kept added in the dkms tree at build time to offer load time optimization at boot for newer instance types.

To minimize perceptible impacts of this change, a new `neuron-kmod-load` service is introduced to be solely responsible for loading the module, which ensures consistent behavior between new boots on snapshots or reboots of the same instance. This is important because prior to this change, the latest driver would be loaded in both scenarios (on the inf1 and then in the new instance booted with the snapshot), but with this `v2.21.x` would be loaded on `inf1`. The `dkms` service included as part of the package and `systemd-modules-load` would try to reload the same version on the next instance type based on the module configurations, so this change disables those and allows `neuron-kmod-load` to correctly pick the module for the context. Building an AMI on an `inf1` for use on another instance type is not necessarily supported or guaranteed to work out, but it is a possible set up that someone may be currently using.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Verified on an `inf1.2xlarge`:

<details><summary>1. v2.21.x driver version loaded before and after boot</summary>

```
$ dkms status
aws-neuronx-legacy/2.21.37.0, 6.1.156-177.286.amzn2023.x86_64, x86_64: installed
efa-nv-peermem/1.2.2, 6.1.156-177.286.amzn2023.x86_64, x86_64: installed
efa/2.17.3, 6.1.156-177.286.amzn2023.x86_64, x86_64: installed (Original modules exist)

$ lsmod | grep 'neuron'
neuron                356352  0

$ cat /sys/module/neuron/version
2.21.37.0
```

</details>


Verified on a trn1:

<details><summary>1. Latest driver version loaded before and after boot</summary>

```
$ dkms status
aws-neuronx/2.24.7.0, 6.1.156-177.286.amzn2023.x86_64, x86_64: installed
efa-nv-peermem/1.2.2, 6.1.156-177.286.amzn2023.x86_64, x86_64: installed
efa/2.17.3, 6.1.156-177.286.amzn2023.x86_64, x86_64: installed (Original modules exist)

$ lsmod | grep 'neuron'
neuron                389120  0

$ cat /sys/module/neuron/version
2.24.7.0
```

</details> 

<details><summary>2. Ran nccl-tests with EFA, e.g.:</summary>

```
               size(B)    count(elems)    type    time:avg(us)    algbw(GB/s)    busbw(GB/s)
                     8               2    fp32           874.7           0.00           0.00
                    16               4    fp32          774.42           0.00           0.00
                    32               8    fp32           888.2           0.00           0.00
                    64              16    fp32          640.91           0.00           0.00
                   128              32    fp32           67.23           0.00           0.00
                   256              64    fp32           68.16           0.00           0.01
                   512             128    fp32           65.54           0.01           0.02
                  1024             256    fp32         1132.38           0.00           0.00
                  2048             512    fp32          771.05           0.00           0.01
                  4096            1024    fp32          890.24           0.00           0.01
                  8192            2048    fp32          769.13           0.01           0.02
                 16384            4096    fp32           899.7           0.02           0.04
                 32768            8192    fp32         1234.57           0.03           0.05
                 65536           16384    fp32         1010.24           0.06           0.13
                131072           32768    fp32          667.05           0.20           0.39
                262144           65536    fp32          901.34           0.29           0.57
                524288          131072    fp32          200.42           2.62           5.15
               1048576          262144    fp32          121.47           8.63          16.99
               2097152          524288    fp32          204.22          10.27          20.22
               4194304         1048576    fp32          338.93          12.38          24.36
               8388608         2097152    fp32          555.49          15.10          29.73
              16777216         4194304    fp32          784.57          21.38          42.10
              33554432         8388608    fp32         1073.27          31.26          61.55
              67108864        16777216    fp32         2102.19          31.92          62.85
             134217728        33554432    fp32         3974.83          33.77          66.48
             268435456        67108864    fp32         7591.04          35.36          69.62
             536870912       134217728    fp32         14551.4          36.89          72.64
            1073741824       268435456    fp32         28696.8          37.42          73.66
            2147483648       536870912    fp32        56722.37          37.86          74.54
        Avg bus bandwidth:      21.4182GB/s
```

</details> 


To test the boot times, I booted 4 `inf1.xlarge` and 4 `inf2.xlarge` and measured the execution time for `neuron-kmod-load.service` for both linear time and execution on a CPU core (the combined total). These are not enough data points for anything conclusive, but there are indications this may save about 1s of CPU time for `inf2` and no substantive difference in linear time, which may allow other boot-time processes to execute faster.

<details><summary>linear times</summary>

inf1
data: 21311ms, 25740ms, 17678ms, 21651ms
average: 21595ms

inf2
data: 22277ms, 21491ms, 18336ms, 25427ms
average: 21882.75ms

diff of averages (inf1 - inf2): -287.75ms

</details> 

<details><summary>cpu times</summary>

inf1
data: 23310ms, 23079ms, 21952ms ,22194ms
average: 22633.75ms

inf2
data: 21404ms, 22407ms, 21579ms, 21948ms
average: 21834.5ms

diff of averages (inf1 - inf2): -799.25 ms

</details> 


<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->


*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
