### PR TITLE
fix(nodeadm): correct typo in disable pod logs exec

### DIFF
--- a/nodeadm/internal/system/local_disk.go
+++ b/nodeadm/internal/system/local_disk.go
@@ -36,7 +36,7 @@ func (a *localDiskAspect) Setup(cfg *api.NodeConfig) error {
 	for _, mount := range cfg.Spec.Instance.LocalStorage.DisabledMounts {
 		switch mount {
 		case api.DisabledMountPodLogs:
-			args = append(args, "--no-bind-pod-logs")
+			args = append(args, "--no-bind-pods-logs")
 		case api.DisabledMountContainerd:
 			args = append(args, "--no-bind-containerd")
 		}


### PR DESCRIPTION
**Issue #, if available:**

Resolves https://github.com/awslabs/amazon-eks-ami/issues/2492

**Description of changes:**
Fixes a typo in the `setup-local-disks` execution where an `s` was omitted following pod, this now matches the script flags:
https://github.com/awslabs/amazon-eks-ami/blob/d1bc8e8c0880747b0337b48c7eb74058a6c879c8/templates/shared/runtime/bin/setup-local-disks#L221-L224

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->


<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
