### PR TITLE
fix: erase efa-nv-peermem on non-NVIDIA AMIs

### DIFF
--- a/templates/al2023/provisioners/cleanup.sh
+++ b/templates/al2023/provisioners/cleanup.sh
@@ -24,7 +24,13 @@ sudo rm -rf \
   /var/log/cloud-init.log \
   /var/log/secure \
   /var/log/wtmp \
-  /var/log/messages \
-  /var/log/audit/*
+  /var/log/messages
+
+# Stop auditd before purging: a blind rm against a running auditd leaves the held
+# inode in place, so build-time AVC denials ship in the AMI.
+sudo service auditd stop 2>/dev/null || true
+sudo truncate -s0 /var/log/audit/audit.log 2>/dev/null || true
+sudo rm -f /var/log/audit/audit.log.* 2>/dev/null || true
+sudo service auditd start 2>/dev/null || true
 
 sudo touch /etc/machine-id

--- a/templates/al2023/provisioners/cleanup.sh
+++ b/templates/al2023/provisioners/cleanup.sh
@@ -28,9 +28,9 @@ sudo rm -rf \
 
 # Stop auditd before purging: a blind rm against a running auditd leaves the held
 # inode in place, so build-time AVC denials ship in the AMI.
-sudo service auditd stop 2>/dev/null || true
-sudo truncate -s0 /var/log/audit/audit.log 2>/dev/null || true
-sudo rm -f /var/log/audit/audit.log.* 2>/dev/null || true
-sudo service auditd start 2>/dev/null || true
+sudo service auditd stop 2> /dev/null || true
+sudo truncate -s0 /var/log/audit/audit.log 2> /dev/null || true
+sudo rm -f /var/log/audit/audit.log.* 2> /dev/null || true
+sudo service auditd start 2> /dev/null || true
 
 sudo touch /etc/machine-id

--- a/templates/al2023/provisioners/install-efa.sh
+++ b/templates/al2023/provisioners/install-efa.sh
@@ -57,11 +57,9 @@ sudo rm -rf "${EFA_INSTALL_DIR}"
 sudo dnf swap -y gnupg2-full gnupg2-minimal
 
 ##########################################################################################
-### Remove NVIDIA peer memory modules-load drop-in on non-NVIDIA AMIs ####################
-### The EFA installer adds /etc/modules-load.d/efa_nv_peermem.conf, which tries to load ##
-### the nvidia kmod at boot. On non-NVIDIA AMIs there is no nvidia driver resulting in  ##
-### load failure                                                                        ##
+### Erase efa-nv-peermem on non-NVIDIA AMIs. It owns efa_nv_peermem.conf and loads the  ##
+### nvidia kmod at boot, which fails where there is no nvidia driver.                    ##
 ##########################################################################################
 if [ "${ENABLE_ACCELERATOR:-}" != "nvidia" ]; then
-  sudo rm -f /etc/modules-load.d/efa_nv_peermem.conf
+  sudo rpm -e --nodeps efa-nv-peermem 2>/dev/null || true
 fi

--- a/templates/al2023/provisioners/install-efa.sh
+++ b/templates/al2023/provisioners/install-efa.sh
@@ -61,5 +61,5 @@ sudo dnf swap -y gnupg2-full gnupg2-minimal
 ### nvidia kmod at boot, which fails where there is no nvidia driver.                    ##
 ##########################################################################################
 if [ "${ENABLE_ACCELERATOR:-}" != "nvidia" ]; then
-  sudo rpm -e --nodeps efa-nv-peermem 2>/dev/null || true
+  sudo rpm -e --nodeps efa-nv-peermem 2> /dev/null || true
 fi


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Since #2697 defaulted enable_efa to true, the EFA installer runs on every AMI
variant and installs the efa-nv-peermem kmod package even on non-NVIDIA builds.
That package owns /etc/modules-load.d/efa_nv_peermem.conf, which asks systemd to
load the nvidia module at boot; on a non-NVIDIA AMI there is no nvidia driver, so
the load fails. #2737 deleted the drop-in file after the installer ran, which
stops the boot-time failure, but the efa-nv-peermem package itself stays
installed. This erases the package outright on non-NVIDIA variants so no stale
artifact is left behind.

The installer's own module-load attempt during the build also records an SELinux
AVC denial in /var/log/audit/audit.log. cleanup.sh tried to clear that log with a
plain rm while auditd was still running, which leaves the file's inode held and
the record intact, so the denial shipped inside the AMI and surfaced in scanners
on hardened images built from it. This stops auditd before truncating the active
log and removing the rotated files, so the build-time denial no longer persists
into the published image.

Follow-up to #2737.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
