### PR TITLE
Fix stale mdadm.conf blocking RAID rebuild

### DIFF
--- a/templates/al2023/runtime/bin/setup-local-disks
+++ b/templates/al2023/runtime/bin/setup-local-disks
@@ -45,7 +45,7 @@ maybe_raid() {
   local array_mount_point="${MNT_DIR}/0"
   mkdir -p "$(dirname "${md_config}")"
 
-  if [[ ! -s "${md_config}" ]]; then
+  if [[ ! -s "${md_config}" ]] || ! mdadm --detail --scan 2>/dev/null | grep -q "ARRAY"; then
     mdadm --create --force --verbose \
       "${md_device}" \
       --level="${raid_level}" \

--- a/templates/al2023/runtime/bin/setup-local-disks
+++ b/templates/al2023/runtime/bin/setup-local-disks
@@ -45,7 +45,7 @@ maybe_raid() {
   local array_mount_point="${MNT_DIR}/0"
   mkdir -p "$(dirname "${md_config}")"
 
-  if [[ ! -s "${md_config}" ]] || ! mdadm --detail --scan 2>/dev/null | grep -q "ARRAY"; then
+  if [[ ! -s "${md_config}" ]] || ! mdadm --detail --scan 2> /dev/null | grep -q "ARRAY"; then
     mdadm --create --force --verbose \
       "${md_device}" \
       --level="${raid_level}" \


### PR DESCRIPTION
**Issue #, if available:**
Related to https://github.com/awslabs/amazon-eks-ami/issues/2122

**Description of changes:**
After an EC2 instance stop/start, instance-store NVMe disks are wiped but `/.aws/mdadm.conf` persists on the EBS root volume. The `maybe_raid()` function in `setup-local-disks` only checks if the config file is non-empty before deciding to skip array creation. This causes the RAID0 rebuild to be skipped, leaving the node broken (bind-mounts for /var/lib/containerd, /var/lib/kubelet, /var/log/pods fail).

This change adds an additional condition to verify the array actually exists before skipping creation:

```
# Before:
if [[ ! -s "${md_config}" ]]; then

# After:
if [[ ! -s "${md_config}" ]] || ! mdadm --detail --scan 2>/dev/null | grep -q "ARRAY"; then
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**
Reproduced the bug on an AMI without the fix to confirm the failure. 
Built AMI with the fix (c5d.large, us-east-1, k8s 1.29):
- First boot: setup-local-disks raid0 creates RAID0 successfully
- Stop/start: script detects missing array and rebuilds it successfully
- Reboot: array persists, no unnecessary rebuild (no regression)

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
