### PR TITLE
chore: suppress G602 for CPU to reserve

### DIFF
--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -433,6 +433,7 @@ func getCPUMillicoresToReserve(resources system.Resources) int {
 
 	for i, percentageToReserveForRange := range cpuPercentageReservedForRanges {
 		startRange := cpuRanges[i]
+		// #nosec G602 // cpuRanges is one item longer than cpuPercentageReservedForRanges
 		endRange := cpuRanges[i+1]
 		cpuToReserve += getResourceToReserveInRange(totalCPUMillicores, startRange, endRange, percentageToReserveForRange)
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This array index is flagged because there's no implicit guarantee that `i + 1` exists in `cpuRanges` if `i` is based on the length of `cpuPercentageReservedForRanges`. This is informally guaranteed though by the nature of the function, so this just adds a suppression until this can be refactored in a way that avoids this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
