### PR TITLE
chore: add test timing to e2e tests

### DIFF
--- a/nodeadm/test/e2e/cases/aws-api-connection-timeout/run.sh
+++ b/nodeadm/test/e2e/cases/aws-api-connection-timeout/run.sh
@@ -16,28 +16,21 @@ mock::kubelet 1.29.0
 DEFAULT_MAX_ATTEMPTS=3
 CONNECTION_TIMEOUT=30
 
-# ensure the max retry attempts can be overridden with the standard env var
-# we have to test with values that are different from the default
-MAX_ATTEMPTS_VALUES=(1 2)
+# This must be different from either our default of 30 or the aws default of 3.
+MAX_ATTEMPTS_VALUE=1
 
-for MAX_ATTEMPTS_VALUE in "${MAX_ATTEMPTS_VALUES[@]}"; do
-  if [ "$MAX_ATTEMPTS_VALUE" = "$DEFAULT_MAX_ATTEMPTS" ]; then
-    echo "We can't test with a value ($MAX_ATTEMPTS_VALUE) that is the same as the default!"
-    exit 1
-  fi
-  echo "testing with MAX_ATTEMPTS=${MAX_ATTEMPTS_VALUE}"
-  START=$(date +%s)
-  AWS_MAX_ATTEMPTS=${MAX_ATTEMPTS_VALUE} nodeadm init --development --skip run --config-source file://config.yaml || true
-  END=$(date +%s)
-  SECONDS_ELAPSED=$((END - START))
-  LOWER_BOUND=$((MAX_ATTEMPTS_VALUE * CONNECTION_TIMEOUT))
-  UPPER_BOUND=$((LOWER_BOUND + 5))
-  echo "MAX_ATTEMPTS=${MAX_ATTEMPTS_VALUE} SECONDS_ELAPSED=${SECONDS_ELAPSED}, LOWER_BOUND=${LOWER_BOUND}, UPPER_BOUND=${UPPER_BOUND}"
-  if ! ((SECONDS_ELAPSED >= LOWER_BOUND && SECONDS_ELAPSED <= UPPER_BOUND)); then
-    echo "The observed AWS SDK retry behavior did not fall within the expected range!"
-    exit 1
-  fi
-done
+echo "testing with MAX_ATTEMPTS=${MAX_ATTEMPTS_VALUE}"
+START=$(date +%s)
+AWS_MAX_ATTEMPTS=${MAX_ATTEMPTS_VALUE} nodeadm init --development --skip run --config-source file://config.yaml || true
+END=$(date +%s)
+SECONDS_ELAPSED=$((END - START))
+LOWER_BOUND=$((MAX_ATTEMPTS_VALUE * CONNECTION_TIMEOUT))
+UPPER_BOUND=$((LOWER_BOUND + 5))
+echo "MAX_ATTEMPTS=${MAX_ATTEMPTS_VALUE} SECONDS_ELAPSED=${SECONDS_ELAPSED}, LOWER_BOUND=${LOWER_BOUND}, UPPER_BOUND=${UPPER_BOUND}"
+if ! ((SECONDS_ELAPSED >= LOWER_BOUND && SECONDS_ELAPSED <= UPPER_BOUND)); then
+  echo "The observed AWS SDK retry behavior did not fall within the expected range!"
+  exit 1
+fi
 
 # now, we need to make sure that if no override is specified,
 # we use our increased number of attempts instead of the default

--- a/nodeadm/test/e2e/run.sh
+++ b/nodeadm/test/e2e/run.sh
@@ -61,10 +61,16 @@ function runTest() {
   local logfile
   logfile=$(mktemp)
 
+  local start_time
+  start_time=$(date +%s)
   if docker exec "$containerd_id" ./run.sh > "$logfile" 2>&1; then
-    echo "passed! ✅"
+    local elapsed
+    elapsed=$(($(date +%s) - start_time))
+    echo "passed! ✅ (${elapsed}s)"
   else
-    echo "failed! ❌"
+    local elapsed
+    elapsed=$(($(date +%s) - start_time))
+    echo "failed! ❌ (${elapsed}s)"
     cat "$logfile"
     FAILED="true"
   fi


### PR DESCRIPTION
Track how long each test takes and output it after the pass/fail message.  Also speed up the aws-api test by 70 seconds by only testing one retry count.

