### PR TITLE
Revert "Pin AL2023 source AMI to 2023.12.20260611.0 (#2757)"

### DIFF
--- a/templates/al2023/variables-1.28.json
+++ b/templates/al2023/variables-1.28.json
@@ -1,5 +1,5 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.12.20260611.0-kernel-6.1-*",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
     "containerd_version": "1.7.*",
     "nvidia_driver_major_version": "570"
 }

--- a/templates/al2023/variables-1.29.json
+++ b/templates/al2023/variables-1.29.json
@@ -1,4 +1,4 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.12.20260611.0-kernel-6.1-*",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*",
     "containerd_version": "1.7.*"
 }

--- a/templates/al2023/variables-1.30.json
+++ b/templates/al2023/variables-1.30.json
@@ -1,3 +1,3 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.12.20260611.0-kernel-6.1-*"
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*"
 }

--- a/templates/al2023/variables-1.31.json
+++ b/templates/al2023/variables-1.31.json
@@ -1,3 +1,3 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.12.20260611.0-kernel-6.1-*"
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*"
 }

--- a/templates/al2023/variables-1.32.json
+++ b/templates/al2023/variables-1.32.json
@@ -1,3 +1,3 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.12.20260611.0-kernel-6.1-*"
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1-*"
 }

--- a/templates/al2023/variables-1.33.json
+++ b/templates/al2023/variables-1.33.json
@@ -1,3 +1,3 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.12.20260611.0-kernel-6.12-*"
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.12-*"
 }

--- a/templates/al2023/variables-1.34.json
+++ b/templates/al2023/variables-1.34.json
@@ -1,3 +1,3 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.12.20260611.0-kernel-6.12-*"
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.12-*"
 }

--- a/templates/al2023/variables-1.35.json
+++ b/templates/al2023/variables-1.35.json
@@ -1,3 +1,3 @@
 {
-    "source_ami_filter_name": "al2023-ami-minimal-2023.12.20260611.0-kernel-6.12-*"
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.12-*"
 }

--- a/templates/al2023/variables-default.json
+++ b/templates/al2023/variables-default.json
@@ -28,7 +28,7 @@
     "remote_folder": "/tmp",
     "runc_version": "*",
     "security_group_id": "",
-    "source_ami_filter_name": "al2023-ami-minimal-2023.12.20260611.0-kernel-6.18-*",
+    "source_ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.18-*",
     "source_ami_id": "",
     "source_ami_owners": "137112412989",
     "ssh_interface": "",


### PR DESCRIPTION
This reverts commit 73a614306b26c3e194204e540812633ab579c962.

**Issue #, if available:**

Now

**Description of changes:**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
