### PR TITLE
fix: set the runtime-cgroup flag

### DIFF
--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -293,6 +293,12 @@ func (ksc *kubeletConfig) withImageServiceEndpoint(cfg *api.NodeConfig, resource
 	}
 }
 
+func (ksc *kubeletConfig) withRuntimeCgroups(flags map[string]string) {
+	// Set runtime cgroups so that cadvisor metrics include container usage.
+	// Reference https://github.com/awslabs/amazon-eks-ami/issues/1667
+	flags["runtime-cgroups"] = "/runtime.slice/containerd.service"
+}
+
 func (k *kubelet) generateKubeletConfig(cfg *api.NodeConfig) (*kubeletConfig, error) {
 	kubeletConfig := defaultKubeletSubConfig()
 
@@ -310,6 +316,7 @@ func (k *kubelet) generateKubeletConfig(cfg *api.NodeConfig) (*kubeletConfig, er
 	kubeletConfig.withCloudProvider(cfg, k.flags)
 	kubeletConfig.withDefaultReservedResources(cfg, k.resources)
 	kubeletConfig.withImageServiceEndpoint(cfg, k.resources)
+	kubeletConfig.withRuntimeCgroups(k.flags)
 
 	nodeLabelFuncs := map[string]LabelProvider{}
 	if semver.Compare(cfg.Status.KubeletVersion, "v1.35.0") >= 0 {

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/containerd.service.d/00-runtime-slice.conf
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/containerd.service.d/00-runtime-slice.conf
@@ -1,2 +1,3 @@
+# Must match runtime-cgroups flag set on kubelet for cadvisor metrics to work.
 [Service]
 Slice=runtime.slice


### PR DESCRIPTION
Set runtime-cgroup flag on the kubelet so that cadvisor metrics will include resource usage for containers.

Fixes: https://github.com/awslabs/amazon-eks-ami/issues/1667

Tests: booted an instance with this flag set and confirmed that the metrics were available.