### PR TITLE
fix: pin python3 to pre-CVE version to fix moto pkgutil crash in e2e tests

### DIFF
--- a/nodeadm/test/e2e/infra/Dockerfile
+++ b/nodeadm/test/e2e/infra/Dockerfile
@@ -7,7 +7,8 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 ARG CONTAINERD_VERSION
 RUN yum install -y --allowerasing curl && yum clean all
 RUN dnf -y update && \
-    dnf -y install systemd jq python3 awscli nmap-ncat iptables tar procps && \
+    dnf -y install systemd jq awscli nmap-ncat iptables tar procps git && \
+    dnf -y install python3-3.9.24-1.amzn2023.0.4 python3-libs-3.9.24-1.amzn2023.0.4 --allowerasing && \
     dnf clean all
 # TO-DO: install containerd v2 from AL repo as well once it is available
 RUN if [[ "$CONTAINERD_VERSION" == *".*" ]]; then \


### PR DESCRIPTION
**Issue #, if available:**
N/A — pre-existing e2e test infrastructure failure affecting all tests.

**Description of changes:**
Pins python3 to ```3.9.24-1.amzn2023.0.4``` in the e2e test Docker image to avoid a recent Python security patch that added strict path validation to ```pkgutil.get_data()```, rejecting paths containing ```..``` components. moto internally uses such paths to load EC2 instance type data, causing all e2e tests to crash with ```ValueError: resource must be a relative path with no parent directory components```. The latest moto release (5.2.2) still uses ```pkgutil.get_data()```, but their master has a fix ([getmoto/moto@006a577](https://github.com/getmoto/moto/commit/006a577f8d6c92b4d07ceacf6b817626c8b8d719)). Once moto releases a version > 5.2.2, we can remove the Python pin and use moto[server] normally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

CI passes — all e2e tests that previously failed now succeed.

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
