### PR TITLE
Remove incorrect assignment of variable

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -10,7 +10,6 @@ fi
 
 MACHINE=$(uname -m)
 readonly MACHINE
-readonly EC2_GRID_DRIVER_S3_BUCKET="ec2-linux-nvidia-drivers"
 
 function rpm_install() {
   local RPMS


### PR DESCRIPTION
**Description of changes:**

`EC2_GRID_DRIVER_S3_BUCKET` is supposed to be set by the packer setup. So it should not be set in this shell script. With this line, the override in the packer definition is not respected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
