### PR TITLE
feat: set oom score for ssm-agent

### DIFF
--- a/templates/al2023/runtime/rootfs/etc/systemd/system/amazon-ssm-agent.service.d/00-oom-score.conf
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/amazon-ssm-agent.service.d/00-oom-score.conf
@@ -1,0 +1,4 @@
+[Slice]
+# Ensure that this is not OOM killed before Kubernetes Guaranteed QoS pods.
+# https://github.com/awslabs/amazon-eks-ami/issues/2175
+OOMScoreAdjust=-999


### PR DESCRIPTION
Add systemd drop-ins for this service that it won't get OOM-killed before Guaranteed pods. See https://github.com/awslabs/amazon-eks-ami/issues/2175.