### PR TITLE
fix: remove efa_nv_peermem.conf modules-load drop-in on non-NVIDIA AMIs

### DIFF
--- a/templates/al2023/provisioners/install-efa.sh
+++ b/templates/al2023/provisioners/install-efa.sh
@@ -55,3 +55,13 @@ sudo ./efa_installer.sh --minimal -y
 cd -
 sudo rm -rf "${EFA_INSTALL_DIR}"
 sudo dnf swap -y gnupg2-full gnupg2-minimal
+
+##########################################################################################
+### Remove NVIDIA peer memory modules-load drop-in on non-NVIDIA AMIs ####################
+### The EFA installer adds /etc/modules-load.d/efa_nv_peermem.conf, which tries to load ##
+### the nvidia kmod at boot. On non-NVIDIA AMIs there is no nvidia driver resulting in  ##
+### load failure                                                                        ##
+##########################################################################################
+if [ "${ENABLE_ACCELERATOR:-}" != "nvidia" ]; then
+  sudo rm -f /etc/modules-load.d/efa_nv_peermem.conf
+fi

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -284,6 +284,7 @@
         "AWS_SESSION_TOKEN={{user `aws_session_token`}}",
         "BINARY_BUCKET_NAME={{user `binary_bucket_name`}}",
         "BINARY_BUCKET_REGION={{user `binary_bucket_region`}}",
+        "ENABLE_ACCELERATOR={{user `enable_accelerator`}}",
         "ENABLE_EFA={{user `enable_efa`}}",
         "WORKING_DIR={{user `working_dir`}}"
       ]


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
The EFA installer adds `/etc/modules-load.d/efa_nv_peermem.conf`, which tries to load the nvidia kmod at boot. Since v20260505 (when #2697 enabled EFA by default for all variants), this file ships on non-NVIDIA AMIs where there is no nvidia driver, causing the load to fail. 

Changes: Remove the file after the EFA installer runs unless the AMI is the Nvidia variant.


**Testing Done**
Built an AL2023 ARM64 standard AMI from this branch and launched it with SELinux set to enforcing (CIS-hardened scenario). Confirmed /etc/modules-load.d/efa_nv_peermem.conf is absent and systemd-modules-load.service boots cleanly with no nvidia load attempt.
