### PR TITLE
fix(ci): remove duplicate permissions entry in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,9 +63,6 @@ jobs:
   kubernetes-versions:
     runs-on: ubuntu-latest
     name: ${{ matrix.k8s_version }} / ${{ matrix.os_distro }}
-    permissions:
-      contents: read
-      id-token: write
     needs:
       - setup
     permissions:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Removes the duplicate `permissions` definition

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
