### PR TITLE
fix(ci): unsetting git maintanence mode to fix ci failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           ref: 'main'
+      # https://github.com/actions/checkout/issues/2437
+      - run: git config --global maintenance.auto false
       - uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # 6.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
## Problem
`go install sigs.k8s.io/kubetest2/...@latest` in the kubetest2 CI action fails deterministically with:

```
github.com/jmespath/go-jmespath@v0.4.1-0.20220621161143-b0104c826a24: invalid pseudo-version:
git fetch --unshallow -f --end-of-options origin in /home/runner/go/pkg/mod/cache/vcs/...:
exit status 128:
    fatal: shallow file has changed since we read it
```
This breaks /ci workflows in all PR's. Example failing run: https://github.com/awslabs/amazon-eks-ami/actions/runs/26553883433

 - The `ubuntu-latest` runner image started using Git v2.54.0: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
 - Git `v2.54.0` changed the default GC strategy from `gc` to `geometric` ([commit `50d7425767`](https://github.com/git/git/commit/50d742576777503eebd9f0f2c6410f64a872a10a)), so `gc.auto=0` no longer suppresses background maintenance.  The new equivalent is `maintenance.auto=false`.

`actions/checkout` sets `gc.auto=0` specifically to prevent background git operations from interfering with subsequent commands. With Git `v2.54.0`, that protection no longer takes effect, so background maintenance ends up racing with the parallel `git fetch --unshallow` operations that come with `go install` commands using `GOPROXY=direct`: https://github.com/actions/checkout/issues/2437

## Fix

Set `git config --global maintenance.auto false` after `actions/checkout` in `ci.yaml`. 

## Test

Testing was a little weird because `ci.yaml` is dispatched by the `/ci` bot with `ref: 'main'`: https://github.com/awslabs/amazon-eks-ami/blob/9c74333d905eacb8ab2076436104d98b5a5adafe/.github/actions/bot/index.js#L284

So PR-branch changes to `ci.yaml` cannot be not exercised pre-merge. 

I validated the fix by triggering two temporary jobs via `ci-auto.yaml` (which triggers from the PR branch HEAD)
https://github.com/awslabs/amazon-eks-ami/actions/runs/26560360540/job/78241603693