### PR TITLE
Changes install-worker.sh to download *.gz artifacts.

### DIFF
--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -166,7 +166,7 @@ AWS_DOMAIN=$(imds "/latest/meta-data/services/domain")
 S3_PATH="s3://$BINARY_BUCKET_NAME/$KUBERNETES_VERSION/$KUBERNETES_BUILD_DATE/bin/linux/$ARCH"
 
 BINARIES=(
-  kubelet
+    kubelet
 )
 for binary in "${BINARIES[@]}"; do
   FILES=(
@@ -201,12 +201,21 @@ sudo systemctl enable ebs-initialize-bin@kubelet
 ################################################################################
 
 ECR_CREDENTIAL_PROVIDER_BINARY="ecr-credential-provider"
+FILES=(
+    "$ECR_CREDENTIAL_PROVIDER_BINARY.sha256"
+    "$ECR_CREDENTIAL_PROVIDER_BINARY.gz"
+    "$ECR_CREDENTIAL_PROVIDER_BINARY.gz.sha256"   
+)
+for file in "${FILES[@]}"; do
+    if ! aws s3 cp --region $BINARY_BUCKET_REGION "$S3_PATH/$file" .; then
+	echo "Fetching ${file} from s3 failed, trying again with unauthenticated request."
+	aws s3 cp --no-sign-request --region $BINARY_BUCKET_REGION "$S3_PATH/$file" .
+    fi
+done
 
-if ! aws s3 cp --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .; then
-  echo "Fetching ${ECR_CREDENTIAL_PROVIDER_BINARY} from s3 failed, trying again with unauthenticated request."
-  aws s3 cp --no-sign-request --region $BINARY_BUCKET_REGION $S3_PATH/$ECR_CREDENTIAL_PROVIDER_BINARY .
-fi
-
+sudo sha256sum -c "$ECR_CREDENTIAL_PROVIDER_BINARY.gz.sha256"
+sudo gunzip "$ECR_CREDENTIAL_PROVIDER_BINARY.gz"
+sudo sha256sum -c "$ECR_CREDENTIAL_PROVIDER_BINARY.sha256"
 sudo chmod +x $ECR_CREDENTIAL_PROVIDER_BINARY
 sudo mkdir -p /etc/eks/image-credential-provider
 sudo mv $ECR_CREDENTIAL_PROVIDER_BINARY /etc/eks/image-credential-provider/


### PR DESCRIPTION
**Issue #, if available:** I noticed a broken build with the message `An error occurred (404) when calling the HeadObject operation: Key "1.35.0/2026-02-18/bin/linux/amd64/kubelet" does not exist.`

I checked the output of ./hack/latest-binaries.sh for 1.34 and 1.35 and ran `aws s3 ls` manually against both S3_PATHs and indeed there is no `kubelet`, only `kubelet.gz`.

The same problem occurs with `ecr-credential-provider` and the same fix is applied.

**Description of changes:**
This downloads `$binary.gz` and `$binary.gz.sha256`, checks the sha256sum on the `*.gz`, runs `gunzip`, then proceeds as always with the plain `$binary` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

#WorksInMyPipeline

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
