### PR TITLE
chore(build,al2023): remove containerd 1.7 override for 1.30

### DIFF
--- a/templates/al2023/variables-1.30.json
+++ b/templates/al2023/variables-1.30.json
@@ -1,4 +1,3 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
-    "containerd_version": "1.7.*"
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*"
 }


### PR DESCRIPTION
**Issue #, if available:**
* upgrade the containerd for 1.30 to 2.1. according to the timeline https://github.com/awslabs/amazon-eks-ami/issues/2470