### PR TITLE
Skip nvidia-repo-sync package during verification

### DIFF
--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -105,7 +105,7 @@ if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
 
   # Verify that all nvidia* packages have the same version as the nvidia driver, ensures user-space compatibility.
   # Skips nvidia-container-toolkit because it's independently versioned and released
-  if rpmquery --all --queryformat '%{NAME} %{VERSION}\n' nvidia* | grep -v "$NVIDIA_DRIVER_FULL_VERSION" | grep -v "nvidia-container-toolkit" | grep -v "nvidia-release"; then
+  if rpmquery --all --queryformat '%{NAME} %{VERSION}\n' nvidia* | grep -v "$NVIDIA_DRIVER_FULL_VERSION" | grep -v "nvidia-container-toolkit" | grep -v "nvidia-release" | grep -v "nvidia-repo-s3"; then
     echo "Installed version mismatch for one or more nvidia package(s)!"
     exit 1
   fi


### PR DESCRIPTION
**Description of changes:**

Now that we are installing `nvidia-repo-s3`package to install the correct AL Nvidia repo, we also need to ensure its skipped during ami build validation as its not prudent to the actual nvidia contents of an AMI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.