### PR TITLE
fix(nodeadm): clarify missing cluster ID error for outposts

### DIFF
--- a/nodeadm/internal/api/validation.go
+++ b/nodeadm/internal/api/validation.go
@@ -17,7 +17,7 @@ func ValidateNodeConfig(cfg *NodeConfig) error {
 	}
 	if enabled := cfg.Spec.Cluster.EnableOutpost; enabled != nil && *enabled {
 		if cfg.Spec.Cluster.ID == "" {
-			return fmt.Errorf("CIDR is missing in cluster configuration")
+			return fmt.Errorf("cluster ID must be provided for outposts")
 		}
 	}
 	return nil


### PR DESCRIPTION
…st is enabled

**Issue #, if available:**

**Description of changes:**
The error message was misleading. Corrected the message

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
