### PR TITLE
fix(bot): remove duplicate checkout

### DIFF
--- a/.github/actions/bot/action.yaml
+++ b/.github/actions/bot/action.yaml
@@ -3,7 +3,6 @@ description: "🤖 beep boop"
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 6.0.1
     - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # 8.0.0
       with:
         script: |


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Removes a duplicate `checkout` that appears to be leading to an authorization issue https://github.com/awslabs/amazon-eks-ami/actions/runs/20180972710/job/57944688111 because of the duplicity with the source caller also using checkout https://github.com/awslabs/amazon-eks-ami/blob/63a717761c2b7823b28eaf01d3a60e460b3e831d/.github/workflows/bot-trigger.yaml#L13


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
