### PR TITLE
feat(workflows): add stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '00 16 * * 1-5'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        days-before-close: 14
+        days-before-stale: 60
+        operations-per-run: 100
+        stale-issue-message: 'This issue is stale because it has been open for 60 days with no activity. Remove the stale label or comment to avoid closure in 14 days'
+        stale-pr-message: 'This pull request is stale because it has been open for 60 days with no activity. Remove the stale label or comment to avoid closure in 14 days'
+        close-issue-message: "Issue closed due to inactivity."
+        close-pr-message: "Pull request closed due to inactivity."


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds a new workflow to manage stale issues and PRs, intended to help avoid the project from being cluttered with issues that were resolved in the background. We may want to extend this in the future by adding labels that protect an issue/PR from being closed regardless of inactivity period (e.g. `needs-triage`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
