### PR TITLE
fix(al2023): fix validate script for nvidia user space driver components

### DIFF
--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -105,7 +105,7 @@ if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
 
   # Verify that all nvidia* packages have the same version as the nvidia driver, ensures user-space compatibility.
   # Skips nvidia-container-toolkit because it's independently versioned and released
-  if rpmquery --all --queryformat '%{NAME} %{VERSION}\n' nvidia* | grep -v "$NVIDIA_DRIVER_FULL_VERSION" | grep -v "nvidia-container-toolkit"; then
+  if rpmquery --all --queryformat '%{NAME} %{VERSION}\n' nvidia* | grep -v "$NVIDIA_DRIVER_FULL_VERSION" | grep -v "nvidia-container-toolkit" | grep -v "nvidia-release"; then
     echo "Installed version mismatch for one or more nvidia package(s)!"
     exit 1
   fi


### PR DESCRIPTION
**Issue #, if available:**
The validate script has a bug where it does not filter out `nvidia-release` rpm while validating (this rpm shows up in isolated regions)

```bash
[root@ip-172-31-0-215 ~]# NVIDIA_DRIVER_FULL_VERSION=570.195.03
[root@ip-172-31-0-215 ~]# rpmquery --all --queryformat '%{NAME} %{VERSION}\n' nvidia* | grep -v "$NVIDIA_DRIVER_FULL_VERSION" | grep -v "nvidia-container-toolkit"
nvidia-release 2023
[root@ip-172-31-0-215 ~]#
```
**Description of changes:**
Excluded `nvidia-release` from the final validation as well. For classic region even if `nvidia-release` doesn't exist, the validation shouldn't break.

This is what you get:
```bash
[root@ip-172-31-0-215 ~]# rpmquery --all --queryformat '%{NAME} %{VERSION}\n' nvidia* | grep -v "$NVIDIA_DRIVER_FULL_VERSION"
nvidia-container-toolkit-base 1.17.8
nvidia-container-toolkit 1.17.8
nvidia-release 2023 # <- this should be excluded as well and is a false negative if validation fails here
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

Manually ran validate script in an affected AMI.

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
