### PR TITLE
chore(build): install efa kmod by default

### DIFF
--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -14,7 +14,7 @@
     "install_containerd_from_s3": "false",
     "creator": "{{env `USER`}}",
     "enable_accelerator": "",
-    "enable_efa": "false",
+    "enable_efa": "true",
     "enable_fips": "false",
     "encrypted": "false",
     "iam_instance_profile": "",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Defaults the `enable_efa` flag to true so that all AMI variants will, by default, have the latest EFA kernel module installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
