### PR TITLE
fix(ci): honor never-stale label for PR/issue cleanup

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,3 +27,5 @@ jobs:
         stale-pr-message: 'This pull request is stale because it has been open for 60 days with no activity. Remove the stale label or comment to avoid closure in 14 days'
         close-issue-message: "Issue closed due to inactivity."
         close-pr-message: "Pull request closed due to inactivity."
+        exempt-issue-labels: never-stale
+        exempt-pr-labels: never-stale


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

As seen in https://github.com/awslabs/amazon-eks-ami/issues/527, issues with the `never-stale` label can currently be incorrectly marked as stale. This adds exemptions for that label to avoid that inconsistency. Though this adds it for both PRs and issues, it is in practice more useful for issues than PRs, as it allows for complex issues to be cataloged until they can be eventually addressed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
