### PR TITLE
fix(ci): consolidate ci-manual permissions

### DIFF
--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -44,13 +44,12 @@ on:
 permissions:
   pull-requests: write
   issues: write
+  contents: read
+  id-token: write
 
 jobs:
   setup:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     outputs:
       git_sha_short: ${{ steps.variables.outputs.git_sha_short }}
       workflow_run_url: ${{ steps.variables.outputs.workflow_run_url }}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**


Fixing workflow failure due to duplicate `permissions` block: 
> Invalid workflow file: .github/workflows/ci-manual.yaml#L78
error parsing called workflow
".github/workflows/ci-manual.yaml"
-> "./.github/workflows/ci.yaml" (source branch with sha:771394f880f4dd8138946e90fd331e759c032f8b)
: (Line: 71, Col: 5): 'permissions' is already defined


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
