### PR TITLE
chore(bot): bump actions/checkout version

### DIFF
--- a/.github/actions/bot/action.yaml
+++ b/.github/actions/bot/action.yaml
@@ -3,7 +3,7 @@ description: "🤖 beep boop"
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # 4.1.7
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
     - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
       with:
         script: |


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bump to `actions/checkout` to latest in the bot

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
