### PR TITLE
build: bump x86 and arm64 instances to larger size to fix packer image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ ifeq ($(os_distro), al2023)
 	AMI_VARIANT := $(AMI_VARIANT)-al2023
 endif
 ifeq ($(arch), arm64)
-	instance_type ?= m6g.large
+	instance_type ?= m6g.xlarge
 	AMI_VARIANT := $(AMI_VARIANT)-arm64
 else
-	instance_type ?= m5.large
+	instance_type ?= m5.xlarge
 endif
 ifeq ($(enable_fips), true)
 	AMI_VARIANT := $(AMI_VARIANT)-fips


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bump the default AMI build instance types from *.large (8 GB) to *.xlarge (16 GB) for both architectures.
arm64: m6g.large → m6g.xlarge
x86_64: m5.large → m5.xlarge

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
