### PR TITLE
bump the go version to 1.25.9

### DIFF
--- a/nodeadm/go.mod
+++ b/nodeadm/go.mod
@@ -1,6 +1,6 @@
 module github.com/awslabs/amazon-eks-ami/nodeadm
 
-go 1.25.7
+go 1.25.9
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
**Issue #, if available:**
* bump go version to 1.25.9 to fix critical CVEs

**Description of changes:**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
