### PR TITLE
fix: use WORKING_DIR in install efa script

### DIFF
--- a/templates/al2023/provisioners/install-efa.sh
+++ b/templates/al2023/provisioners/install-efa.sh
@@ -21,8 +21,9 @@ if [[ "${PARTITION}" =~ ^aws-iso ]]; then
   EFA_URL="https://aws-efa-installer.s3.${AWS_REGION}.${AWS_DOMAIN}"
 fi
 
-mkdir -p /tmp/efa-installer
-cd /tmp/efa-installer
+EFA_INSTALL_DIR="${WORKING_DIR}/efa-installer"
+mkdir -p "${EFA_INSTALL_DIR}"
+cd "${EFA_INSTALL_DIR}"
 
 #https://github.com/amazonlinux/amazon-linux-2023/issues/243
 sudo dnf swap -y gnupg2-minimal gnupg2-full
@@ -52,5 +53,5 @@ tar -xf ${EFA_PACKAGE} && cd aws-efa-installer
 sudo ./efa_installer.sh --minimal -y
 
 cd -
-sudo rm -rf /tmp/efa-installer
+sudo rm -rf "${EFA_INSTALL_DIR}"
 sudo dnf swap -y gnupg2-full gnupg2-minimal

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -284,7 +284,8 @@
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
         "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",
         "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}",
-        "ENABLE_EFA={{user `enable_efa`}}"
+        "ENABLE_EFA={{user `enable_efa`}}",
+        "WORKING_DIR={{user `working_dir`}}"
       ]
     },
     {


### PR DESCRIPTION
**Issue #, if available:**

Fixes #2725 

**Description of changes:**

install-efa.sh hard-codes /tmp as its working directory. On hardened images with noexec on /tmp, the build fails. This replaces it with WORKING_DIR, matching the pattern used by the other provisioner scripts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Confirmed script execution fails from a noexec-mounted /tmp and succeeds from a non-noexec path.
Verified EFA now installs at the workdir path
