### PR TITLE
fix: pin moto>=5.2.2 and revert python3 downgrade

### DIFF
--- a/nodeadm/test/e2e/infra/Dockerfile
+++ b/nodeadm/test/e2e/infra/Dockerfile
@@ -7,8 +7,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 ARG CONTAINERD_VERSION
 RUN yum install -y --allowerasing curl && yum clean all
 RUN dnf -y update && \
-    dnf -y install systemd jq awscli nmap-ncat iptables tar procps git && \
-    dnf -y install python3-3.9.24-1.amzn2023.0.4 python3-libs-3.9.24-1.amzn2023.0.4 --allowerasing && \
+    dnf -y install systemd jq python3 awscli nmap-ncat iptables tar procps git e2fsprogs xfsprogs util-linux && \
     dnf clean all
 # TO-DO: install containerd v2 from AL repo as well once it is available
 RUN if [[ "$CONTAINERD_VERSION" == *".*" ]]; then \

--- a/nodeadm/test/e2e/infra/requirements.txt
+++ b/nodeadm/test/e2e/infra/requirements.txt
@@ -1,2 +1,2 @@
 mitmproxy
-moto[server]
+moto[server]>=5.2.2


### PR DESCRIPTION
**Issue #, if available:**
Follow-up to #2760

**Description of changes:**
Replaces the python3 version pin (stopgap from #2760) with a proper fix: pins ```moto[server]>=5.2.2``` which includes the ```importlib.resources``` fix for the ```pkgutil.get_data()``` crash. Reverts the python3 downgrade so we use the latest Python. Also adds ```e2fsprogs, xfsprogs, and util-linux``` to the test Docker image (needed for EBS storage e2e tests in #2759).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**
CI will validate — all e2e tests should pass with moto 5.2.2 on latest Python.

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
