### PR TITLE
fix(nodeadm): import sandbox image into SOCI snapshotter before kubel…

### DIFF
--- a/nodeadm/internal/containerd/daemon.go
+++ b/nodeadm/internal/containerd/daemon.go
@@ -29,7 +29,13 @@ func (cd *containerd) Configure(c *api.NodeConfig) error {
 	if err := writeSnapshotterConfig(c, cd.resources); err != nil {
 		return err
 	}
-	return writeContainerdConfig(c, cd.resources)
+	if err := writeContainerdConfig(c, cd.resources); err != nil {
+		return err
+	}
+	if err := writeSOCIServiceDependency(c, cd.resources); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (cd *containerd) EnsureRunning() error {
@@ -37,6 +43,11 @@ func (cd *containerd) EnsureRunning() error {
 }
 
 func (cd *containerd) PostLaunch(c *api.NodeConfig) error {
+	if UseSOCISnapshotter(c, cd.resources) {
+		if err := importSandboxImageForSOCI(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/nodeadm/internal/containerd/sandbox_image.go
+++ b/nodeadm/internal/containerd/sandbox_image.go
@@ -1,0 +1,84 @@
+package containerd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"go.uber.org/zap"
+
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/system"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
+)
+
+const (
+	// pauseImageArchive is the path to the pre-cached pause container image tarball,
+	// created during AMI build by the cache-pause-container script.
+	pauseImageArchive = "/etc/eks/pause.tar"
+
+	// sociDependencyDropInPath is the systemd drop-in that makes containerd.service
+	// depend on soci-snapshotter.service. This ensures the SOCI gRPC server is
+	// fully ready (Type=notify) before containerd is considered active.
+	sociDependencyDropInPath = "/etc/systemd/system/containerd.service.d/10-soci-snapshotter.conf"
+	sociDependencyDropIn     = `[Unit]
+Requires=soci-snapshotter.service
+After=soci-snapshotter.service
+`
+)
+
+// writeSOCIServiceDependency writes a systemd drop-in for containerd.service that
+// adds a hard dependency on soci-snapshotter.service. Because soci-snapshotter is
+// Type=notify, systemd will not consider it active until its gRPC server sends
+// READY=1. This guarantees that when EnsureRunning() returns after starting
+// containerd, the SOCI snapshotter is fully initialized and ready to serve requests.
+func writeSOCIServiceDependency(cfg *api.NodeConfig, resources system.Resources) error {
+	if !UseSOCISnapshotter(cfg, resources) {
+		return nil
+	}
+	zap.L().Info("Writing SOCI dependency drop-in for containerd.service")
+	if err := util.WriteFileWithDir(sociDependencyDropInPath, []byte(sociDependencyDropIn), configPerm); err != nil {
+		return fmt.Errorf("writing SOCI dependency drop-in: %w", err)
+	}
+	if output, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
+		return fmt.Errorf("reloading systemd after writing drop-in: %w, output: %s", err, string(output))
+	}
+	return nil
+}
+
+// importSandboxImageForSOCI imports the pre-cached pause image tarball into the
+// SOCI snapshotter's store. This is necessary because the pause image is cached
+// during AMI build using the default overlayfs snapshotter, so its layers are not
+// available in the SOCI snapshotter's store. Without this, containerd 2.2.3 would
+// attempt to fetch the pause image layer headers from ECR at sandbox creation time,
+// which fails because ECR credentials are not yet available (kubelet's credential
+// provider hasn't initialized).
+//
+// By the time this function runs, the SOCI snapshotter is guaranteed to be ready
+// because writeSOCIServiceDependency() adds a systemd ordering constraint ensuring
+// soci-snapshotter.service is active before containerd.service starts.
+func importSandboxImageForSOCI() error {
+	if _, err := os.Stat(pauseImageArchive); err != nil {
+		if os.IsNotExist(err) {
+			zap.L().Warn("Pause image archive not found, skipping SOCI import", zap.String("path", pauseImageArchive))
+			return nil
+		}
+		return fmt.Errorf("checking pause image archive: %w", err)
+	}
+
+	zap.L().Info("Importing pause image into SOCI snapshotter", zap.String("path", pauseImageArchive))
+	cmd := exec.Command("ctr",
+		"--namespace", "k8s.io",
+		"images", "import",
+		"--snapshotter", "soci",
+		"--discard-unpacked-layers=false",
+		"--local",
+		pauseImageArchive,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("importing pause image into SOCI snapshotter: %w, output: %s", err, string(output))
+	}
+	zap.L().Info("Successfully imported pause image into SOCI snapshotter")
+	return nil
+}


### PR DESCRIPTION
**Issue #, if available:**

Fixes: https://github.com/awslabs/amazon-eks-ami/issues/2710

**Description of changes:**

A behavioral change in containerd 2.2.3 ([containerd/containerd#12835](https://github.com/containerd/containerd/pull/12835)) causes pod sandbox creation to deadlock when FastImagePull (SOCI snapshotter) is enabled.

In containerd 2.2.1, the pinned sandbox image was handled without routing through the configured CRI snapshotter. In 2.2.3, containerd now routes all image unpacks through the target snapshotter and attempts to populate per-layer snapshot labels by fetching layer header metadata from the source registry. When SOCI receives the unpack request for the pause image, it doesn't have the layer in its local store (it was only cached in overlayfs during AMI build), so it attempts to fetch layer header info from ECR to resolve snapshot annotations. This fails because ECR credentials depend on kubelet's credential provider, which depends on pods running, which depends on the sandbox container, creating a deadlock.

This change does two things:

1. During the Configure phase, when SOCI is enabled, writes a systemd drop-in for containerd.service that adds `Requires=soci-snapshotter.service` and `After=soci-snapshotter.service`. Because soci-snapshotter is `Type=notify`, systemd will not consider it active until its gRPC server sends `READY=1`. This guarantees that when `EnsureRunning()` starts containerd, the SOCI snapshotter is fully initialized and ready to serve requests.

2. During `PostLaunch` (after containerd and SOCI are running, before kubelet starts), imports `/etc/eks/pause.tar` into the SOCI snapshotter's store using `ctr images import --snapshotter soci --local`. The `--local` flag reads entirely from the on-disk tarball without any network or registry access. This makes `IsUnpacked(ctx, "soci")` return true before kubelet's first `RunPodSandbox` call, so the new `unpackImage` code path is never entered for the sandbox image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

- Built AMI with this change (containerd 2.2.3)
- Launched 20 nodes with `FastImagePull: true` in NodeConfig user-data and confirmed all nodes join and are healthy
- Verified all system pods (aws-node, kube-proxy, eks-pod-identity-agent) start successfully