### PR TITLE
feat: use igzip for faster container image layer decompression

### DIFF
--- a/nodeadm/internal/containerd/snapshotter/soci-snapshotter.config.toml
+++ b/nodeadm/internal/containerd/snapshotter/soci-snapshotter.config.toml
@@ -17,5 +17,5 @@ max_concurrent_unpacks = -1
 max_concurrent_unpacks_per_image = 12
 
 [pull_modes.parallel_pull_unpack.decompress_streams."gzip"]
-path = '/usr/bin/unpigz'
+path = '/usr/bin/igzip'
 args = ['-d', '-c']

--- a/templates/al2023/provisioners/install-worker.sh
+++ b/templates/al2023/provisioners/install-worker.sh
@@ -67,6 +67,10 @@ sudo dnf install -y \
   pigz \
   python3-dnf-plugin-versionlock
 
+# Install isa-l-tools from SPAL for faster gzip decompression (used by containerd and SOCI)
+sudo dnf install -y spal-release
+sudo dnf install -y isa-l-tools
+
 # we need to handle different kernel packages depending on the namespace
 # associated with the minor version.
 KERNEL_PACKAGE="kernel"

--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -31,7 +31,7 @@ validate_file_nonexists '/var/log/cloud-init.log'
 validate_file_nonexists '/var/log/secure'
 validate_file_nonexists '/var/log/wtmp'
 
-REQUIRED_COMMANDS=(unpigz)
+REQUIRED_COMMANDS=(unpigz igzip)
 
 for ENTRY in "${REQUIRED_COMMANDS[@]}"; do
   if ! command -v "$ENTRY" > /dev/null; then


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Install isa-l-tools from SPAL and configure the SOCI to use igzip instead of unpigz for gzip decompression during container image layer unpacking.
It benefits two image pull paths:
Standard containerd pull — containerd auto-detects igzip in PATH and uses it for layer decompression. No config change needed.
SOCI/FastImagePull — SOCI uses the binary explicitly configured in its config file. Updated from /usr/bin/unpigz to /usr/bin/igzip
https://github.com/amazonlinux/amazon-linux-2023/issues/1091

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Testing Done**
Built AMIs for both x86_64 and arm64, launched clusters, and verified containerd uses igzip during image pulls by monitoring processes during ctr image pull.


*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
