### PR TITLE
run binaries as a privileged user to avoid permission denied errors to support hardened AMIs

### DIFF
--- a/templates/al2023/provisioners/cache-pause-container.sh
+++ b/templates/al2023/provisioners/cache-pause-container.sh
@@ -5,5 +5,5 @@ set -o errexit
 set -o pipefail
 
 sudo systemctl start containerd
-cache-pause-container -i ${PAUSE_CONTAINER_IMAGE}
+sudo cache-pause-container -i ${PAUSE_CONTAINER_IMAGE}
 sudo systemctl stop containerd

--- a/templates/al2023/provisioners/install-nodeadm.sh
+++ b/templates/al2023/provisioners/install-nodeadm.sh
@@ -47,7 +47,7 @@ sudo nerdctl rmi \
 sudo nerdctl image prune --force
 
 # move the nodeadm binaries into bin folder
-sudo chmod a+x $PROJECT_DIR/_bin/*
+sudo chmod -R a+x $PROJECT_DIR/_bin/*
 sudo mv --context \
   $PROJECT_DIR/_bin/nodeadm \
   $PROJECT_DIR/_bin/nodeadm-internal \

--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -107,7 +107,7 @@ sudo systemctl restart sshd.service
 
 ### isolated regions can't communicate to awscli.amazonaws.com so installing awscli through dnf
 
-PARTITION=$(imds /latest/meta-data/services/partition)
+PARTITION=$(sudo imds /latest/meta-data/services/partition)
 if [[ "${PARTITION}" =~ ^aws-iso ]]; then
   echo "Installing awscli package"
   sudo dnf install -y awscli
@@ -162,7 +162,7 @@ sudo mkdir -p /var/lib/kubelet
 sudo mkdir -p /opt/cni/bin
 
 echo "Downloading binaries from: s3://$BINARY_BUCKET_NAME"
-AWS_DOMAIN=$(imds "/latest/meta-data/services/domain")
+AWS_DOMAIN=$(sudo imds "/latest/meta-data/services/domain")
 S3_URL_BASE="https://$BINARY_BUCKET_NAME.s3.$BINARY_BUCKET_REGION.$AWS_DOMAIN/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
 S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
 
@@ -187,7 +187,7 @@ done
 
 sudo rm ./*.sha256
 
-kubelet --version > "${WORKING_DIR}/kubelet-version.txt"
+sudo kubelet --version > "${WORKING_DIR}/kubelet-version.txt"
 sudo mv "${WORKING_DIR}/kubelet-version.txt" /etc/eks/kubelet-version.txt
 
 sudo systemctl enable ebs-initialize-bin@kubelet
@@ -237,7 +237,7 @@ fi
 ### AMI Metadata ###############################################################
 ################################################################################
 
-BASE_AMI_ID=$($WORKING_DIR/shared/bin/imds /latest/meta-data/ami-id)
+BASE_AMI_ID=$(sudo $WORKING_DIR/shared/bin/imds /latest/meta-data/ami-id)
 cat << EOF | sudo tee /etc/eks/release
 BASE_AMI_ID="$BASE_AMI_ID"
 BUILD_TIME="$(date)"

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-config.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-config.service
@@ -8,6 +8,7 @@ After=systemd-networkd-wait-online.service
 
 [Service]
 Type=oneshot
+User=root
 ExecStart=/usr/bin/nodeadm init --skip run --config-source imds://user-data --config-cache /run/eks/nodeadm/config.json
 
 [Install]

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-run.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-run.service
@@ -8,6 +8,7 @@ Requires=nodeadm-config.service
 
 [Service]
 Type=oneshot
+User=root
 ExecStart=/usr/bin/nodeadm init --skip config --config-source imds://user-data --config-source file:///etc/eks/nodeadm.d/ --config-cache /run/eks/nodeadm/config.json
 
 [Install]

--- a/templates/shared/provisioners/generate-version-info.sh
+++ b/templates/shared/provisioners/generate-version-info.sh
@@ -23,14 +23,14 @@ for modname in $(sudo lsmod | cut -d' ' -f 1 | tail -n +2); do
 done
 
 # binaries
-KUBELET_VERSION=$(kubelet --version | awk '{print $2}')
+KUBELET_VERSION=$(sudo kubelet --version | awk '{print $2}')
 if [ "$?" != 0 ]; then
   echo "unable to get kubelet version"
   exit 1
 fi
 echo "$(jq ".binaries.kubelet = \"$KUBELET_VERSION\"" $OUTPUT_FILE)" > $OUTPUT_FILE
 
-CLI_VERSION=$(aws --version | awk '{print $1}' | cut -d '/' -f 2)
+CLI_VERSION=$(sudo aws --version | awk '{print $1}' | cut -d '/' -f 2)
 if [ "$?" != 0 ]; then
   echo "unable to get aws cli version"
   exit 1


### PR DESCRIPTION
**Issue #, if available:**
Related PRs/Issues: 

- https://github.com/awslabs/amazon-eks-ami/pull/1661
- https://github.com/awslabs/amazon-eks-ami/pull/1513
- https://github.com/awslabs/amazon-eks-ami/pull/1556
- https://github.com/awslabs/amazon-eks-ami/issues/1839
- https://github.com/awslabs/amazon-eks-ami/issues/1838

**Description of changes:**

Problem

When building a hardened AMI with SELinux enabled (enforcing), the amazon-eks-ami Packer build fails during provisioning. Several binaries installed or copied by the build are placed in /usr/bin with incorrect Unix ownership/permissions and without an executable SELinux file context.

As a result, these binaries cannot be executed during subsequent build steps, causing the Packer build to fail.

Solution

I am working on a separate branch to update the selinux contexts and permissions for these binaries but what works is just sudo-ing all the affected binaries. 

Unfortunately, we're not able to set ssh_username=root because there is a restriction to SSH into the machine as root in our hardened environment.

**Testing Done**

We have successfully built a working EKS AMI from this in both ARM and x86 using a base AL2023 hardened with https://github.com/ansible-lockdown/AMAZON2023-CIS

