### PR TITLE
fix(ci): define permissions for ci and ci manual

### DIFF
--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -48,6 +48,9 @@ permissions:
 jobs:
   setup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       git_sha_short: ${{ steps.variables.outputs.git_sha_short }}
       workflow_run_url: ${{ steps.variables.outputs.workflow_run_url }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,9 @@ jobs:
   kubernetes-versions:
     runs-on: ubuntu-latest
     name: ${{ matrix.k8s_version }} / ${{ matrix.os_distro }}
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - setup
     permissions:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**


The manual CI is failing because of undefined permissions, e.g. https://github.com/awslabs/amazon-eks-ami/actions/runs/20183726162

>  The workflow is not valid. .github/workflows/ci-manual.yaml (Line: 74, Col: 3): Error calling workflow 'awslabs/amazon-eks-ami/.github/workflows/ci.yaml@6c94a885cc843980820c4f706518284c38d38c06'. The nested job 'setup' is requesting 'contents: read, id-token: write', but is only allowed 'contents: none, id-token: none'. .github/workflows/ci-manual.yaml (Line: 74, Col: 3): Error calling workflow 'awslabs/amazon-eks-ami/.github/workflows/ci.yaml@6c94a885cc843980820c4f706518284c38d38c06'. The nested job 'kubernetes-versions' is requesting 'contents: read, id-token: write', but is only allowed 'contents: none, id-token: none'.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
