### PR TITLE
ci: fix eni max pods syntax

### DIFF
--- a/.github/workflows/sync-eni-max-pods.yaml
+++ b/.github/workflows/sync-eni-max-pods.yaml
@@ -23,7 +23,7 @@ jobs:
           repository: awslabs/amazon-eks-ami
           ref: refs/heads/main
           path: amazon-eks-ami/
-        run: |
+      - run: |
           #!/usr/bin/env bash
           set -o errexit
           cd amazon-eks-ami/nodeadm


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

The `sync-eni-max-pods` workflow has been failing for a while due to incorrect syntax, specifically grouping `run` with a `use`/`with` step

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
