### PR TITLE
chore: create file system fake

### DIFF
--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -100,9 +100,10 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 	}
 	defer daemonManager.Close()
 
+	resources := system.NewResources(system.RealFileSystem{})
 	daemons := []daemon.Daemon{
-		containerd.NewContainerdDaemon(daemonManager, system.SysfsResources{}),
-		kubelet.NewKubeletDaemon(daemonManager, system.SysfsResources{}),
+		containerd.NewContainerdDaemon(daemonManager, resources),
+		kubelet.NewKubeletDaemon(daemonManager, resources),
 	}
 
 	// to handle edge cases where the cached config is stale (because the user

--- a/nodeadm/internal/system/filesystem.go
+++ b/nodeadm/internal/system/filesystem.go
@@ -1,0 +1,171 @@
+package system
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type FileSystem interface {
+	Glob(pattern string) ([]string, error)
+	ReadFile(name string) ([]byte, error)
+	ReadDir(name string) ([]fs.DirEntry, error)
+	Stat(name string) (fs.FileInfo, error)
+}
+
+type RealFileSystem struct{}
+
+func (RealFileSystem) Glob(pattern string) ([]string, error) {
+	return filepath.Glob(pattern)
+}
+
+func (RealFileSystem) ReadFile(name string) ([]byte, error) {
+	// This has a slight issue since gosec will not flag lines that call RealFileSystem.ReadFile.
+	// #nosec G304 intended usage.
+	return os.ReadFile(name)
+}
+
+func (RealFileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
+	return os.ReadDir(name)
+}
+
+func (RealFileSystem) Stat(name string) (fs.FileInfo, error) {
+	return os.Stat(name)
+}
+
+const EmptyDirectoryMarker = "[empty directory]"
+
+type FakeFileSystem struct {
+	Files map[string]string
+}
+
+func (f FakeFileSystem) allPaths() map[string]bool {
+	paths := make(map[string]bool)
+	for path := range f.Files {
+		paths[path] = true
+		for dir := filepath.Dir(path); dir != "/" && dir != "."; dir = filepath.Dir(dir) {
+			paths[dir] = true
+		}
+	}
+	return paths
+}
+
+func (f FakeFileSystem) Glob(pattern string) ([]string, error) {
+	var matches []string
+	for path := range f.allPaths() {
+		matched, err := filepath.Match(pattern, path)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			matches = append(matches, path)
+		}
+	}
+	return matches, nil
+}
+
+func (f FakeFileSystem) ReadFile(name string) ([]byte, error) {
+	content, ok := f.Files[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	if content == EmptyDirectoryMarker {
+		return nil, &os.PathError{Op: "read", Path: name, Err: os.ErrInvalid}
+	}
+	return []byte(content), nil
+}
+
+func (f FakeFileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
+	name = strings.TrimSuffix(name, "/")
+	if content, ok := f.Files[name]; ok && content != EmptyDirectoryMarker {
+		return nil, &os.PathError{Op: "readdir", Path: name, Err: os.ErrInvalid}
+	}
+
+	var entries []fs.DirEntry
+	seen := make(map[string]bool)
+	prefix := name + "/"
+
+	for path := range f.Files {
+		if !strings.HasPrefix(path, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(path, prefix)
+		parts := strings.SplitN(rest, "/", 2)
+		entryName := parts[0]
+		if seen[entryName] {
+			continue
+		}
+		seen[entryName] = true
+
+		entryPath := name + "/" + entryName
+		entries = append(entries, &fakeEntry{name: entryName, isDir: f.isDir(entryPath)})
+	}
+
+	if len(entries) == 0 {
+		if _, ok := f.Files[name]; !ok {
+			return nil, os.ErrNotExist
+		}
+	}
+	return entries, nil
+}
+
+func (f FakeFileSystem) isDir(name string) bool {
+	if content, ok := f.Files[name]; ok && content == EmptyDirectoryMarker {
+		return true
+	}
+	prefix := name + "/"
+	for path := range f.Files {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f FakeFileSystem) Stat(name string) (fs.FileInfo, error) {
+	name = strings.TrimSuffix(name, "/")
+	if content, ok := f.Files[name]; ok {
+		return &fakeFileInfo{name: filepath.Base(name), isDir: content == EmptyDirectoryMarker, size: int64(len(content))}, nil
+	}
+	if f.isDir(name) {
+		return &fakeFileInfo{name: filepath.Base(name), isDir: true}, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+type fakeEntry struct {
+	name  string
+	isDir bool
+}
+
+func (e *fakeEntry) Name() string { return e.name }
+func (e *fakeEntry) IsDir() bool  { return e.isDir }
+func (e *fakeEntry) Type() fs.FileMode {
+	if e.isDir {
+		return fs.ModeDir
+	}
+	return 0
+}
+func (e *fakeEntry) Info() (fs.FileInfo, error) {
+	return &fakeFileInfo{name: e.name, isDir: e.isDir}, nil
+}
+
+type fakeFileInfo struct {
+	name  string
+	isDir bool
+	size  int64
+}
+
+func (fi *fakeFileInfo) Name() string { return fi.name }
+func (fi *fakeFileInfo) Size() int64  { return fi.size }
+func (fi *fakeFileInfo) Mode() fs.FileMode {
+	if fi.isDir {
+		return fs.ModeDir | 0755
+	}
+	return 0644
+}
+func (fi *fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (fi *fakeFileInfo) IsDir() bool        { return fi.isDir }
+func (fi *fakeFileInfo) Sys() any           { return nil }

--- a/nodeadm/internal/system/resources_test.go
+++ b/nodeadm/internal/system/resources_test.go
@@ -1,0 +1,120 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOnlineMemory(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string
+		expected int64
+	}{
+		{
+			name: "single online block",
+			files: map[string]string{
+				"/sys/devices/system/memory/block_size_bytes": "8000000",
+				"/sys/devices/system/memory/memory0/online":   "1",
+			},
+			expected: 0x8000000,
+		},
+		{
+			name: "multiple blocks mixed online status",
+			files: map[string]string{
+				"/sys/devices/system/memory/block_size_bytes": "8000000",
+				"/sys/devices/system/memory/memory0/online":   "1",
+				"/sys/devices/system/memory/memory1/online":   "0",
+				"/sys/devices/system/memory/memory2/online":   "1",
+			},
+			expected: 0x8000000 * 2,
+		},
+		{
+			name: "no online blocks",
+			files: map[string]string{
+				"/sys/devices/system/memory/block_size_bytes": "8000000",
+				"/sys/devices/system/memory/memory0/online":   "0",
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewResources(FakeFileSystem{Files: tt.files})
+			mem, err := r.GetOnlineMemory()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, mem)
+		})
+	}
+}
+
+func TestGetMilliNumCores_FallbackToCPUCount(t *testing.T) {
+	files := map[string]string{
+		"/sys/devices/system/cpu/cpu0": EmptyDirectoryMarker,
+		"/sys/devices/system/cpu/cpu1": EmptyDirectoryMarker,
+		"/sys/devices/system/cpu/cpu2": EmptyDirectoryMarker,
+		"/sys/devices/system/cpu/cpu3": EmptyDirectoryMarker,
+	}
+	r := NewResources(FakeFileSystem{Files: files})
+	cores, err := r.GetMilliNumCores()
+	assert.NoError(t, err)
+	assert.Equal(t, 4000, cores)
+}
+
+func TestGetMilliNumCores_WithNodeTopology(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string
+		expected int
+	}{
+		{
+			name: "single node with four cpus",
+			files: map[string]string{
+				"/sys/devices/system/node/node0/cpu0": EmptyDirectoryMarker,
+				"/sys/devices/system/node/node0/cpu1": EmptyDirectoryMarker,
+				"/sys/devices/system/node/node0/cpu2": EmptyDirectoryMarker,
+				"/sys/devices/system/node/node0/cpu3": EmptyDirectoryMarker,
+			},
+			expected: 4000,
+		},
+		{
+			name: "two nodes with two cpus each",
+			files: map[string]string{
+				"/sys/devices/system/node/node0/cpu0": EmptyDirectoryMarker,
+				"/sys/devices/system/node/node0/cpu1": EmptyDirectoryMarker,
+				"/sys/devices/system/node/node1/cpu2": EmptyDirectoryMarker,
+				"/sys/devices/system/node/node1/cpu3": EmptyDirectoryMarker,
+			},
+			expected: 4000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewResources(FakeFileSystem{Files: tt.files})
+			cores, err := r.GetMilliNumCores()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, cores)
+		})
+	}
+}
+
+func TestGetMilliNumCores_OfflineCPUs(t *testing.T) {
+	files := map[string]string{
+		"/sys/devices/system/cpu/online":      "0,2-4,6",
+		"/sys/devices/system/node/node0/cpu0": EmptyDirectoryMarker,
+		"/sys/devices/system/node/node0/cpu1": EmptyDirectoryMarker,
+		"/sys/devices/system/node/node1/cpu2": EmptyDirectoryMarker,
+		"/sys/devices/system/node/node1/cpu3": EmptyDirectoryMarker,
+		"/sys/devices/system/node/node2/cpu4": EmptyDirectoryMarker,
+		"/sys/devices/system/node/node2/cpu5": EmptyDirectoryMarker,
+		"/sys/devices/system/node/node3/cpu6": EmptyDirectoryMarker,
+		"/sys/devices/system/node/node4/cpu7": EmptyDirectoryMarker,
+	}
+	r := NewResources(FakeFileSystem{Files: files})
+	cores, err := r.GetMilliNumCores()
+	assert.NoError(t, err)
+	assert.Equal(t, 5000, cores)
+}


### PR DESCRIPTION
Create a file system abstraction and pass it into our resources library so that we can test the resources logic.

Greatly simplify the CPU count logic.

Update some unit tests to use the new file system abstraction.