### PR TITLE
feat(log-collector): collect mountpoint-s3-csi-driver logs

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -20,7 +20,7 @@ export LANG="C"
 export LC_ALL="C"
 
 # Global options
-readonly PROGRAM_VERSION="0.7.8"
+readonly PROGRAM_VERSION="0.7.9"
 readonly PROGRAM_SOURCE="https://github.com/awslabs/amazon-eks-ami/blob/main/log-collector-script/"
 readonly PROGRAM_DIR="/opt/log-collector"
 readonly LOG_DIR="/var/log"
@@ -435,6 +435,8 @@ get_common_logs() {
         cp --force --dereference --recursive /var/log/containers/fsx-csi* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/containers/fsx-openzfs-csi* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/containers/file-cache-csi* "${COLLECT_DIR}"/var_log/ 2> /dev/null
+        cp --force --dereference --recursive /var/log/containers/s3-csi* "${COLLECT_DIR}"/var_log/ 2> /dev/null
+        cp --force --dereference --recursive /var/log/containers/mp_*_mount_s3* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/containers/eks-pod-identity-agent* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         continue
       fi
@@ -448,6 +450,9 @@ get_common_logs() {
         cp --force --dereference --recursive /var/log/pods/kube-system_fsx-csi-* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/pods/kube-system_fsx-openzfs-csi-* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/pods/kube-system_file-cache-csi-* "${COLLECT_DIR}"/var_log/ 2> /dev/null
+        cp --force --dereference --recursive /var/log/pods/kube-system_s3-csi* "${COLLECT_DIR}"/var_log/ 2> /dev/null
+        cp --force --dereference --recursive /var/log/pods/mount-s3_mp-* "${COLLECT_DIR}"/var_log/ 2> /dev/null
+        cp --force --dereference --recursive /var/log/pods/mount-s3_hr-* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         cp --force --dereference --recursive /var/log/pods/kube-system_eks-pod-identity-agent* "${COLLECT_DIR}"/var_log/ 2> /dev/null
         continue
       fi


### PR DESCRIPTION
**Issue #, if available:** #2535

**Description of changes:**

Add all [Mountpoint for Amazon S3 CSI Driver](https://github.com/awslabs/mountpoint-s3-csi-driver/) pod/container logs to the log-collector script. This CSI driver is only supported for Linux, and so this change is limited only to the Linux script.

There are two major versions of Mountpoint's CSI Driver. V1 and V2 both have a node daemon, and V2 extends this with a controller, Mountpoint pods, and Mountpoint headroom pods (optionally). The controller is deployed to only one node on the cluster - so it will only be included if the node is the one running the controller.

The log collector version number is bumped so that we can ask that this version is used for debugging Mountpoint for Amazon S3 CSI Driver issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

- Manually downloaded the script on an existing EKS cluster and verified the new logs are included in the archive.
- I have not followed steps 1-4 given I do not believe these shell script changes are at all related. Please let me know if this is the wrong decision. https://github.com/awslabs/amazon-eks-ami/blob/7f0847dede115c74947f1847ceeefdc86fe87c29/doc/CONTRIBUTING.md#testing-changes
