### PR TITLE
feat(al2023/nvidia): allow nvidia grid install bucket customization

### DIFF
--- a/doc/usage/al2023.md
+++ b/doc/usage/al2023.md
@@ -34,6 +34,7 @@
 | `nodeadm_build_image` | Image to use as a build environment for nodeadm |
 | `nvidia_driver_major_version` | To be used only when ```enable_accelerator = nvidia```. Driver version to install, depends on what is available in NVIDIA repository. |
 | `nvidia_repository_url` | YUM/DNF Repository override for the NVIDIA driver packages |
+| `nvidia_grid_runfile_bucket_name` | Bucket name for sourcing the Nvidia GRID runfile |
 | `pause_container_image` | Image ref for the pause container image |
 | `remote_folder` | Directory path for shell provisioner scripts on the builder instance |
 | `runc_version` |  |

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -30,6 +30,7 @@
     "nodeadm_build_image": null,
     "nvidia_driver_major_version": null,
     "nvidia_repository_url": null,
+    "nvidia_grid_runfile_bucket_name": null,
     "pause_container_image": null,
     "remote_folder": null,
     "runc_version": null,
@@ -267,6 +268,7 @@
         "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}",
         "NVIDIA_DRIVER_MAJOR_VERSION={{user `nvidia_driver_major_version`}}",
         "NVIDIA_REPOSITORY={{user `nvidia_repository_url`}}",
+        "EC2_GRID_DRIVER_S3_BUCKET={{user `nvidia_grid_runfile_bucket_name`}}",
         "WORKING_DIR={{user `working_dir`}}"
       ]
     },

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -23,6 +23,7 @@
     "nodeadm_build_image": "public.ecr.aws/eks-distro-build-tooling/golang:1.25",
     "nvidia_driver_major_version": "580",
     "nvidia_repository_url": null,
+    "nvidia_grid_runfile_bucket_name": "ec2-linux-nvidia-drivers",
     "pause_container_image": "602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.10",
     "remote_folder": "/tmp",
     "runc_version": "*",


### PR DESCRIPTION
**Issue #, if available:**

Follow up to https://github.com/awslabs/amazon-eks-ami/pull/2500

**Description of changes:**
Allow configuration of the bucket used to install Nvidia GRID drivers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
