### PR TITLE
chore: unpin containerd minor version

### DIFF
--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -10,7 +10,7 @@
     "aws_session_token": "{{env `AWS_SESSION_TOKEN`}}",
     "binary_bucket_name": "amazon-eks",
     "binary_bucket_region": "us-west-2",
-    "containerd_version": "2.1.*",
+    "containerd_version": "2.*",
     "install_containerd_from_s3": "false",
     "creator": "{{env `USER`}}",
     "enable_accelerator": "",


### PR DESCRIPTION
**Issue #, if available:**

Resolves https://github.com/awslabs/amazon-eks-ami/issues/2625

**Description of changes:**

Updating the variable defaults to start consuming the latest minor version in the 2.x branch as AL2023 has started including containerd2.2, and 2.1 reaches upstream EOS in 2 months: https://containerd.io/releases/.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
