### PR TITLE
fix(ci/max-pods): remove duplicate create PR step

### DIFF
--- a/.github/workflows/sync-eni-max-pods.yaml
+++ b/.github/workflows/sync-eni-max-pods.yaml
@@ -28,7 +28,6 @@ jobs:
           set -o errexit
           cd amazon-eks-ami/nodeadm
           make generate-instance-info
-      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # 7.0.8
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
         with:
           repository: aws/amazon-vpc-cni-k8s
@@ -47,7 +46,7 @@ jobs:
           base: main
           add-paths: |
             templates/shared/runtime/eni-max-pods.txt
-            nodeadm/internal/kubelet/eni-max-pods.txt
+            nodeadm/internal/kubelet/instance-info.jsonl
           commit-message: "chore: update eni-max-pods.txt"
           committer: "GitHub <noreply@github.com>"
           author: "GitHub <noreply@github.com>"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

https://github.com/awslabs/amazon-eks-ami/commit/6826d21327dbe59a710f6e44a54b44abf7a56fec added a new create PR step that fails because the path's not correctly configured so it ends up being executed outside of a git repo, and the git commands fail (ref: https://github.com/awslabs/amazon-eks-ami/actions/runs/19520908457/job/55883963963). This step is redundant/unnecessary though, we should continue relying on the PR step at the end of the workflow.

Also fixes the added path for nodeadm to use the new `jsonl` file instead of the removed `txt` file https://github.com/awslabs/amazon-eks-ami/commit/6826d21327dbe59a710f6e44a54b44abf7a56fec#diff-da779390bd059ad68d19b79c74e09d1a9f397bb9055ceb0fbdfc8de0a4096ee3R141

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->