### PR TITLE
Grab pinned kernel packages for 6.18

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-driver.sh
+++ b/templates/al2023/provisioners/install-nvidia-driver.sh
@@ -100,6 +100,11 @@ KERNEL_PACKAGE="kernel"
 if [[ "$(uname -r)" == 6.12.* ]]; then
   KERNEL_PACKAGE="kernel6.12"
 fi
+
+if [[ "$(uname -r)" == 6.18.* ]]; then
+  KERNEL_PACKAGE="kernel6.18"
+fi
+
 sudo dnf -y install \
   "${KERNEL_PACKAGE}-devel" \
   "${KERNEL_PACKAGE}-headers" \


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

The latest AL2023 release changes include the rename of all kernel 6.18 packages to the namespace package kernel6.18. This PR updates all locations that we install previous non-namespaced kernel packages. This will be used for K8s 1.36.

    https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes-2023.11.20260413.html#amis-2023.11.20260413.Default-Kernel-6-18-AMI
    https://docs.aws.amazon.com/linux/al2023/ug/kernel-update.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
