### PR TITLE
Improve HyperPod log collection in EKS log collector

### DIFF
--- a/log-collector-script/linux/eks-log-collector.sh
+++ b/log-collector-script/linux/eks-log-collector.sh
@@ -73,6 +73,7 @@ COMMON_DIRECTORIES=(
   nodeadm       # eks
   cni           # eks
   gpu           # eks
+  hyperpod      # sagemaker hyperpod
 )
 
 COMMON_LOGS=(
@@ -327,6 +328,7 @@ collect() {
   get_io_throttled_processes
   get_reboot_history
   get_nvidia_bug_report
+  get_hyperpod_info
 }
 
 pack() {
@@ -968,6 +970,63 @@ get_nvidia_bug_report() {
   else
     timeout 75 nvidia-bug-report.sh --output-file "${COLLECT_DIR}"/gpu/nvidia-bug-report.log &> /dev/null
   fi
+  ok
+}
+
+get_hyperpod_info () {
+  try "Collect SageMaker HyperPod information"
+
+  # Check if this is a HyperPod EKS node by looking for HyperPod components
+  if [[ ! -d "/opt/ml/config/" ]] && [[ ! -d "/var/log/aws/clusters" ]] && [[ ! -d "/var/log/provision" ]] ; then
+      echo "No SageMaker HyperPod components found, skipping HyperPod log collection."
+      return
+  fi
+
+  # Collect complete /opt/ml/config directory
+  if [[ -d "/opt/ml/config/" ]] ; then
+      cp -R "/opt/ml/config/" "${COLLECT_DIR}/hyperpod/opt_ml_config" 2> /dev/null
+  fi
+
+  # Collect complete /etc/opt/ml directory if exists
+  if [[ -d "/etc/opt/ml/" ]] ; then
+      cp -R "/etc/opt/ml/" "${COLLECT_DIR}/hyperpod/etc_opt_ml" 2> /dev/null
+  fi
+
+  # Collect AWS clusters logs (HyperPod specific)
+  if [[ -d "/var/log/aws/clusters" ]] ; then
+      cp -R "/var/log/aws/clusters" "${COLLECT_DIR}/hyperpod/var_log_aws_clusters" 2> /dev/null
+  fi
+
+  # Collect complete HyperPod provisioning logs directory
+  if [[ -d "/var/log/provision" ]] ; then
+      cp -R "/var/log/provision" "${COLLECT_DIR}/hyperpod/var_log_provision" 2> /dev/null
+  fi
+
+  # Collect CloudWatch agent config, logs, and state (skip binaries/docs)
+  if [[ -d "/opt/aws/amazon-cloudwatch-agent/" ]] ; then
+      mkdir -p "${COLLECT_DIR}/hyperpod/cloudwatch_agent_config"
+      for subdir in etc logs var; do
+          if [[ -d "/opt/aws/amazon-cloudwatch-agent/${subdir}" ]] ; then
+              cp -R "/opt/aws/amazon-cloudwatch-agent/${subdir}" "${COLLECT_DIR}/hyperpod/cloudwatch_agent_config/" 2> /dev/null
+          fi
+      done
+  fi
+
+  # Collect GPU diagnostics if NVIDIA devices are present
+  if [[ -e /dev/nvidia0 ]] && command -v nvidia-smi > /dev/null 2>&1 ; then
+      timeout 75 nvidia-smi > "${COLLECT_DIR}/hyperpod/nvidia-smi.log" 2>&1
+      timeout 75 nvidia-smi -q > "${COLLECT_DIR}/hyperpod/nvidia-smi-q.log" 2>&1
+  fi
+
+  # Collect HyperPod observability add-on logs if present
+  if command -v kubectl > /dev/null 2>&1 ; then
+      timeout 75 kubectl get pods -n hyperpod-observability > "${COLLECT_DIR}/hyperpod/hyperpod-observability-pods.log" 2>&1
+      timeout 75 kubectl logs -n hyperpod-observability --all-containers --tail=-1000 > "${COLLECT_DIR}/hyperpod/hyperpod-observability-logs.log" 2>&1
+
+      timeout 75 kubectl get pods -n hyperpod-inference-system > "${COLLECT_DIR}/hyperpod/hyperpod-inference-system-pods.log" 2>&1
+      timeout 75 kubectl logs -n hyperpod-inference-system --all-containers --tail=-1000 > "${COLLECT_DIR}/hyperpod/hyperpod-inference-system-logs.log" 2>&1
+  fi
+
   ok
 }
 


### PR DESCRIPTION
**Issue #, if available:**

SageMaker HyperPod EKS clusters run on AWS managed instances where node level troubleshooting data is critical for support cases. 

Created `get_hyperpod_info` function to collects HyperPod specific config file and GPU diagnostics.

**Description of changes:**

Wrote `get_hyperpod_info` to improve HyperPod log collection coverage:

1. **Hyperpod config config collection**: Collect config files from `/opt/ml/config/` and `/etc/opt/ml/` directories.
2. **CloudWatch agent**: Collect `etc/`, `logs/`, and `var/` subdirectories from `/opt/aws/amazon-cloudwatch-agent/` instead of a single config file. Skips binaries (`bin/`), `THIRD-PARTY-LICENSES` (~170KB), `RELEASE_NOTES`, and `doc/` which aren't useful for troubleshooting.
3. **GPU diagnostics**: Add `nvidia-smi` and `nvidia-smi -q` capture gated on `/dev/nvidia0` device presence, providing a quick-parse GPU health snapshot within the HyperPod section.
4. **hyperpod namespace**: Add `kubectl get pods` and `kubectl logs` collection for the `hyperpod-inference-system` namespace and `hyperpod-observability` collection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

- Verified on a HyperPod EKS node that `/opt/ml/config/` and `/etc/opt/ml/` are fully captured
- Verified CloudWatch agent collection only includes `etc/`, `logs/`, and `var/` subdirectories
- Confirmed `nvidia-smi` collection is skipped on nodes without `/dev/nvidia0`
- Confirmed hyperpod related pod listing and logs are captured when the namespace exists
- Verified no regressions on non-HyperPod EKS nodes (function exits early when no HyperPod components detected)
