### PR TITLE
fix(nodeadm): restart containerd in EnsureRunning() to load new config

### DIFF
--- a/nodeadm/internal/containerd/daemon.go
+++ b/nodeadm/internal/containerd/daemon.go
@@ -33,7 +33,7 @@ func (cd *containerd) Configure(c *api.NodeConfig) error {
 }
 
 func (cd *containerd) EnsureRunning() error {
-	return cd.daemonManager.StartDaemon(ContainerdDaemonName)
+	return cd.daemonManager.RestartDaemon(ContainerdDaemonName)
 }
 
 func (cd *containerd) PostLaunch(c *api.NodeConfig) error {

--- a/nodeadm/internal/kubelet/daemon.go
+++ b/nodeadm/internal/kubelet/daemon.go
@@ -51,7 +51,7 @@ func (k *kubelet) Configure(cfg *api.NodeConfig) error {
 }
 
 func (k *kubelet) EnsureRunning() error {
-	return k.daemonManager.StartDaemon(KubeletDaemonName)
+	return k.daemonManager.RestartDaemon(KubeletDaemonName)
 }
 
 func (k *kubelet) PostLaunch(_ *api.NodeConfig) error {


### PR DESCRIPTION
**Issue #, if available:**
  
Fixes #2702
  
**Description of changes:**
  
`containerd.EnsureRunning()` calls `StartDaemon` which maps to systemd's `StartUnit`. If containerd is already running (e.g., enabled at boot), `StartUnit` is a no-op — containerd continues with the old config and never loads the new `config.toml` written by `Configure()`.
  
This change replaces `StartDaemon` with `RestartDaemon` (which maps to systemd's `RestartUnit`). `RestartDaemon` restarts the service if running (loading new config) or starts it if not — matching the `Daemon.EnsureRunning()` interface contract:
  > * If the daemon is not running, it will be started.
  > * If the daemon is already running, and has been re-configured, it will be restarted.
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
  
  **Testing Done**
  
Tested on a live AL2023 EKS 1.31 node (`amazon-eks-node-al2023-x86_64-standard-1.31`, containerd 2.x) by building the patched `nodeadm` binary and replacing `/usr/bin/nodeadm` on the instance.
  
**Steps to reproduce and validate:**
  
```bash
# 1. Set SystemdCgroup to false and restart containerd to load it
sudo sed -i 's/SystemdCgroup = true/SystemdCgroup = false/' /etc/containerd/config.toml
systemctl restart containerd
  
# 2. Confirm containerd is running with old config
cat /etc/containerd/config.toml | grep Systemd
# SystemdCgroup = false
crictl info 2>/dev/null | jq '.config.containerd.runtimes.runc.options.SystemdCgroup'
# false
systemctl show containerd --property=ActiveEnterTimestamp
 # ActiveEnterTimestamp=Wed 2026-05-06 09:02:05 UTC
  
# 3. Run nodeadm init with the patched binary
nodeadm init --config-source file:///etc/nodeConfig.yaml
  
# 4. Verify containerd was restarted and new config is loaded
cat /etc/containerd/config.toml | grep Systemd
# SystemdCgroup = true
crictl info 2>/dev/null | jq '.config.containerd.runtimes.runc.options.SystemdCgroup'
# true
systemctl show containerd --property=ActiveEnterTimestamp
# ActiveEnterTimestamp=Wed 2026-05-06 09:02:53 UTC  <-- timestamp changed, restart happened
```

**Result:** After nodeadm init, containerd was restarted (timestamp changed from 09:02:05 to 09:02:53) and the in-memory config reflects the new value (SystemdCgroup= true). Without the fix, the timestamp would remain unchanged and crictl info would still show false.