### PR TITLE
fix: maxPods for ipv6 clusters

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -17,7 +17,8 @@ By default, the maximum number of pods able to be scheduled on a node is based o
 available, which is determined by the instance type. Larger instances generally have more ENIs. The
 number of ENIs limits how many IPv4 addresses are available on an instance, and
 we need one IP address per pod. For IPv6 clusters, the IP count per ENI is not a constraint, so the
-default max pods value is 110 (the kubelet default). You can reference [this file](https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/internal/kubelet/eni_max_pods.go)
+max pods value is `max(110, ENI-formula)` — small instances get at least 110 pods while large
+instances keep their higher ENI-based value. You can reference [this file](https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/internal/kubelet/eni_max_pods.go)
 for the code that generates these values.
 
 As an optimization, the default values for all known instance types are cached in the AMI. If an

--- a/doc/development.md
+++ b/doc/development.md
@@ -15,8 +15,9 @@ hack/mkdocs.sh serve
 
 By default, the maximum number of pods able to be scheduled on a node is based off of the number of ENIs
 available, which is determined by the instance type. Larger instances generally have more ENIs. The
-number of ENIs limits how many IPV4 addresses are available on an instance, and
-we need one IP address per pod. You can reference [this file](https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/internal/kubelet/eni_max_pods.go)
+number of ENIs limits how many IPv4 addresses are available on an instance, and
+we need one IP address per pod. For IPv6 clusters, the IP count per ENI is not a constraint, so the
+default max pods value is 110 (the kubelet default). You can reference [this file](https://github.com/awslabs/amazon-eks-ami/blob/main/nodeadm/internal/kubelet/eni_max_pods.go)
 for the code that generates these values.
 
 As an optimization, the default values for all known instance types are cached in the AMI. If an

--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -168,7 +168,7 @@ as a [CEL](https://cel.dev/overview/cel-overview) expression with three variable
 
 * `default_enis` - the maximum number of network interfaces attachable on the default network card
 * `ips_per_eni` - the maximum number of IPv4 addresses attachable to a single interface
-* `max_pods` - the standard `maxPods` for the current instance type. This can be equivalently expressed in CEL as `(default_enis * (ips_per_eni - 1)) + 2`
+* `max_pods` - the standard `maxPods` for the current instance type. For IPv4 clusters, this can be equivalently expressed in CEL as `(default_enis * (ips_per_eni - 1)) + 2`. For IPv6 clusters, this is always 110 since the IP count per ENI is not a constraint.
 
 ⚠️ **Note**: These values will vary between instance types and may require `ec2:DescribeInstanceTypes` API calls. Expressions should be tested to confirm desired outputs before final use in the intended environment.
 

--- a/nodeadm/doc/examples.md
+++ b/nodeadm/doc/examples.md
@@ -168,7 +168,7 @@ as a [CEL](https://cel.dev/overview/cel-overview) expression with three variable
 
 * `default_enis` - the maximum number of network interfaces attachable on the default network card
 * `ips_per_eni` - the maximum number of IPv4 addresses attachable to a single interface
-* `max_pods` - the standard `maxPods` for the current instance type. For IPv4 clusters, this can be equivalently expressed in CEL as `(default_enis * (ips_per_eni - 1)) + 2`. For IPv6 clusters, this is always 110 since the IP count per ENI is not a constraint.
+* `max_pods` - the standard `maxPods` for the current instance type. For IPv4 clusters, this can be equivalently expressed in CEL as `(default_enis * (ips_per_eni - 1)) + 2`. For IPv6 clusters, this is `max(110, (default_enis * (ips_per_eni - 1)) + 2)` since the IP count per ENI is not a constraint — small instances get at least 110, large instances keep their higher ENI-based value.
 
 ⚠️ **Note**: These values will vary between instance types and may require `ec2:DescribeInstanceTypes` API calls. Expressions should be tested to confirm desired outputs before final use in the intended environment.
 

--- a/nodeadm/internal/kubelet/config.go
+++ b/nodeadm/internal/kubelet/config.go
@@ -274,11 +274,12 @@ func (ksc *kubeletConfig) withCloudProvider(cfg *api.NodeConfig, flags map[strin
 func (ksc *kubeletConfig) withDefaultReservedResources(cfg *api.NodeConfig, resources system.Resources) {
 	ksc.SystemReservedCgroup = ptr.String("/system")
 	ksc.KubeReservedCgroup = ptr.String("/runtime")
+	ipFamily, _ := api.GetCIDRIpFamily(cfg.Spec.Cluster.CIDR)
 	if instanceInfo, err := GetInstanceInfo(context.TODO(), cfg.Status.Instance.Region, cfg.Status.Instance.Type); err != nil {
 		zap.L().Warn("Failed to retrieve instance info, falling back to default", zap.Error(err))
 		ksc.MaxPods = defaultMaxPods
 	} else {
-		ksc.MaxPods = CalcMaxPods(instanceInfo, cfg.Spec.Kubelet.MaxPodsExpression)
+		ksc.MaxPods = CalcMaxPods(instanceInfo, cfg.Spec.Kubelet.MaxPodsExpression, ipFamily == api.IPFamilyIPv6)
 	}
 	ksc.KubeReserved = map[string]string{
 		"cpu":               fmt.Sprintf("%dm", getCPUMillicoresToReserve(resources)),

--- a/nodeadm/internal/kubelet/eni_max_pods.go
+++ b/nodeadm/internal/kubelet/eni_max_pods.go
@@ -57,16 +57,18 @@ func GetInstanceInfo(ctx context.Context, awsRegion string, instanceType string)
 //
 //	# of ENI on default network card * (# of IPv4 per ENI - 1) + 2
 //
-// For IPv6 clusters, the IP count per ENI is not a constraint, so the default
-// max pods value (110) is used instead of the ENI-based calculation.
+// For IPv6 clusters, the IP count per ENI is not a constraint, so the result
+// is max(110, ENI-formula) — small instances get at least 110 while large
+// instances keep their higher ENI-based value.
 //
 // TODO: isolate this into a public-facing package for external use by other projects
 func CalcMaxPods(instanceInfo util.InstanceInfo, customExpression string, isIPv6 bool) int32 {
 	var standardMaxPods int32
+	eniMaxPods := calculateStandardMaxPods(instanceInfo)
 	if isIPv6 {
-		standardMaxPods = defaultMaxPods
+		standardMaxPods = max(defaultMaxPods, eniMaxPods)
 	} else {
-		standardMaxPods = calculateStandardMaxPods(instanceInfo)
+		standardMaxPods = eniMaxPods
 	}
 	if len(customExpression) == 0 {
 		return standardMaxPods

--- a/nodeadm/internal/kubelet/eni_max_pods.go
+++ b/nodeadm/internal/kubelet/eni_max_pods.go
@@ -57,9 +57,17 @@ func GetInstanceInfo(ctx context.Context, awsRegion string, instanceType string)
 //
 //	# of ENI on default network card * (# of IPv4 per ENI - 1) + 2
 //
+// For IPv6 clusters, the IP count per ENI is not a constraint, so the default
+// max pods value (110) is used instead of the ENI-based calculation.
+//
 // TODO: isolate this into a public-facing package for external use by other projects
-func CalcMaxPods(instanceInfo util.InstanceInfo, customExpression string) int32 {
-	standardMaxPods := calculateStandardMaxPods(instanceInfo)
+func CalcMaxPods(instanceInfo util.InstanceInfo, customExpression string, isIPv6 bool) int32 {
+	var standardMaxPods int32
+	if isIPv6 {
+		standardMaxPods = defaultMaxPods
+	} else {
+		standardMaxPods = calculateStandardMaxPods(instanceInfo)
+	}
 	if len(customExpression) == 0 {
 		return standardMaxPods
 	}

--- a/nodeadm/internal/kubelet/eni_max_pods_test.go
+++ b/nodeadm/internal/kubelet/eni_max_pods_test.go
@@ -22,6 +22,7 @@ func TestCalcMaxPods(t *testing.T) {
 		customExpression string
 		defaultENIs      int
 		ipsPerENI        int
+		isIPv6           bool
 		expectedValue    int32
 	}{
 		{
@@ -57,6 +58,21 @@ func TestCalcMaxPods(t *testing.T) {
 			ipsPerENI:        6,
 			expectedValue:    17,
 		},
+		{
+			// IPv6 should return default max pods (110) regardless of ENI/IP count
+			defaultENIs:   3,
+			ipsPerENI:     6,
+			isIPv6:        true,
+			expectedValue: 110,
+		},
+		{
+			// IPv6 with custom expression should use 110 as the standard base
+			customExpression: "max_pods",
+			defaultENIs:      3,
+			ipsPerENI:        6,
+			isIPv6:           true,
+			expectedValue:    110,
+		},
 	}
 	for _, test := range tests {
 		instanceInfo := util.InstanceInfo{
@@ -64,7 +80,7 @@ func TestCalcMaxPods(t *testing.T) {
 			DefaultMaxENIs:            int32(test.defaultENIs),
 			Ipv4AddressesPerInterface: int32(test.ipsPerENI),
 		}
-		val := CalcMaxPods(instanceInfo, test.customExpression)
+		val := CalcMaxPods(instanceInfo, test.customExpression, test.isIPv6)
 		assert.Equal(t, test.expectedValue, val)
 	}
 	cachedInstanceInfoBytes = initialCacheContents

--- a/nodeadm/internal/kubelet/eni_max_pods_test.go
+++ b/nodeadm/internal/kubelet/eni_max_pods_test.go
@@ -59,19 +59,42 @@ func TestCalcMaxPods(t *testing.T) {
 			expectedValue:    17,
 		},
 		{
-			// IPv6 should return default max pods (110) regardless of ENI/IP count
+			// IPv6 small instance: ENI formula (17) < 110, so use 110
 			defaultENIs:   3,
 			ipsPerENI:     6,
 			isIPv6:        true,
 			expectedValue: 110,
 		},
 		{
-			// IPv6 with custom expression should use 110 as the standard base
+			// IPv6 large instance: ENI formula (737) > 110, so keep 737
+			defaultENIs:   15,
+			ipsPerENI:     50,
+			isIPv6:        true,
+			expectedValue: 737,
+		},
+		{
+			// IPv6 with custom expression should use max(110, ENI-formula) as the base
 			customExpression: "max_pods",
 			defaultENIs:      3,
 			ipsPerENI:        6,
 			isIPv6:           true,
 			expectedValue:    110,
+		},
+		{
+			// IPv6 custom expression can still reference ENI vars directly
+			customExpression: "(default_enis * (ips_per_eni - 1)) + 2",
+			defaultENIs:      3,
+			ipsPerENI:        6,
+			isIPv6:           true,
+			expectedValue:    17,
+		},
+		{
+			// IPv6 custom expression using ENI vars on a large instance
+			customExpression: "default_enis * ips_per_eni",
+			defaultENIs:      15,
+			ipsPerENI:        50,
+			isIPv6:           true,
+			expectedValue:    750,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
**Issue #, if available:** NA

**Description of changes:**

For IPv6 clusters, the IP count per ENI is not a constraint on pod density since each pod gets a unique IPv6 address from the vast address space. The previous ENI-based formula (ENIs * (IPs_per_ENI - 1) + 2) unnecessarily limited maxPods on IPv6 clusters.

This Change fixes by setting defaultMaxPods for ipv6 clusters.

EKS/IPv6 is only supported in prefix mode, If you run ipv6 on EKS then the VPC CNI assigns a /80 IPv6 prefix which give 2⁴⁸ addresses.

https://docs.aws.amazon.com/eks/latest/best-practices/ipv6.html#_overview
https://docs.aws.amazon.com/eks/latest/best-practices/prefix-mode-linux.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


**Testing Done**

Unit tests.

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
