### PR TITLE
chore(build,al2023): bin_dir is deprecated in containerd 2.1 use…

### DIFF
--- a/nodeadm/internal/containerd/config2.template.toml
+++ b/nodeadm/internal/containerd/config2.template.toml
@@ -33,7 +33,7 @@ BinaryName = "{{.RuntimeBinaryName}}"
 SystemdCgroup = true
 
 [plugins.'io.containerd.cri.v1.runtime'.cni]
-bin_dir = "/opt/cni/bin"
+bin_dirs = ['/opt/cni/bin']
 conf_dir = "/etc/cni/net.d"
 
 {{if .UseSOCISnapshotter}}


### PR DESCRIPTION
**Issue #, if available:**

* bin_dir will be deprecated in containerd 2.1 and will be removed in containerd 2.3, use bin_dirs instead
* ref the deprecated features https://github.com/containerd/containerd/blob/ba0a05aab81b67c28cc77a9b3364da5948998ad2/RELEASES.md#deprecated-features
