### PR TITLE
Revert "fix(al2023): Only enable DNS for the primary interface to avoid duplicate entries (#2578)"

### DIFF
--- a/nodeadm/cmd/nodeadm-internal/udev/eks-managed.network.tpl
+++ b/nodeadm/cmd/nodeadm-internal/udev/eks-managed.network.tpl
@@ -16,13 +16,13 @@ DNSDefaultRoute=yes
 
 [DHCPv4]
 UseHostname=no
-UseDNS={{.UseDNS}}
+UseDNS=yes
 UseNTP=yes
 UseDomains=yes
 
 [DHCPv6]
 UseHostname=no
-UseDNS={{.UseDNS}}
+UseDNS=yes
 UseNTP=yes
 WithoutRA=solicit
 

--- a/nodeadm/cmd/nodeadm-internal/udev/net_manager.go
+++ b/nodeadm/cmd/nodeadm-internal/udev/net_manager.go
@@ -146,21 +146,12 @@ func (c *netManager) manageLink(ctx context.Context) error {
 		ruleBase = 10000
 	)
 
-	// TODO: this is a temporary fix needed because of a bug in upstream systemd
-	// only enable DNS for the primary interface to avoid duplicate entries
-	// see: https://github.com/systemd/systemd/pull/40069
-	useDNSValue := "no"
-	if c.selfMac == c.primaryMac {
-		useDNSValue = "yes"
-	}
-
 	templateVars := networkTemplateVars{
 		MAC: c.selfMac,
 		// setup route metics. this provides priority on good interfaces over
 		// ones that could potentially delay startup.
 		// see: https://github.com/amazonlinux/amazon-ec2-net-utils/blob/3261b3b4c8824343706ee54d4a6f5d05cd8a5979/lib/lib.sh#L348-L366
 		Metric: metricBase + 100*networkCard + deviceIndex,
-		UseDNS: useDNSValue,
 	}
 
 	// we only need to add routes/rules to interfaces beyond the primary.

--- a/nodeadm/cmd/nodeadm-internal/udev/systemd.go
+++ b/nodeadm/cmd/nodeadm-internal/udev/systemd.go
@@ -21,7 +21,6 @@ type networkTemplateVars struct {
 	Metric      int
 	TableID     int
 	InterfaceIP string
-	UseDNS      string
 }
 
 func renderNetworkTemplate(templateVars networkTemplateVars) ([]byte, error) {

--- a/nodeadm/cmd/nodeadm-internal/udev/systemd_test.go
+++ b/nodeadm/cmd/nodeadm-internal/udev/systemd_test.go
@@ -15,7 +15,6 @@ func Test_renderNetworkTemplate(t *testing.T) {
 			Metric:      42,
 			TableID:     99,
 			InterfaceIP: "127.0.0.1",
-			UseDNS:      "yes",
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(`
@@ -85,7 +84,6 @@ Priority=32765
 			MAC:     "foo",
 			Metric:  42,
 			TableID: 99,
-			UseDNS:  "yes",
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(`
@@ -148,7 +146,6 @@ Gateway=_dhcp4
 		networkConfig, err := renderNetworkTemplate(networkTemplateVars{
 			MAC:    "foo",
 			Metric: 42,
-			UseDNS: "yes",
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, strings.TrimSpace(`


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This reverts commit f48f04c0df8f90c81f0fd22cceca48990588cb95.

This was a temporary fix. This is no longer needed since the upstream fix in systemd now has made its way to base al2023 images so no longer an issue:
https://github.com/systemd/systemd/pull/40069


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
