### PR TITLE
feat(log-collector): collect nodeadm boot-hook and udev-net-manager logs

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -566,18 +566,19 @@ get_nodeadm_info() {
       timeout 75 journalctl --unit=nodeadm-run --since "${DAYS_10}" > "${COLLECT_DIR}"/nodeadm/nodeadm-run.log
 
       timeout 75 journalctl --unit=nodeadm-boot-hook --since "${DAYS_10}" > "${COLLECT_DIR}"/nodeadm/nodeadm-boot-hook.log
-      
+
       # Collect udev-net-manager logs using cached interface names for this instance.
       # https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/cmd/nodeadm-internal/udev/broker.go#L16
       NETWORK_MANAGER_CACHE_DIR="/etc/eks/nodeadm/udev-net-manager/${INSTANCE_ID}"
       if [ -d "$NETWORK_MANAGER_CACHE_DIR" ]; then
-          for interface_file in "$NETWORK_MANAGER_CACHE_DIR"/*; do
-            if [ -f "$interface_file" ]; then
-                interface=$(basename "$interface_file")
-                timeout 75 journalctl --unit=udev-net-manager@${interface} --since "${DAYS_10}" > "${COLLECT_DIR}"/nodeadm/udev-net-manager_${interface}.log
-            fi
+        for interface_file in "$NETWORK_MANAGER_CACHE_DIR"/*; do
+          if [ -f "$interface_file" ]; then
+            interface=$(basename "$interface_file")
+            timeout 75 journalctl --unit=udev-net-manager@${interface} --since "${DAYS_10}" > "${COLLECT_DIR}"/nodeadm/udev-net-manager_${interface}.log
+          fi
         done
       fi
+
       ;;
     *)
       warning "The current operating system is not supported."


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Added ```nodeadm-boot-hook``` and ```udev-net-manager``` service log collection to ```get_nodeadm_info()``` function.
```udev-net-amanger``` logs are collected for all network interfaces under the cached directory with current instance id (```/etc/eks/nodeadm/udev-net-manager/${INSTANCE_ID}```). 

I believe this will help with troubleshooting network interface and routing related issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

testing done with ```m7i.2xlarge``` instance and successfully collected nodeadm-boot-hook and udev-net-manager logs.
```
# sh nodeadm_collector.sh

        This is version 0.7.8. New versions can be found at https://github.com/awslabs/amazon-eks-ami/blob/main/log-collector-script/
...
Trying to collect nodeadm information...

Trying to archive gathered information...

        Done... your bundled logs are located in /var/log/eks_i-03f885755185492f2_2025-10-30_0847-UTC_0.7.8.tar.gz

****************************************************************************************
* WARNING: The log bundle collected by this script may contain sensitive information.  *
*                                                                                      *
* Please review the contents of the log bundle carefully and redact or obfuscate       *
* any information you do not wish to be accessible before sharing it with others.      *
****************************************************************************************

# ls -al nodeadm
total 48
drwxr-xr-x.  2 root root   156 Oct 30 08:47 .
drwxr-xr-x. 17 root root 16384 Oct 30 08:47 ..
-rw-r--r--.  1 root root  1122 Oct 30 08:47 nodeadm-boot-hook.log
-rw-r--r--.  1 root root  8606 Oct 30 08:47 nodeadm-config.log
-rw-r--r--.  1 root root  7205 Oct 30 08:47 nodeadm-run.log
-rw-r--r--.  1 root root  1058 Oct 30 08:47 udev-net-manager_enp39s0.log
-rw-r--r--.  1 root root  1028 Oct 30 08:47 udev-net-manager_enp40s0.log
```

```log
# cat nodeadm-boot-hook.log
Oct 30 08:45:56 localhost systemd[1]: Starting nodeadm-boot-hook.service - EKS Nodeadm Boot Hook...
Oct 30 08:45:58 localhost nodeadm-internal[3165]: {"level":"info","ts":1761813958.1514843,"caller":"boot-book/hook.go:58","msg":"Waiting for consistent network interfaces.."}
Oct 30 08:45:58 localhost nodeadm-internal[3165]: {"level":"info","ts":1761813958.2040935,"caller":"system/networking.go:83","msg":"checking link states..."}
Oct 30 08:45:58 localhost nodeadm-internal[3165]: {"level":"info","ts":1761813958.2114847,"caller":"system/networking.go:119","msg":"secondary link unmanaged","linkName":"lo"}
Oct 30 08:45:58 localhost nodeadm-internal[3165]: {"level":"info","ts":1761813958.2115154,"caller":"system/networking.go:109","msg":"link configured","linkName":"enp39s0"}
Oct 30 08:45:58 localhost nodeadm-internal[3165]: {"level":"info","ts":1761813958.2115233,"caller":"boot-book/hook.go:62","msg":"Completed boot hook!"}
Oct 30 08:45:58 localhost systemd[1]: nodeadm-boot-hook.service: Deactivated successfully.
Oct 30 08:45:58 localhost systemd[1]: Finished nodeadm-boot-hook.service - EKS Nodeadm Boot Hook.

# cat udev-net-manager_enp39s0.log
Oct 30 08:45:56 localhost systemd[1]: Starting udev-net-manager@enp39s0.service - Setup network interface enp39s0...
Oct 30 08:45:58 localhost nodeadm-internal[3139]: {"level":"info","ts":1761813958.114953,"caller":"udev/net_manager.go:83","msg":"found self interface mac","interface":"enp39s0","address":"02:b7:09:d4:de:43"}
Oct 30 08:45:58 localhost nodeadm-internal[3139]: {"level":"info","ts":1761813958.121689,"caller":"udev/net_manager.go:90","msg":"found primary interface mac","interface":"enp39s0","address":"02:b7:09:d4:de:43"}
Oct 30 08:45:58 localhost nodeadm-internal[3139]: {"level":"info","ts":1761813958.1916654,"caller":"udev/net_manager.go:103","msg":"resolved net manager","interface":"enp39s0","name":"io.systemd.Network"}
Oct 30 08:45:58 localhost nodeadm-internal[3139]: {"level":"info","ts":1761813958.1945198,"caller":"udev/net_manager.go:117","msg":"disabling default ec2 network configuration","interface":"enp39s0"}
Oct 30 08:45:58 localhost systemd[1]: Finished udev-net-manager@enp39s0.service - Setup network interface enp39s0.

# cat udev-net-manager_enp40s0.log
Oct 30 08:46:18 ip-10-0-137-37.ap-northeast-2.compute.internal systemd[1]: Starting udev-net-manager@enp40s0.service - Setup network interface enp40s0...
Oct 30 08:46:18 ip-10-0-137-37.ap-northeast-2.compute.internal nodeadm-internal[4448]: {"level":"info","ts":1761813978.700757,"caller":"udev/net_manager.go:83","msg":"found self interface mac","interface":"enp40s0","address":"02:2a:42:3d:2e:af"}
Oct 30 08:46:18 ip-10-0-137-37.ap-northeast-2.compute.internal nodeadm-internal[4448]: {"level":"info","ts":1761813978.7024987,"caller":"udev/net_manager.go:90","msg":"found primary interface mac","interface":"enp40s0","address":"02:b7:09:d4:de:43"}
Oct 30 08:46:18 ip-10-0-137-37.ap-northeast-2.compute.internal nodeadm-internal[4448]: {"level":"info","ts":1761813978.704116,"caller":"udev/net_manager.go:103","msg":"resolved net manager","interface":"enp40s0","name":"cni"}
Oct 30 08:46:18 ip-10-0-137-37.ap-northeast-2.compute.internal systemd[1]: Finished udev-net-manager@enp40s0.service - Setup network interface enp40s0.
```

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
