### PR TITLE
fix(ci): use stable gover for deploy docs

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # 6.0.0
+      with:
+        go-version: 'stable'
     - run: |
         pushd nodeadm && make wasm && popd
         mkdir -p ./site/assets/wasm && cp ./nodeadm/_bin/nodeadm.wasm ./site/assets/wasm/


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

The CI has been failing to deploy docs for a while, this is due to the `go` version used in the workflow. We recently bumped up the go.mod to require `1.25.1`, but the cached version is `1.24.7`. This PR automates updates (from our POV) for the future by always using the latest `stable` version defined in https://github.com/actions/go-versions/blob/main/versions-manifest.json, which is currently `1.25.3`. We could also use `check-latest: true`, but that'll mean more frequent updates and that are not necessary at the moment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
