### PR TITLE
feat(nodeadm): add console logging support to nodeadm

### DIFF
--- a/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-boot-hook.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-boot-hook.service
@@ -15,6 +15,7 @@ Before=systemd-networkd-wait-online.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/nodeadm-internal boot-hook
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-config.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-config.service
@@ -9,6 +9,7 @@ After=systemd-networkd-wait-online.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/nodeadm init --skip run --config-source imds://user-data --config-cache /run/eks/nodeadm/config.json
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-run.service
+++ b/templates/al2023/runtime/rootfs/etc/systemd/system/nodeadm-run.service
@@ -9,6 +9,7 @@ Requires=nodeadm-config.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/nodeadm init --skip config --config-source imds://user-data --config-source file:///etc/eks/nodeadm.d/ --config-cache /run/eks/nodeadm/config.json
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

This PR adds a global flag `--console` to enable sending nodeadm logs to the node console. This helps troubleshoot node not joining cluster issues and the access to node is limited.  The global flag `--console` defaults to false to be backward compatible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
