### PR TITLE
chore(build,al2023): remove containerd 1.7 override for 1.31

### DIFF
--- a/templates/al2023/variables-1.31.json
+++ b/templates/al2023/variables-1.31.json
@@ -1,5 +1,4 @@
 {
     "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
-    "containerd_version": "1.7.*",
     "nvidia_driver_major_version": "570"
 }


### PR DESCRIPTION
**Issue #, if available:**
* remove containerd 1.7 override for 1.31, according to the backport timeline: https://github.com/awslabs/amazon-eks-ami/issues/2470

