### PR TITLE
fix: persist kernel args to GRUB_CMDLINE_LINUX so they survive boot config regerneration

### DIFF
--- a/templates/al2023/provisioners/limit-c-states.sh
+++ b/templates/al2023/provisioners/limit-c-states.sh
@@ -8,6 +8,4 @@ if [ "$ENABLE_EFA" != "true" ]; then
 fi
 
 echo "Limiting deeper C-states"
-sudo grubby \
-  --update-kernel=ALL \
-  --args="intel_idle.max_cstate=1 processor.max_cstate=1"
+set-kernel-arg "intel_idle.max_cstate=1 processor.max_cstate=1"

--- a/templates/al2023/provisioners/set-clocksource.sh
+++ b/templates/al2023/provisioners/set-clocksource.sh
@@ -6,6 +6,4 @@ set -o errexit
 
 # use the tsc clocksource by default
 # https://repost.aws/knowledge-center/manage-ec2-linux-clock-source
-sudo grubby \
-  --update-kernel=ALL \
-  --args="clocksource=tsc tsc=reliable"
+set-kernel-arg "clocksource=tsc tsc=reliable"

--- a/templates/al2023/runtime/bin/set-kernel-arg
+++ b/templates/al2023/runtime/bin/set-kernel-arg
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# usage: set-kernel-arg "ARG[ ARG...]"
+#
+# Adds kernel command-line argument(s) to the current boot entries and to
+# GRUB_CMDLINE_LINUX in /etc/default/grub, so they also survive a regeneration
+# of the boot config. Idempotent.
+
+set -o pipefail
+set -o nounset
+set -o errexit
+
+if [ "$#" -eq 0 ]; then
+  echo >&2 "usage: set-kernel-arg \"ARG[ ARG...]\""
+  exit 1
+fi
+
+KERNEL_ARGS="$*"
+
+# Apply to the current boot entries.
+sudo grubby --update-kernel=ALL --args="${KERNEL_ARGS}"
+
+. /etc/default/grub
+CMDLINE="${GRUB_CMDLINE_LINUX:-}"
+# Append each arg that isn't already present.
+for arg in ${KERNEL_ARGS}; do
+  grep -qFw -- "${arg}" <<< "${CMDLINE}" || CMDLINE+=" ${arg}"
+done
+CMDLINE="${CMDLINE# }"
+
+# Replace the existing GRUB_CMDLINE_LINUX line, or add it if absent.
+if grep -q '^GRUB_CMDLINE_LINUX=' /etc/default/grub; then
+  sudo sed -i "s|^GRUB_CMDLINE_LINUX=.*|GRUB_CMDLINE_LINUX=\"${CMDLINE}\"|" /etc/default/grub
+else
+  echo "GRUB_CMDLINE_LINUX=\"${CMDLINE}\"" | sudo tee -a /etc/default/grub > /dev/null
+fi


### PR DESCRIPTION
**Issue #, if available:**

Fixes #2741 

**Description of changes:**

On AL2023 NVIDIA AMIs, the kernel command-line args set by `set-clocksource.sh (clocksource=tsc tsc=reliable) and limit-c-states.sh (intel_idle.max_cstate=1 processor.max_cstate=1)` were missing at boot.  Standard and Neuron AMIs were unaffected. 

These scripts applied the args with `grubby --update-kernel=ALL`, which edits only the BLS boot entries (/boot/loader/entries/*.conf). The NVIDIA build script pulls in `nvidia-kmod-common` as a driver dependency, and its `%post` scriptlet runs `nvidia-boot-update` , which regenerates the boot entries and drops args that existed only in the boot entries. Standard/Neuron builds never regenerate, so their grubby-only edits survived.
Ref: https://github.com/NVIDIA/yum-packaging-nvidia-kmod-common/blob/main/nvidia-boot-update

This change sets kernel args both on the current boot entries (via grubby) and in GRUB_CMDLINE_LINUX in `/etc/default/grub`, so they survive a later boot-config regeneration. The call is idempotent and merges into any existing GRUB_CMDLINE_LINUX value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Built v1.35 AMIs for both standard and NVIDIA variants

Standard:
```
cat /proc/cmdline
BOOT_IMAGE=(hd0,gpt1)/boot/vmlinuz-6.12.92-122.166.amzn2023.x86_64 root=UUID=4b9941ea-b69d-42ce-a01a-2acd80dbd5fa ro console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 rd.emergency=poweroff rd.shell=0 selinux=1 security=selinux quiet clocksource=tsc tsc=reliable intel_idle.max_cstate=1 processor.max_cstate=1
```

NVIDIA
```
cat /proc/cmdline
BOOT_IMAGE=(hd0,gpt1)/boot/vmlinuz-6.12.92-122.166.amzn2023.x86_64 root=UUID=4b9941ea-b69d-42ce-a01a-2acd80dbd5fa ro clocksource=tsc tsc=reliable intel_idle.max_cstate=1 processor.max_cstate=1 rd.driver.blacklist=nouveau console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 rd.emergency=poweroff rd.shell=0 selinux=1security=selinux quiet
```