### PR TITLE
added nftables in AL2023 AMI

### DIFF
--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -54,6 +54,7 @@ sudo dnf install -y \
   aws-cfn-bootstrap \
   chrony \
   conntrack \
+  nftables \
   ec2-instance-connect \
   ethtool \
   ipvsadm \


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Added nftables in AMI such that it can be used for collect nftables as part of NodeLogs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Created AMI by `make k8s=1.31 os_distro=al2023` and validated nft binary is present

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
