### PR TITLE
chore: drop AL2-specific logic from CI

### DIFF
--- a/.github/actions/ci/build/action.yaml
+++ b/.github/actions/ci/build/action.yaml
@@ -27,18 +27,6 @@ runs:
     - id: build
       shell: bash
       run: |
-        ECR_MISSING_REGION="false"
-        ECR_SCRIPT_PATH=templates/al2/runtime/get-ecr-uri.sh
-        for REGION in $(aws account list-regions | jq -r '.Regions[].RegionName'); do
-          if ! grep -q "${REGION}" "${ECR_SCRIPT_PATH}"; then
-            echo >&2 "ERROR: missing account for ${REGION} in ${ECR_SCRIPT_PATH}"
-            ECR_MISSING_REGION="true"
-          fi
-        done
-        if [ "$ECR_MISSING_REGION" = "true" ]; then
-          exit 1
-        fi
-
         PACKER_GITHUB_API_TOKEN="${{ github.token }}" packer plugins install github.com/hashicorp/amazon
         AMI_NAME="amazon-eks-node-${{ inputs.os_distro }}-${{ inputs.k8s_version }}-${{ inputs.build_id }}"
         make k8s=${{ inputs.k8s_version }} os_distro=${{ inputs.os_distro }} ami_name=${AMI_NAME} ${{ inputs.additional_arguments }}

--- a/.github/actions/ci/kubetest2/action.yaml
+++ b/.github/actions/ci/kubetest2/action.yaml
@@ -34,9 +34,6 @@ runs:
         go install github.com/aws/aws-k8s-tester/...@HEAD
 
         case "${{ inputs.os_distro }}" in
-          al2)
-            KUBETEST2_ARGS="--user-data-format=bootstrap.sh"
-            ;;
           al2023)
             KUBETEST2_ARGS="--user-data-format=nodeadm"
             ;;

--- a/.github/workflows/ci-auto.yaml
+++ b/.github/workflows/ci-auto.yaml
@@ -20,11 +20,6 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
     - run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
     - run: make lint-code
-  templates-test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-    - run: make test
   nodeadm-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -26,8 +26,8 @@ on:
           - "build"
           - "test"
       os_distros:
-        description: 'Operating System Distributions (comma-separated, e.g., al2,al2023)'
-        default: "al2,al2023"
+        description: 'Operating System Distributions (comma-separated, e.g., al2023)'
+        default: "al2023"
         required: false
         type: string
       k8s_versions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,8 @@ on:
         type: string
         default: "test"
       os_distros:
-        description: 'Operating System Distributions (comma-separated, e.g., al2,al2023)'
-        default: "al2,al2023"
+        description: 'Operating System Distributions (comma-separated, e.g., al2023)'
+        default: "al2023"
         required: false
         type: string
       k8s_versions:


### PR DESCRIPTION
AL2 support has been EOL for several months, remove it from the CI logic. Once this is done we can delete the corresponding AL2 code.