### PR TITLE
chore(al2023/nvidia): default to 580 driver for 1.31

### DIFF
--- a/templates/al2023/variables-1.31.json
+++ b/templates/al2023/variables-1.31.json
@@ -1,4 +1,3 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
-    "nvidia_driver_major_version": "570"
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*"
 }


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/awslabs/amazon-eks-ami/issues/2470

**Description of changes:**

Backport 580 version bump to 1.31 AMI builds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
