### PR TITLE
feat: use console formatted logging for nodeadm

### DIFF
--- a/nodeadm/internal/cli/logger.go
+++ b/nodeadm/internal/cli/logger.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func NewLogger(opts *GlobalOptions) *zap.Logger {
@@ -10,7 +11,13 @@ func NewLogger(opts *GlobalOptions) *zap.Logger {
 	if opts.DevelopmentMode {
 		logger, err = zap.NewDevelopment()
 	} else {
-		logger, err = zap.NewProduction()
+		config := zap.NewProductionConfig()
+		config.DisableStacktrace = true
+		config.Encoding = "console"
+		config.EncoderConfig.TimeKey = ""
+		config.EncoderConfig.ConsoleSeparator = " "
+		config.EncoderConfig.EncodeCaller = zapcore.ShortCallerEncoder
+		logger, err = config.Build()
 	}
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Since we don't parse the JSON output, print in human-readable console format instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Testing*

Built and ran AMI.

Example logs:
```
Dec 08 20:02:45 localhost nodeadm[1885]: info containerd/version.go:33 Reading containerd version from file {"path": "/etc/eks/containerd-version.txt"}
Dec 08 20:02:45 localhost nodeadm[1885]: info containerd/config.go:77 Writing containerd config to file.. {"path": "/etc/containerd/config.toml"}
Dec 08 20:02:45 localhost nodeadm[1885]: info init/init.go:288 Configured daemon {"name": "containerd"}
Dec 08 20:02:45 localhost nodeadm[1885]: info init/init.go:284 Configuring daemon... {"name": "kubelet"}
Dec 08 20:02:45 localhost nodeadm[1885]: info kubelet/config.go:209 Setup IP for node {"ip": "192.168.163.10"}
Dec 08 20:02:45 localhost nodeadm[1885]: info kubelet/config.go:362 Writing kubelet config to file.. {"path": "/etc/kubernetes/kubelet/config.json"}
Dec 08 20:02:45 localhost nodeadm[1885]: info kubelet/config.go:371 Enabling kubelet config drop-in dir..
Dec 08 20:02:45 localhost nodeadm[1885]: info kubelet/config.go:386 Writing user kubelet config to drop-in file.. {"path": "/etc/kubernetes/kubelet/config.json.d/40-nodeadm.conf"}
Dec 08 20:02:45 localhost nodeadm[1885]: info init/init.go:288 Configured daemon {"name": "kubelet"}
Dec 08 20:02:45 localhost nodeadm[1885]: info init/init.go:159 done! {"duration": 2.349235856}
```

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
