### PR TITLE
Pin 6.18 kernel for neuron and base

### DIFF
--- a/templates/al2023/provisioners/install-neuron-driver.sh
+++ b/templates/al2023/provisioners/install-neuron-driver.sh
@@ -54,6 +54,11 @@ KERNEL_PACKAGE="kernel"
 if [[ "$(uname -r)" == 6.12.* ]]; then
   KERNEL_PACKAGE="kernel6.12"
 fi
+
+if [[ "$(uname -r)" == 6.18.* ]]; then
+  KERNEL_PACKAGE="kernel6.18"
+fi
+
 sudo dnf -y install \
   "${KERNEL_PACKAGE}-devel" \
   "${KERNEL_PACKAGE}-headers"

--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -73,6 +73,11 @@ KERNEL_PACKAGE="kernel"
 if [[ "$(uname -r)" == 6.12.* ]]; then
   KERNEL_PACKAGE="kernel6.12"
 fi
+
+if [[ "$(uname -r)" == 6.18.* ]]; then
+  KERNEL_PACKAGE="kernel6.18"
+fi
+
 sudo dnf -y install \
   "${KERNEL_PACKAGE}-devel" \
   "${KERNEL_PACKAGE}-headers"


### PR DESCRIPTION
**Description of changes:**

Per last PR, https://github.com/awslabs/amazon-eks-ami/pull/2689, also update Neuron and Base variants with pinned 6.18 for K8s versions 1.36

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.