### PR TITLE
fix(nodeadm): refer to default sandbox image as :latest

### DIFF
--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -201,7 +201,7 @@ func (*initCmd) enrichConfig(log *zap.Logger, cfg *api.NodeConfig, opts *cli.Glo
 	log.Info("Instance details populated", zap.Reflect("details", instanceDetails))
 	log.Info("Fetching default options...")
 	cfg.Status.Defaults = api.DefaultOptions{
-		SandboxImage: "localhost/kubernetes/pause",
+		SandboxImage: "localhost/kubernetes/pause:latest",
 	}
 	log.Info("Default options populated", zap.Reflect("defaults", cfg.Status.Defaults))
 	return nil

--- a/nodeadm/test/e2e/cases/containerdv1-config/expected-containerd-config-pre-1.32.toml
+++ b/nodeadm/test/e2e/cases/containerdv1-config/expected-containerd-config-pre-1.32.toml
@@ -8,7 +8,7 @@ address = '/run/foo/foo.sock'
 [plugins]
 [plugins.'io.containerd.grpc.v1.cri']
 enable_cdi = false
-sandbox_image = 'localhost/kubernetes/pause'
+sandbox_image = 'localhost/kubernetes/pause:latest'
 
 [plugins.'io.containerd.grpc.v1.cri'.cni]
 bin_dir = '/opt/cni/bin'

--- a/nodeadm/test/e2e/cases/containerdv1-config/expected-containerd-config.toml
+++ b/nodeadm/test/e2e/cases/containerdv1-config/expected-containerd-config.toml
@@ -8,7 +8,7 @@ address = '/run/foo/foo.sock'
 [plugins]
 [plugins.'io.containerd.grpc.v1.cri']
 enable_cdi = true
-sandbox_image = 'localhost/kubernetes/pause'
+sandbox_image = 'localhost/kubernetes/pause:latest'
 
 [plugins.'io.containerd.grpc.v1.cri'.cni]
 bin_dir = '/opt/cni/bin'

--- a/nodeadm/test/e2e/cases/containerdv1-runtime-config-neuron/expected-containerd-config.toml
+++ b/nodeadm/test/e2e/cases/containerdv1-runtime-config-neuron/expected-containerd-config.toml
@@ -8,7 +8,7 @@ address = '/run/foo/foo.sock'
 [plugins]
 [plugins.'io.containerd.grpc.v1.cri']
 enable_cdi = false
-sandbox_image = 'localhost/kubernetes/pause'
+sandbox_image = 'localhost/kubernetes/pause:latest'
 
 [plugins.'io.containerd.grpc.v1.cri'.cni]
 bin_dir = '/opt/cni/bin'

--- a/nodeadm/test/e2e/cases/containerdv1-runtime-config-nvidia/expected-containerd-config.toml
+++ b/nodeadm/test/e2e/cases/containerdv1-runtime-config-nvidia/expected-containerd-config.toml
@@ -8,7 +8,7 @@ address = '/run/foo/foo.sock'
 [plugins]
 [plugins.'io.containerd.grpc.v1.cri']
 enable_cdi = false
-sandbox_image = 'localhost/kubernetes/pause'
+sandbox_image = 'localhost/kubernetes/pause:latest'
 
 [plugins.'io.containerd.grpc.v1.cri'.cni]
 bin_dir = '/opt/cni/bin'


### PR DESCRIPTION
**Issue #, if available:** #2729

**Description of changes:** cache-pause-container stores the pause image in containerd's image store as "localhost/kubernetes/pause:latest". In containerd, the CRI sandbox lookup of "pinned_images.sandbox" queries the image store with the configured value verbatim (possibly there is a normalization step missing in containerd), so the stored reference must match exactly.

Configure the default sandbox reference explicitly with a tag so it matches what cache-pause-container writes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Used the compiled nodeadm as a drop-in replacement in the setup described in #2729, i.e.

- containerd: v2.3.0 (overlayfs snapshotter, default podsandbox controller)
- FastImagePull/SOCI: not enabled
- boot or reboot a node in an EKS cluster

When the node previously failed to become _Ready_, with the patched nodeadm it becomes healthy (with the default daemon sets deployed) and is ready to accept workloads.
