### PR TITLE
fix:  update the nodeadm_build_image to 1.26

### DIFF
--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -20,7 +20,7 @@
     "iam_instance_profile": "",
     "kms_key_id": "",
     "launch_block_device_mappings_volume_size": "20",
-    "nodeadm_build_image": "public.ecr.aws/eks-distro-build-tooling/golang:1.25",
+    "nodeadm_build_image": "public.ecr.aws/eks-distro-build-tooling/golang:1.26",
     "nvidia_driver_major_version": "580",
     "nvidia_repository_url": null,
     "nvidia_grid_runfile_bucket_name": "ec2-linux-nvidia-drivers",


### PR DESCRIPTION
**Issue #, if available:**

Fixes: https://github.com/awslabs/amazon-eks-ami/actions/runs/25469656713/job/74730631422#step:4:2947

**Description of changes:**

Recently bumped up golang to 1.26 but forgot to bump up image here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
