### PR TITLE
feat(nvidia): installing prebuilt kernel modules to trees

### DIFF
--- a/templates/al2023/helpers/nvidia-kmods.sh
+++ b/templates/al2023/helpers/nvidia-kmods.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# Per-flavor builders for one driver tree's kernel modules, each harvesting into
+# <tree>/flavors/<flavor>/lib/modules/<kernel>/.
+
+KERNEL_RELEASE="$(uname -r)"
+readonly KERNEL_RELEASE
+
+ARCH="$(uname -m)"
+readonly ARCH
+
+# Build and harvests nvidia open flavor kernel modules
+function build-open-kmods() {
+  local TREE_DIR="${1}"
+  local DRIVER_VERSION="${2}"
+
+  echo "Building open kernel modules for NVIDIA ${DRIVER_VERSION}"
+  extract-kmod-source "kmod-nvidia-open-dkms-${DRIVER_VERSION}" "${TREE_DIR}"
+  sudo dkms add -m nvidia -v "${DRIVER_VERSION}"
+  sudo dkms build -m nvidia -v "${DRIVER_VERSION}"
+  harvest-dkms-modules nvidia "${DRIVER_VERSION}" "${TREE_DIR}/flavors/open"
+
+  # Built here, while this version's nvidia source is the only one in /usr/src.
+  build-gdrdrv "${TREE_DIR}" "${DRIVER_VERSION}"
+
+  sudo dkms remove -m nvidia -v "${DRIVER_VERSION}" --all
+  sudo rm -rf "/usr/src/nvidia-${DRIVER_VERSION}"
+}
+
+# Build and harvests nvidia proprietary flavor kernel modules
+function build-proprietary-kmods() {
+  local TREE_DIR="${1}"
+  local DRIVER_VERSION="${2}"
+
+  echo "Building proprietary kernel modules for NVIDIA ${DRIVER_VERSION}"
+  extract-kmod-source "kmod-nvidia-latest-dkms-${DRIVER_VERSION}" "${TREE_DIR}"
+  sudo dkms add -m nvidia -v "${DRIVER_VERSION}"
+  sudo dkms build -m nvidia -v "${DRIVER_VERSION}"
+  harvest-dkms-modules nvidia "${DRIVER_VERSION}" "${TREE_DIR}/flavors/proprietary"
+
+  sudo dkms remove -m nvidia -v "${DRIVER_VERSION}" --all
+  sudo rm -rf "/usr/src/nvidia-${DRIVER_VERSION}"
+}
+
+# Build and harvests gdrdrv kernel modules. Built only with the open nvidia flavor
+function build-gdrdrv() {
+  local TREE_DIR="${1}"
+  local DRIVER_VERSION="${2}"
+
+  if [ "${ENABLE_NVIDIA_GDRCOPY_DRIVER}" != "true" ] || [ -z "${NVIDIA_GDRCOPY_DRIVER_VERSION}" ]; then
+    return 0
+  fi
+
+  local GDRCOPY_VERSION="${NVIDIA_GDRCOPY_DRIVER_VERSION}"
+
+  echo "Building gdrdrv ${GDRCOPY_VERSION} against NVIDIA ${DRIVER_VERSION}"
+  extract-kmod-source "gdrcopy-kmod-${GDRCOPY_VERSION}" "${TREE_DIR}"
+  sudo dkms add -m gdrdrv -v "${GDRCOPY_VERSION}"
+  sudo dkms build -m gdrdrv -v "${GDRCOPY_VERSION}"
+  harvest-dkms-modules gdrdrv "${GDRCOPY_VERSION}" "${TREE_DIR}/flavors/open"
+
+  sudo dkms remove -m gdrdrv -v "${GDRCOPY_VERSION}" --all
+  sudo rm -rf "/usr/src/gdrdrv-${GDRCOPY_VERSION}"
+}
+
+# Build and harvest nvidia grid flavor kernel modules
+function build-grid-kmods() {
+  local TREE_DIR="${1}"
+  local DRIVER_VERSION="${2}"
+
+  if [ "${ARCH}" != "x86_64" ]; then
+    echo "No GRID runfile is published for ${ARCH}, skipping"
+    return 0
+  fi
+
+  local RUNFILE_NAME="NVIDIA-Linux-x86_64-${DRIVER_VERSION}-grid-aws.run"
+  local RUNFILE_KEY
+  RUNFILE_KEY=$(aws s3 ls --recursive "s3://${EC2_GRID_DRIVER_S3_BUCKET}/" \
+    | grep -F "${RUNFILE_NAME}" \
+    | sort -k1,2 \
+    | tail -1 \
+    | awk '{print $4}' || true)
+
+  if [ -z "${RUNFILE_KEY}" ]; then
+    echo >&2 "ERROR: no GRID runfile ${RUNFILE_NAME} in s3://${EC2_GRID_DRIVER_S3_BUCKET}/"
+    return 1
+  fi
+
+  local GRID_DIR="${WORKING_DIR}/nvidia-grid-${DRIVER_VERSION}"
+  local RUNFILE_PATH="${GRID_DIR}/${RUNFILE_NAME}"
+  local KERNEL_OPEN_DIR="${GRID_DIR}/source/kernel-open"
+  mkdir -p "${GRID_DIR}"
+
+  echo "Building GRID kernel modules for NVIDIA ${DRIVER_VERSION}"
+  aws s3 cp "s3://${EC2_GRID_DRIVER_S3_BUCKET%%/*}/${RUNFILE_KEY}" "${RUNFILE_PATH}"
+  chmod +x "${RUNFILE_PATH}"
+  "${RUNFILE_PATH}" --extract-only --target "${GRID_DIR}/source"
+
+  make -C "${KERNEL_OPEN_DIR}" \
+    -j"$(nproc)" \
+    SYSSRC="/lib/modules/${KERNEL_RELEASE}/build" \
+    modules
+
+  # Harvest the modules to the tree
+  local DEST_DIR="${TREE_DIR}/flavors/grid/lib/modules/${KERNEL_RELEASE}/extra"
+  local MODULE_PATH
+  sudo install -d "${DEST_DIR}"
+  for MODULE_PATH in "${KERNEL_OPEN_DIR}"/*.ko; do
+    strip -g --strip-unneeded "${MODULE_PATH}"
+    sudo install -m 0644 "${MODULE_PATH}" "${DEST_DIR}/"
+  done
+
+  sudo rm -rf "${GRID_DIR}"
+}
+
+# Download a kmod source rpm and unpack it
+function extract-kmod-source() {
+  local SOURCE_PACKAGE="${1}"
+  local TREE_DIR="${2}"
+  local DOWNLOAD_DIR="${WORKING_DIR}/nvidia-kmod-rpms"
+
+  mkdir -p "${DOWNLOAD_DIR}"
+  sudo dnf download --setopt=*.module_hotfixes=true --destdir="${DOWNLOAD_DIR}" "${SOURCE_PACKAGE}"
+
+  # dnf download skips signature checks, so verify before unpacking.
+  rpm -K "${DOWNLOAD_DIR}"/*.rpm
+  rpm2cpio "${DOWNLOAD_DIR}"/*.rpm | (cd / && sudo cpio -idmu --quiet)
+
+  # Save the RPM files for rpmdb registration later.
+  sudo install -d "${TREE_DIR}/.rpms"
+  sudo mv "${DOWNLOAD_DIR}"/*.rpm "${TREE_DIR}/.rpms/"
+  sudo rm -rf "${DOWNLOAD_DIR}"
+}
+
+# Copy the modules a dkms.conf declares out of the dkms build tree and into a flavor
+# All dkms modules end up in /lib/modules/${KERNEL_RELEASE}/extra for AL2023
+# https://man.archlinux.org/man/extra/dkms/dkms.8.en#DEST_MODULE_LOCATION___=
+function harvest-dkms-modules() {
+  local PACKAGE_NAME="${1}"
+  local PACKAGE_VERSION="${2}"
+  local DEST_DIR="${3}/lib/modules/${KERNEL_RELEASE}/extra"
+  local DKMS_MODULE_DIR="/var/lib/dkms/${PACKAGE_NAME}/${PACKAGE_VERSION}/${KERNEL_RELEASE}/${ARCH}/module"
+
+  local DECLARED_MODULES
+  DECLARED_MODULES=$(dkms-declared-modules "${PACKAGE_NAME}" "${PACKAGE_VERSION}")
+  local MODULE_NAMES
+  mapfile -t MODULE_NAMES <<< "${DECLARED_MODULES}"
+
+  sudo install -d "${DEST_DIR}"
+  local MODULE_NAME
+  for MODULE_NAME in "${MODULE_NAMES[@]}"; do
+    # The suffix varies with the kernel's module compression.
+    if ! compgen -G "${DKMS_MODULE_DIR}/${MODULE_NAME}.ko*" > /dev/null; then
+      echo >&2 "ERROR: ${PACKAGE_NAME} declares ${MODULE_NAME}, missing from ${DKMS_MODULE_DIR}"
+      return 1
+    fi
+    sudo install -m 0644 "${DKMS_MODULE_DIR}/${MODULE_NAME}".ko* "${DEST_DIR}/"
+  done
+}
+
+# Print the module names a dkms.conf declares.
+# https://man.archlinux.org/man/extra/dkms/dkms.8.en#BUILT_MODULE_NAME___=
+function dkms-declared-modules() {
+  local PACKAGE_NAME="${1}"
+  local PACKAGE_VERSION="${2}"
+  local PACKAGE_DKMS_CONF="/usr/src/${PACKAGE_NAME}-${PACKAGE_VERSION}/dkms.conf"
+
+  (
+    # Exported for the conf's MAKE line, which expands them at source time.
+    export kernelver="${KERNEL_RELEASE}"
+    export dkms_tree="/var/lib/dkms"
+    declare -a BUILT_MODULE_NAME=()
+    # shellcheck disable=SC1090
+    if ! source "${PACKAGE_DKMS_CONF}" > /dev/null; then
+      echo >&2 "ERROR: cannot read ${PACKAGE_DKMS_CONF}"
+      exit 1
+    fi
+    if [ "${#BUILT_MODULE_NAME[@]}" -eq 0 ]; then
+      echo >&2 "ERROR: ${PACKAGE_DKMS_CONF} declares no modules"
+      exit 1
+    fi
+    printf '%s\n' "${BUILT_MODULE_NAME[@]}"
+  )
+}

--- a/templates/al2023/provisioners/install-nvidia-drivers.sh
+++ b/templates/al2023/provisioners/install-nvidia-drivers.sh
@@ -33,12 +33,8 @@ readonly MACHINE
 
 readonly NVIDIA_TREE_ROOT="/opt/nvidia"
 
-readonly NVIDIA_TREES=(lts pb)
-declare -A NVIDIA_TREE_MAJOR=(
-  [lts]="${NVIDIA_DRIVER_LTS_VERSION}"
-  [pb]="${NVIDIA_DRIVER_PB_VERSION}"
-)
-declare -A NVIDIA_TREE_VERSION=()
+# shellcheck disable=SC1090
+source "${WORKING_DIR}/helpers/nvidia-kmods.sh"
 
 ################################################################################
 ### Add repository #############################################################
@@ -67,6 +63,36 @@ else
   sudo dnf config-manager --save --setopt=*.gpgcheck=1
 fi
 
+# dnf records repo keys in the rpmdb on install, not on download,
+# so we don't get a sig verification by default.
+# Import all repos since NVIDIA_REPOSITORY can be any url, so its unreliable to pin a repo-id.
+# Cheap and idempotent.
+dnf config-manager --dump '*' | sed -n 's/^gpgkey = //p' | tr ',' '\n' | sed 's/^ *//' | sort -u \
+  | xargs -r -n1 sudo rpm --import || true
+
+################################################################################
+### Install kernel module build dependencies ###################################
+################################################################################
+
+KERNEL_PACKAGE="kernel"
+if [[ "$(uname -r)" == 6.12.* ]]; then
+  KERNEL_PACKAGE="kernel6.12"
+fi
+
+if [[ "$(uname -r)" == 6.18.* ]]; then
+  KERNEL_PACKAGE="kernel6.18"
+fi
+
+sudo dnf -y install \
+  "${KERNEL_PACKAGE}-devel" \
+  "${KERNEL_PACKAGE}-headers" \
+  "${KERNEL_PACKAGE}-modules-extra" \
+  "${KERNEL_PACKAGE}-modules-extra-common"
+
+sudo dnf versionlock 'kernel*'
+
+sudo dnf -y install dkms
+
 ################################################################################
 ### Resolve versions and create the driver trees ###############################
 ################################################################################
@@ -75,42 +101,52 @@ fi
 # so they are compatible with the same userspace components.
 # If one of the open module or the grid driver runfile version are older, we use that version for all installations.
 function resolve-tree-version() {
-  local MAJOR="${1}"
+  local MAJOR_VERSION="${1}"
   local LATEST_OPEN_DRIVER_VERSION
   local LATEST_GRID_DRIVER_VERSION
 
-  LATEST_OPEN_DRIVER_VERSION=$(dnf repoquery --setopt=*.module_hotfixes=true --latest=1 --queryformat "%{version}" "kmod-nvidia-open-dkms-${MAJOR}*")
+  LATEST_OPEN_DRIVER_VERSION=$(dnf repoquery --setopt=*.module_hotfixes=true --latest=1 --queryformat "%{version}" "kmod-nvidia-open-dkms-${MAJOR_VERSION}*")
   if [ -z "${LATEST_OPEN_DRIVER_VERSION}" ]; then
-    echo >&2 "ERROR: no kmod-nvidia-open-dkms package found for major version ${MAJOR}"
+    echo >&2 "ERROR: no kmod-nvidia-open-dkms package found for major version ${MAJOR_VERSION}"
     return 1
   fi
 
   LATEST_GRID_DRIVER_VERSION=$(aws s3 ls --recursive "s3://${EC2_GRID_DRIVER_S3_BUCKET}/" \
-    | grep -Eo "(NVIDIA-Linux-x86_64-)${MAJOR}\.[0-9]+\.[0-9]+(-grid-aws\.run)" \
+    | grep -Eo "(NVIDIA-Linux-x86_64-)${MAJOR_VERSION}\.[0-9]+\.[0-9]+(-grid-aws\.run)" \
     | cut -d'-' -f4 \
     | sort -V \
     | tail -1 || true)
 
   if [ -z "${LATEST_GRID_DRIVER_VERSION}" ]; then
-    echo >&2 "ERROR: no GRID runfile found for major version ${MAJOR} in s3://${EC2_GRID_DRIVER_S3_BUCKET}/"
+    echo >&2 "ERROR: no GRID runfile found for major version ${MAJOR_VERSION} in s3://${EC2_GRID_DRIVER_S3_BUCKET}/"
     return 1
   fi
 
-  if vercmp "${LATEST_OPEN_DRIVER_VERSION}" lteq "${LATEST_GRID_DRIVER_VERSION}"; then
+  if VERCMP_QUIET=true vercmp "${LATEST_OPEN_DRIVER_VERSION}" lteq "${LATEST_GRID_DRIVER_VERSION}"; then
     echo "${LATEST_OPEN_DRIVER_VERSION}"
   else
     echo "${LATEST_GRID_DRIVER_VERSION}"
   fi
 }
 
-for TREE in "${NVIDIA_TREES[@]}"; do
-  MAJOR="${NVIDIA_TREE_MAJOR[${TREE}]}"
-  NVIDIA_TREE_VERSION[${TREE}]=$(resolve-tree-version "${MAJOR}")
-  echo "Tree ${TREE}: major version ${MAJOR} resolved to ${NVIDIA_TREE_VERSION[${TREE}]}"
+function build-driver-tree() {
+  local TREE="${1}"
+  local MAJOR_VERSION="${2}"
 
-  TREE_DIR="${NVIDIA_TREE_ROOT}/${TREE}"
+  local DRIVER_VERSION
+  DRIVER_VERSION=$(resolve-tree-version "${MAJOR_VERSION}")
+  echo "Tree ${TREE}: major version ${MAJOR_VERSION} resolved to ${DRIVER_VERSION}"
+
+  local TREE_DIR="${NVIDIA_TREE_ROOT}/${TREE}"
   sudo mkdir -p "${TREE_DIR}"
-  echo "${NVIDIA_TREE_VERSION[${TREE}]}" | sudo tee "${TREE_DIR}/.version" > /dev/null
+  echo "${DRIVER_VERSION}" | sudo tee "${TREE_DIR}/.version" > /dev/null
   # A simple marker to act as conditional for systemd services
   sudo touch "${TREE_DIR}/.tree-${TREE}"
-done
+
+  build-open-kmods "${TREE_DIR}" "${DRIVER_VERSION}"
+  build-proprietary-kmods "${TREE_DIR}" "${DRIVER_VERSION}"
+  build-grid-kmods "${TREE_DIR}" "${DRIVER_VERSION}"
+}
+
+build-driver-tree lts "${NVIDIA_DRIVER_LTS_VERSION}"
+build-driver-tree pb "${NVIDIA_DRIVER_PB_VERSION}"

--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -72,3 +72,38 @@ if command -v dkms > /dev/null; then
     exit 1
   fi
 fi
+
+#############################
+### nvidia drivers #####
+#############################
+NVIDIA_DRIVER_MODULES=(nvidia nvidia-drm nvidia-modeset nvidia-peermem nvidia-uvm)
+KERNEL_RELEASE=$(uname -r)
+
+# GRID is harvested by glob rather than from a dkms manifest, so confirm the tree
+# ended up with exactly the driver's modules.
+validate_nvidia_grid_modules() {
+  local tree=$1
+  local extra_dir="/opt/nvidia/${tree}/flavors/grid/lib/modules/${KERNEL_RELEASE}/extra"
+  local module_name harvested
+
+  for module_name in "${NVIDIA_DRIVER_MODULES[@]}"; do
+    if [ ! -f "${extra_dir}/${module_name}.ko" ]; then
+      echo "${extra_dir} is missing ${module_name}.ko"
+      exit 1
+    fi
+  done
+
+  harvested=("${extra_dir}"/*.ko)
+  if [ "${#harvested[@]}" -ne "${#NVIDIA_DRIVER_MODULES[@]}" ]; then
+    echo "${extra_dir} has ${#harvested[@]} modules, expected ${#NVIDIA_DRIVER_MODULES[@]}: ${harvested[*]##*/}"
+    exit 1
+  fi
+}
+
+if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
+  # NVIDIA publishes no aarch64 GRID runfile, so that flavor is never built there.
+  if [ "$(uname -m)" == "x86_64" ]; then
+    validate_nvidia_grid_modules lts
+    validate_nvidia_grid_modules pb
+  fi
+fi

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -134,7 +134,8 @@
         "mkdir -p {{user `working_dir`}}/bin",
         "mkdir -p {{user `working_dir`}}/log-collector-script",
         "mkdir -p {{user `working_dir`}}/nodeadm",
-        "mkdir -p {{user `working_dir`}}/gpu"
+        "mkdir -p {{user `working_dir`}}/gpu",
+        "mkdir -p {{user `working_dir`}}/helpers"
       ]
     },
     {
@@ -146,6 +147,11 @@
       "type": "file",
       "source": "{{template_dir}}/runtime/gpu/",
       "destination": "{{user `working_dir`}}/gpu"
+    },
+    {
+      "type": "file",
+      "source": "{{template_dir}}/helpers/",
+      "destination": "{{user `working_dir`}}/helpers"
     },
     {
       "type": "file",
@@ -261,7 +267,7 @@
     {
       "type": "shell",
       "remote_folder": "{{ user `remote_folder`}}",
-      "script": "{{template_dir}}/provisioners/install-nvidia-driver-trees.sh",
+      "script": "{{template_dir}}/provisioners/install-nvidia-drivers.sh",
       "environment_vars": [
         "AWS_REGION={{user `aws_region`}}",
         "ENABLE_ACCELERATOR={{user `enable_accelerator`}}",
@@ -272,6 +278,8 @@
         "NVIDIA_DRIVER_PB_VERSION={{user `nvidia_driver_pb_version`}}",
         "NVIDIA_REPOSITORY={{user `nvidia_repository_url`}}",
         "EC2_GRID_DRIVER_S3_BUCKET={{user `nvidia_grid_runfile_bucket_name`}}",
+        "ENABLE_NVIDIA_GDRCOPY_DRIVER={{user `enable_nvidia_gdrcopy_driver`}}",
+        "NVIDIA_GDRCOPY_DRIVER_VERSION={{user `nvidia_gdrcopy_driver_version`}}",
         "WORKING_DIR={{user `working_dir`}}"
       ]
     },


### PR DESCRIPTION
**Description of changes:**

Builds the NVIDIA kernel modules into the driver trees created in the previous PR https://github.com/awslabs/amazon-eks-ami/pull/2783

A new sourced library, `helpers/nvidia/nvidia-kmods.sh`, builds and harvests the kernel modules for a single tree, and is invoked once per driver version. 

In this PR:

- Installs the kernel module build dependencies (`kernel-devel`, `headers`, `modules-extra`, `dkms`) and version-locks the kernel.
- Builds the open and proprietary flavors from their dkms source RPMs, without installing them onto the build host.
- Builds the GRID flavor from the runfile with a direct `make`, and validates the module set it produces.
- Builds `gdrdrv` against the open driver source, harvested into the open flavor only.
- Harvests each flavor's modules into `/opt/nvidia/<tree>/flavors/<flavor>/lib/modules/<kernel>/extra`, and keeps the kmod RPMs in `/opt/nvidia/<tree>/.rpms` for registration in the rpmdb at boot.

Build time checks
- Open and proprietary - Sources `dkms.conf` to ensure built module names are copied as produced
- Grid - Since a `dkms.conf` file is not available and a `.manifest` is brittle to parse, relying on a hard coded list of known driver modules. The build will fail if any module is not available from the known list after build and if the build produces more than the known modules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

