### PR TITLE
fix: initialize logger after parsing command line flags

### DIFF
--- a/nodeadm/internal/cli/main.go
+++ b/nodeadm/internal/cli/main.go
@@ -14,7 +14,6 @@ type Main struct {
 
 func (m *Main) Run() {
 	opts := NewGlobalOptions()
-	log := NewLogger(opts)
 
 	flaggy.SetName(m.Name)
 	flaggy.SetDescription(m.Description)
@@ -27,6 +26,7 @@ func (m *Main) Run() {
 		flaggy.AttachSubcommand(cmd.Flaggy(), 1)
 	}
 	flaggy.Parse()
+	log := NewLogger(opts)
 
 	for _, cmd := range m.Commands {
 		if cmd.Flaggy().Used {


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

Move logger initialization after flaggy.Parse() to make the global flag `--development` work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
