### PR TITLE
fix(neuron): install aws-neuronx-dkms-2.21 at boot on inf1

### DIFF
--- a/templates/al2023/provisioners/install-neuron-driver.sh
+++ b/templates/al2023/provisioners/install-neuron-driver.sh
@@ -4,6 +4,8 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
+readonly PACKAGE_CACHE_PATH="/var/cache/eks/packages"
+
 if [ "$ENABLE_ACCELERATOR" != "neuron" ]; then
   exit 0
 fi
@@ -23,6 +25,27 @@ EOF
 
 # Manually install the GPG key, verifies repository can be reached
 sudo rpm --import https://yum.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB
+
+################################################################################
+### Cache packages for conditional install at boot #############################
+################################################################################
+# TODO: remove this section if inf1 is not supported
+
+# Install and remove aws-neuronx-dkms-2.21.x to ensure all of its dependencies are
+# pre-installed
+sudo dnf install -y aws-neuronx-dkms-2.21.*
+sudo dnf remove -y --noautoremove aws-neuronx-dkms
+
+# Cache the 2.21.x rpm for contidtional boot-time install
+sudo dnf download aws-neuronx-dkms-2.21.*
+sudo mkdir -p "$PACKAGE_CACHE_PATH"
+sudo mv aws-neuronx-dkms-2.21.*.rpm "${PACKAGE_CACHE_PATH}/"
+
+sudo mv ${WORKING_DIR}/gpu/neuron-package-install.sh /etc/eks/
+sudo mv ${WORKING_DIR}/gpu/neuron-package-install.service /etc/systemd/system/
+
+sudo systemctl daemon-reload
+sudo systemctl enable neuron-package-install.service
 
 ################################################################################
 ### Install packages ###########################################################

--- a/templates/al2023/runtime/gpu/neuron-package-install.service
+++ b/templates/al2023/runtime/gpu/neuron-package-install.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Install Neuron packages
+# Run before cloud-init so packages are installed
+# before user data that may query the installed information
+Before=cloud-init.service
+
+[Service]
+Type=oneshot
+ExecStart=/etc/eks/neuron-package-install.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/al2023/runtime/gpu/neuron-package-install.sh
+++ b/templates/al2023/runtime/gpu/neuron-package-install.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+readonly PACKAGE_CACHE_PATH="/var/cache/eks/packages"
+
+readonly AMAZON_VENDOR_CODE="1d0f"
+# Based on https://github.com/aws-neuron/aws-neuron-driver/blob/fca19f7df31b44cbbffaf121230a66df6f59d118/neuron_device.h#L36-L39
+readonly INF1_DEVICE_IDS=("7064" "7065" "7066" "7067")
+
+function is-inf1() {
+  for DEVICE_ID in "${INF1_DEVICE_IDS[@]}"; do
+    MATCHED_DEVICES=$(lspci -d "${AMAZON_VENDOR_CODE}:${DEVICE_ID}" | wc -l)
+    if [[ "$MATCHED_DEVICES" -gt 0 ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# the aws-neuronx-dkms module has a pre-install script that calls
+# on update-pciids, which will hang if called from a node
+# that cannot reach https://pci-ids.ucw.cz/v2.2/pci.ids
+# the values pulled by the install at build time can be used
+# in lieu of this
+function update-pciids() {
+  echo "update-pciids called: doing nothing"
+}
+
+function installed-neuron-driver-version() {
+  rpm -q aws-neuronx-dkms --queryformat '%{VERSION}'
+}
+
+if is-inf1 && [[ $(installed-neuron-driver-version) != 2.21.* ]]; then
+  echo "downgrading driver to 2.21"
+  # "dnf downgrade" would fail because the post remove script for the package
+  # does not fully remove the module, and then the post install script for the
+  # downgraded version fails because of an attempt to probe an older version of
+  # a loaded module without --force. relying on the rpm cli directly makes the
+  # operations more intuitive
+  export -f update-pciids
+  rpm --erase aws-neuronx-dkms
+  rpm -i "${PACKAGE_CACHE_PATH}/aws-neuronx-dkms-2.21.*.rpm"
+else
+  echo "nothing to do!"
+fi

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -251,7 +251,8 @@
       "script": "{{template_dir}}/provisioners/install-neuron-driver.sh",
       "environment_vars": [
         "AWS_REGION={{user `aws_region`}}",
-        "ENABLE_ACCELERATOR={{user `enable_accelerator`}}"
+        "ENABLE_ACCELERATOR={{user `enable_accelerator`}}",
+        "WORKING_DIR={{user `working_dir`}}"
       ]
     },
     {


### PR DESCRIPTION
**Issue #, if available:**

N/A but related PR: https://github.com/awslabs/amazon-eks-ami/pull/2486

**Description of changes:**

This adds a new service to run on boot to forcefully downgrade `aws-neuronx-dkms` to a cached `2.21.x` version if it's detected to be running on an `inf1` instance type with a different version installed. 

This should be functionally equivalent to the current AMIs with two caveats:
1.  non-inf1 instances running on a snapshot of an `inf1` instance using this AMI will also use the downgraded driver version. This can be made equivalent by also caching the latest driver version and and always ensuring that is the one installed on those instances, but this introduces potentially unnecessary complexity as the need for this use case is unclear
2. `inf1` instances will now have the `v2.21.x` package installed, which is a requirement detailed in https://awsdocs-neuron.readthedocs-hosted.com/en/latest/about-neuron/announcements/neuron2.x/announce-eos-neuron-driver-support-inf1.html. Startup will take a bit longer on these instance types because of the additional time required to remove the newer module loaded and then building and loading the `v2.21.x` version.


For the hypothetical users relying on a snapshot and impacted by 1), they can restore parity to before by updating their snapshotting process to include
```
sudo dnf upgrade -y aws-neuronx-dkms
sudo systemctl disable neuron-package-install
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

Launched `inf1.xlarge` and `inf2.xlarge` to confirm that `dkms status` and `modinfo neuron` show the `v2.21.x` and latest driver versions respectively. Also checked the time it takes for `neuron-package-install` to complete, and it was approximately 45s across four launches on `inf1`, and less than 1 second in `inf2`.

Additionally launched an `inf1.xlarge` in a private subnet with no egress route to the public internet as well as a node in a public subnet with security groups allowing no egress to confirm that the script completes within a similar timeframe. This is to ensure that all network calls are bypassed, which is just the `update-pciids` override in this case.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->


*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
