### PR TITLE
fix: wait for systemd restart to complete

### DIFF
--- a/nodeadm/cmd/nodeadm-internal/boot-book/hook.go
+++ b/nodeadm/cmd/nodeadm-internal/boot-book/hook.go
@@ -32,9 +32,7 @@ func (c *bootHookCmd) Flaggy() *flaggy.Subcommand {
 	return c.cmd
 }
 
-func (c *bootHookCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
-	ctx := context.Background()
-
+func (c *bootHookCmd) Run(ctx context.Context, log *zap.Logger, opts *cli.GlobalOptions) error {
 	identity, err := imds.NewClient(imds.New(true)).GetInstanceIdentityDocument(ctx)
 	if err != nil {
 		return err

--- a/nodeadm/cmd/nodeadm-internal/udev/net_manager.go
+++ b/nodeadm/cmd/nodeadm-internal/udev/net_manager.go
@@ -42,11 +42,10 @@ func (c *netManager) Flaggy() *flaggy.Subcommand {
 	return c.cmd
 }
 
-func (c *netManager) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+func (c *netManager) Run(ctx context.Context, log *zap.Logger, opts *cli.GlobalOptions) error {
 	if len(c.iface) == 0 {
 		return fmt.Errorf("interface name cannot be empty")
 	}
-	ctx := context.TODO()
 	log = log.With(zap.String("interface", c.iface))
 	switch c.action {
 	case "add":

--- a/nodeadm/cmd/nodeadm/config/check.go
+++ b/nodeadm/cmd/nodeadm/config/check.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"context"
+
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/cli"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/configprovider"
@@ -26,7 +28,7 @@ func (c *checkCmd) Flaggy() *flaggy.Subcommand {
 	return c.cmd
 }
 
-func (c *checkCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+func (c *checkCmd) Run(_ context.Context, log *zap.Logger, opts *cli.GlobalOptions) error {
 	c.configSources = cli.ResolveConfigSources(c.configSources)
 
 	log.Info("Checking configuration", zap.Strings("source", c.configSources))

--- a/nodeadm/cmd/nodeadm/config/dump.go
+++ b/nodeadm/cmd/nodeadm/config/dump.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -34,7 +35,7 @@ func (c *dumpCmd) Flaggy() *flaggy.Subcommand {
 	return c.cmd
 }
 
-func (c *dumpCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+func (c *dumpCmd) Run(_ context.Context, log *zap.Logger, opts *cli.GlobalOptions) error {
 	c.configSources = cli.ResolveConfigSources(c.configSources)
 
 	if c.configOutput != "" {

--- a/nodeadm/cmd/nodeadm/init/init.go
+++ b/nodeadm/cmd/nodeadm/init/init.go
@@ -49,7 +49,7 @@ func (c *initCmd) Flaggy() *flaggy.Subcommand {
 	return c.cmd
 }
 
-func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
+func (c *initCmd) Run(ctx context.Context, log *zap.Logger, opts *cli.GlobalOptions) error {
 	start := time.Now()
 
 	log.Info("Checking user is root..")
@@ -82,7 +82,7 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		// we don't need to enrich config when defaulting to a cache, since that is
 		// the only time we already have the NodeConfig .status details populated.
 		log.Info("Enriching configuration..")
-		if err := c.enrichConfig(log, nodeConfig, opts); err != nil {
+		if err := c.enrichConfig(ctx, log, nodeConfig, opts); err != nil {
 			return err
 		}
 	}
@@ -127,7 +127,7 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		}
 
 		log.Info("Configuring daemons...")
-		if err := c.configureDaemons(log, nodeConfig, daemons); err != nil {
+		if err := c.configureDaemons(ctx, log, nodeConfig, daemons); err != nil {
 			return err
 		}
 
@@ -149,7 +149,7 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 		}
 
 		log.Info("Running daemons...")
-		if err := c.runDaemons(log, nodeConfig, daemons); err != nil {
+		if err := c.runDaemons(ctx, log, nodeConfig, daemons); err != nil {
 			return err
 		}
 	}
@@ -161,7 +161,7 @@ func (c *initCmd) Run(log *zap.Logger, opts *cli.GlobalOptions) error {
 
 // enrichConfig populates the internal .status portion of the NodeConfig, used
 // only for internal implementation details.
-func (*initCmd) enrichConfig(log *zap.Logger, cfg *api.NodeConfig, opts *cli.GlobalOptions) error {
+func (*initCmd) enrichConfig(ctx context.Context, log *zap.Logger, cfg *api.NodeConfig, opts *cli.GlobalOptions) error {
 	log.Info("Fetching kubelet version..")
 	kubeletVersion, err := kubelet.GetKubeletVersion()
 	if err != nil {
@@ -176,7 +176,7 @@ func (*initCmd) enrichConfig(log *zap.Logger, cfg *api.NodeConfig, opts *cli.Glo
 		// https://github.com/aws/aws-sdk-go-v2/blob/838fb872e9701fc62b7b86164389791f5313bfcb/aws/logging.go#L18
 		awsClientLogMode = aws.ClientLogMode((1 << 64) - 1)
 	}
-	awsConfig, err := config.LoadDefaultConfig(context.TODO(),
+	awsConfig, err := config.LoadDefaultConfig(ctx,
 		config.WithClientLogMode(awsClientLogMode),
 		config.WithEC2IMDSRegion(func(o *config.UseEC2IMDSRegion) {
 			o.Client = imds.New(true /* treat 404's as retryable to make credential chain more resilient */)
@@ -194,7 +194,7 @@ func (*initCmd) enrichConfig(log *zap.Logger, cfg *api.NodeConfig, opts *cli.Glo
 		// we'll give up after approximately 10 minutes
 		awsConfig.RetryMaxAttempts = 30
 	}
-	instanceDetails, err := api.GetInstanceDetails(context.TODO(), cfg.Spec.FeatureGates, ec2.NewFromConfig(awsConfig), imds.DefaultClient())
+	instanceDetails, err := api.GetInstanceDetails(ctx, cfg.Spec.FeatureGates, ec2.NewFromConfig(awsConfig), imds.DefaultClient())
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func (*initCmd) enrichConfig(log *zap.Logger, cfg *api.NodeConfig, opts *cli.Glo
 	return nil
 }
 
-func (c *initCmd) configureDaemons(log *zap.Logger, cfg *api.NodeConfig, daemons []daemon.Daemon) error {
+func (c *initCmd) configureDaemons(ctx context.Context, log *zap.Logger, cfg *api.NodeConfig, daemons []daemon.Daemon) error {
 	for _, daemon := range daemons {
 		if len(c.daemons) > 0 && !slices.Contains(c.daemons, daemon.Name()) {
 			continue
@@ -216,7 +216,7 @@ func (c *initCmd) configureDaemons(log *zap.Logger, cfg *api.NodeConfig, daemons
 		log := log.With(zap.String("name", daemon.Name()))
 
 		log.Info("Configuring daemon...")
-		if err := daemon.Configure(cfg); err != nil {
+		if err := daemon.Configure(ctx, cfg); err != nil {
 			return err
 		}
 		log.Info("Configured daemon")
@@ -224,7 +224,7 @@ func (c *initCmd) configureDaemons(log *zap.Logger, cfg *api.NodeConfig, daemons
 	return nil
 }
 
-func (c *initCmd) runDaemons(log *zap.Logger, cfg *api.NodeConfig, daemons []daemon.Daemon) error {
+func (c *initCmd) runDaemons(ctx context.Context, log *zap.Logger, cfg *api.NodeConfig, daemons []daemon.Daemon) error {
 	for _, daemon := range daemons {
 		if len(c.daemons) > 0 && !slices.Contains(c.daemons, daemon.Name()) {
 			continue
@@ -232,13 +232,13 @@ func (c *initCmd) runDaemons(log *zap.Logger, cfg *api.NodeConfig, daemons []dae
 		log := log.With(zap.String("name", daemon.Name()))
 
 		log.Info("Ensuring daemon is running..")
-		if err := daemon.EnsureRunning(); err != nil {
+		if err := daemon.EnsureRunning(ctx); err != nil {
 			return err
 		}
 		log.Info("Daemon is running")
 
 		log.Info("Running post-launch tasks..")
-		if err := daemon.PostLaunch(cfg); err != nil {
+		if err := daemon.PostLaunch(ctx, cfg); err != nil {
 			return err
 		}
 		log.Info("Finished post-launch tasks")

--- a/nodeadm/crds/node.eks.aws_nodeconfigs.yaml
+++ b/nodeadm/crds/node.eks.aws_nodeconfigs.yaml
@@ -163,6 +163,34 @@ spec:
                           type: string
                         type: array
                     type: object
+                  storage:
+                    description: |-
+                      StorageOptions configures additional EBS volumes to be mounted for
+                      container runtime directories such as /var/lib/containerd.
+                    properties:
+                      volumes:
+                        description: Volumes is a list of EBS volumes to format and
+                          mount on the node.
+                        items:
+                          description: VolumeMount specifies an EBS volume device
+                            and where it should be mounted.
+                          properties:
+                            device:
+                              description: Device is the block device path (e.g.,
+                                "/dev/xvdb").
+                              type: string
+                            fsType:
+                              description: |-
+                                FsType is the filesystem type to format the volume with.
+                                Defaults to "xfs" if unspecified.
+                              type: string
+                            mountTarget:
+                              description: MountTarget is the directory to mount this
+                                volume on.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
                 type: object
               kubelet:
                 description: KubeletOptions are additional parameters passed to `kubelet`.

--- a/nodeadm/internal/cli/container.go
+++ b/nodeadm/internal/cli/container.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 )
@@ -8,7 +10,7 @@ import (
 type CommandContainer interface {
 	AddCommand(Command)
 	Flaggy() *flaggy.Subcommand
-	Run(log *zap.Logger, opts *GlobalOptions) error
+	Run(ctx context.Context, log *zap.Logger, opts *GlobalOptions) error
 	AsCommand() Command
 }
 
@@ -36,10 +38,10 @@ func (c *cmdContainer) Flaggy() *flaggy.Subcommand {
 	return c.cmd
 }
 
-func (c *cmdContainer) Run(log *zap.Logger, opts *GlobalOptions) error {
+func (c *cmdContainer) Run(ctx context.Context, log *zap.Logger, opts *GlobalOptions) error {
 	for _, cmd := range c.cmds {
 		if cmd.Flaggy().Used {
-			return cmd.Run(log, opts)
+			return cmd.Run(ctx, log, opts)
 		}
 	}
 	flaggy.ShowHelpAndExit("No command specified")

--- a/nodeadm/internal/cli/interface.go
+++ b/nodeadm/internal/cli/interface.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 )
 
 type Command interface {
-	Run(log *zap.Logger, opts *GlobalOptions) error
+	Run(ctx context.Context, log *zap.Logger, opts *GlobalOptions) error
 	Flaggy() *flaggy.Subcommand
 }

--- a/nodeadm/internal/cli/main.go
+++ b/nodeadm/internal/cli/main.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/integrii/flaggy"
 	"go.uber.org/zap"
 )
@@ -30,7 +32,8 @@ func (m *Main) Run() {
 
 	for _, cmd := range m.Commands {
 		if cmd.Flaggy().Used {
-			err := cmd.Run(log, opts)
+			ctx := context.Background()
+			err := cmd.Run(ctx, log, opts)
 			if err != nil {
 				log.Fatal("Command failed", zap.Error(err))
 			}

--- a/nodeadm/internal/containerd/daemon.go
+++ b/nodeadm/internal/containerd/daemon.go
@@ -1,6 +1,8 @@
 package containerd
 
 import (
+	"context"
+
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/daemon"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/system"
@@ -22,7 +24,7 @@ func NewContainerdDaemon(daemonManager daemon.DaemonManager, resources system.Re
 	}
 }
 
-func (cd *containerd) Configure(c *api.NodeConfig) error {
+func (cd *containerd) Configure(ctx context.Context, c *api.NodeConfig) error {
 	if err := writeBaseRuntimeSpec(c); err != nil {
 		return err
 	}
@@ -32,19 +34,19 @@ func (cd *containerd) Configure(c *api.NodeConfig) error {
 	if err := writeContainerdConfig(c, cd.resources); err != nil {
 		return err
 	}
-	if err := writeSOCIServiceDependency(c, cd.resources); err != nil {
+	if err := writeSOCIServiceDependency(ctx, c, cd.resources, cd.daemonManager); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (cd *containerd) EnsureRunning() error {
-	return cd.daemonManager.RestartDaemon(ContainerdDaemonName)
+func (cd *containerd) EnsureRunning(ctx context.Context) error {
+	return cd.daemonManager.RestartDaemon(ctx, ContainerdDaemonName)
 }
 
-func (cd *containerd) PostLaunch(c *api.NodeConfig) error {
+func (cd *containerd) PostLaunch(ctx context.Context, c *api.NodeConfig) error {
 	if UseSOCISnapshotter(c, cd.resources) {
-		if err := importSandboxImageForSOCI(); err != nil {
+		if err := importSandboxImageForSOCI(ctx); err != nil {
 			return err
 		}
 	}

--- a/nodeadm/internal/containerd/sandbox_image.go
+++ b/nodeadm/internal/containerd/sandbox_image.go
@@ -1,6 +1,7 @@
 package containerd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -8,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
+	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/daemon"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/system"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
 )
@@ -32,7 +34,7 @@ After=soci-snapshotter.service
 // Type=notify, systemd will not consider it active until its gRPC server sends
 // READY=1. This guarantees that when EnsureRunning() returns after starting
 // containerd, the SOCI snapshotter is fully initialized and ready to serve requests.
-func writeSOCIServiceDependency(cfg *api.NodeConfig, resources system.Resources) error {
+func writeSOCIServiceDependency(ctx context.Context, cfg *api.NodeConfig, resources system.Resources, daemonManager daemon.DaemonManager) error {
 	if !UseSOCISnapshotter(cfg, resources) {
 		return nil
 	}
@@ -40,8 +42,8 @@ func writeSOCIServiceDependency(cfg *api.NodeConfig, resources system.Resources)
 	if err := util.WriteFileWithDir(sociDependencyDropInPath, []byte(sociDependencyDropIn), configPerm); err != nil {
 		return fmt.Errorf("writing SOCI dependency drop-in: %w", err)
 	}
-	if output, err := exec.Command("systemctl", "daemon-reload").CombinedOutput(); err != nil {
-		return fmt.Errorf("reloading systemd after writing drop-in: %w, output: %s", err, string(output))
+	if err := daemonManager.Reload(ctx); err != nil {
+		return fmt.Errorf("reloading systemd after writing drop-in: %w", err)
 	}
 	return nil
 }
@@ -57,7 +59,7 @@ func writeSOCIServiceDependency(cfg *api.NodeConfig, resources system.Resources)
 // By the time this function runs, the SOCI snapshotter is guaranteed to be ready
 // because writeSOCIServiceDependency() adds a systemd ordering constraint ensuring
 // soci-snapshotter.service is active before containerd.service starts.
-func importSandboxImageForSOCI() error {
+func importSandboxImageForSOCI(ctx context.Context) error {
 	if _, err := os.Stat(pauseImageArchive); err != nil {
 		if os.IsNotExist(err) {
 			zap.L().Warn("Pause image archive not found, skipping SOCI import", zap.String("path", pauseImageArchive))
@@ -67,7 +69,7 @@ func importSandboxImageForSOCI() error {
 	}
 
 	zap.L().Info("Importing pause image into SOCI snapshotter", zap.String("path", pauseImageArchive))
-	cmd := exec.Command("ctr",
+	cmd := exec.CommandContext(ctx, "ctr",
 		"--namespace", "k8s.io",
 		"images", "import",
 		"--snapshotter", "soci",

--- a/nodeadm/internal/daemon/interface.go
+++ b/nodeadm/internal/daemon/interface.go
@@ -1,21 +1,23 @@
 package daemon
 
 import (
+	"context"
+
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
 )
 
 type Daemon interface {
 	// Configure configures the daemon.
-	Configure(*api.NodeConfig) error
+	Configure(context.Context, *api.NodeConfig) error
 	// EnsureRunning ensures that the daemon is running by either
 	// starting/restarting the daemon, then blocking until the status of the
 	// daemon reflects that it is running.
 	//	* If the daemon is not running, it will be started.
 	//	* If the daemon is already running, and has been re-configured, it will be restarted.
-	EnsureRunning() error
+	EnsureRunning(context.Context) error
 	// PostLaunch runs any additional step that needs to occur after the service
 	// daemon as been started
-	PostLaunch(*api.NodeConfig) error
+	PostLaunch(context.Context, *api.NodeConfig) error
 	// Name returns the name of the daemon.
 	Name() string
 }

--- a/nodeadm/internal/daemon/manager.go
+++ b/nodeadm/internal/daemon/manager.go
@@ -1,5 +1,7 @@
 package daemon
 
+import "context"
+
 type DaemonStatus string
 
 const (
@@ -9,23 +11,34 @@ const (
 )
 
 type DaemonManager interface {
-	// StartDaemon starts the daemon with the given name.
+	// StartDaemon starts the daemon with the given name, blocking until the
+	// daemon has finished starting.
 	// If the daemon is already running, this is a no-op.
-	StartDaemon(name string) error
-	// StopDaemon stops the daemon with the given name.
+	StartDaemon(ctx context.Context, name string) error
+	// StopDaemon stops the daemon with the given name, blocking until the
+	// daemon has finished stopping.
 	// If the daemon is not running, this is a no-op.
-	StopDaemon(name string) error
-	// RestartDaemon restarts the daemon with the given name.
+	StopDaemon(ctx context.Context, name string) error
+	// RestartDaemon restarts the daemon with the given name, blocking until the
+	// daemon has stopped and finished starting again.
 	// If the daemon is not running, it will be started.
-	RestartDaemon(name string) error
+	RestartDaemon(ctx context.Context, name string) error
 	// GetDaemonStatus returns the status of the daemon with the given name.
-	GetDaemonStatus(name string) (DaemonStatus, error)
+	//
+	// Note that the returned status is only a point-in-time observation, and the
+	// daemon may change state immediately afterwards. Prefer making operations
+	// that depend on a daemon retryable over gating them on this status.
+	GetDaemonStatus(ctx context.Context, name string) (DaemonStatus, error)
 	// EnableDaemon enables the daemon with the given name.
 	// If the daemon is already enabled, this is a no-op.
-	EnableDaemon(name string) error
+	EnableDaemon(ctx context.Context, name string) error
 	// DisableDaemon disables the daemon with the given name.
 	// If the daemon is not enabled, this is a no-op.
-	DisableDaemon(name string) error
+	DisableDaemon(ctx context.Context, name string) error
+	// Reload instructs the daemon manager to scan for and reload unit files,
+	// picking up any unit file changes made since it last did so. This is the
+	// equivalent of `systemctl daemon-reload`.
+	Reload(ctx context.Context) error
 	// Close cleans up any underlying resources used by the daemon manager.
 	Close()
 }

--- a/nodeadm/internal/daemon/noop.go
+++ b/nodeadm/internal/daemon/noop.go
@@ -2,6 +2,8 @@
 
 package daemon
 
+import "context"
+
 var _ DaemonManager = &noopDaemonManager{}
 
 type noopDaemonManager struct{}
@@ -10,27 +12,31 @@ func NewDaemonManager() (DaemonManager, error) {
 	return &noopDaemonManager{}, nil
 }
 
-func (m *noopDaemonManager) StartDaemon(name string) error {
+func (m *noopDaemonManager) StartDaemon(ctx context.Context, name string) error {
 	return nil
 }
 
-func (m *noopDaemonManager) StopDaemon(name string) error {
+func (m *noopDaemonManager) StopDaemon(ctx context.Context, name string) error {
 	return nil
 }
 
-func (m *noopDaemonManager) RestartDaemon(name string) error {
+func (m *noopDaemonManager) RestartDaemon(ctx context.Context, name string) error {
 	return nil
 }
 
-func (m *noopDaemonManager) GetDaemonStatus(name string) (DaemonStatus, error) {
+func (m *noopDaemonManager) GetDaemonStatus(ctx context.Context, name string) (DaemonStatus, error) {
 	return DaemonStatusUnknown, nil
 }
 
-func (m *noopDaemonManager) EnableDaemon(name string) error {
+func (m *noopDaemonManager) EnableDaemon(ctx context.Context, name string) error {
 	return nil
 }
 
-func (m *noopDaemonManager) DisableDaemon(name string) error {
+func (m *noopDaemonManager) DisableDaemon(ctx context.Context, name string) error {
+	return nil
+}
+
+func (m *noopDaemonManager) Reload(ctx context.Context) error {
 	return nil
 }
 

--- a/nodeadm/internal/daemon/systemd.go
+++ b/nodeadm/internal/daemon/systemd.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/util"
 	"github.com/coreos/go-systemd/v22/dbus"
 )
 
@@ -21,7 +20,23 @@ const (
 	ModeReplace = "replace"
 	TypeSymlink = "symlink"
 	TypeUnlink  = "unlink"
+
+	// jobResultDone is the systemd job result indicating that a job ran to
+	// completion successfully. The other possible results are: canceled,
+	// timeout, failed, dependency, and skipped.
+	jobResultDone = "done"
+
+	// defaultJobTimeout bounds how long we will wait for a systemd job to
+	// complete when the caller's context carries no deadline of its own.
+	// systemd enforces its own per-unit job timeouts and will report a job
+	// result of "timeout" when they are exceeded, so this is only a backstop
+	// against never hearing back from systemd at all.
+	defaultJobTimeout = 5 * time.Minute
 )
+
+// unitJobFunc enqueues a systemd job for a unit, matching the signature of the
+// go-systemd Conn methods that operate on units, e.g. StartUnitContext.
+type unitJobFunc func(ctx context.Context, name string, mode string, ch chan<- string) (int, error)
 
 func NewDaemonManager() (DaemonManager, error) {
 	conn, err := dbus.NewWithContext(context.Background())
@@ -33,30 +48,68 @@ func NewDaemonManager() (DaemonManager, error) {
 	}, nil
 }
 
-func (m *systemdDaemonManager) StartDaemon(name string) error {
-	if _, err := m.conn.StartUnitContext(context.TODO(), getServiceUnitName(name), ModeReplace, nil); err != nil {
-		return err
-	}
-	return m.waitForStatus(context.TODO(), name, DaemonStatusRunning)
+func (m *systemdDaemonManager) StartDaemon(ctx context.Context, name string) error {
+	return m.runUnitJob(ctx, name, "start", m.conn.StartUnitContext)
 }
 
-func (m *systemdDaemonManager) StopDaemon(name string) error {
-	if _, err := m.conn.StopUnitContext(context.TODO(), getServiceUnitName(name), ModeReplace, nil); err != nil {
-		return err
-	}
-	return m.waitForStatus(context.TODO(), name, DaemonStatusStopped)
+func (m *systemdDaemonManager) StopDaemon(ctx context.Context, name string) error {
+	return m.runUnitJob(ctx, name, "stop", m.conn.StopUnitContext)
 }
 
-func (m *systemdDaemonManager) RestartDaemon(name string) error {
-	if _, err := m.conn.RestartUnitContext(context.TODO(), getServiceUnitName(name), ModeReplace, nil); err != nil {
-		return err
-	}
-	return m.waitForStatus(context.TODO(), name, DaemonStatusRunning)
+func (m *systemdDaemonManager) RestartDaemon(ctx context.Context, name string) error {
+	return m.runUnitJob(ctx, name, "restart", m.conn.RestartUnitContext)
 }
 
-func (m *systemdDaemonManager) GetDaemonStatus(name string) (DaemonStatus, error) {
+// runUnitJob enqueues a systemd job for the given daemon and blocks until
+// systemd reports that the job has completed.
+//
+// The Start/Stop/RestartUnit methods reply as soon as the job has been
+// *enqueued*, not once it has run. PID 1 sends the reply from its D-Bus handler
+// while the job is still sitting in the run queue, and the run queue is
+// dispatched at a lower event loop priority than incoming IPC. A caller that
+// reads the unit's ActiveState immediately after the call returns is therefore
+// likely to observe the state from before the job ran, e.g. the still-running
+// process that a restart is about to stop.
+//
+// Waiting on the job's completion signal avoids that entirely: systemd emits
+// JobRemoved only once the job is finished, which for a restart is after the
+// unit has been stopped and has become active again. For a Type=notify unit,
+// "active" means the service has sent READY=1.
+func (m *systemdDaemonManager) runUnitJob(ctx context.Context, name string, verb string, enqueue unitJobFunc) error {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultJobTimeout)
+		defer cancel()
+	}
+
 	unitName := getServiceUnitName(name)
-	status, err := m.conn.GetUnitPropertyContext(context.TODO(), unitName, "ActiveState")
+
+	// this channel must be buffered: the connection cannot process further jobs
+	// until the completion result has been written to it, and we abandon it
+	// without reading if we stop waiting below.
+	resultCh := make(chan string, 1)
+
+	// note that go-systemd registers resultCh for the job's completion signal
+	// while holding the lock its signal dispatcher needs, so the result cannot
+	// be missed even if the job completes before this call returns.
+	if _, err := enqueue(ctx, unitName, ModeReplace, resultCh); err != nil {
+		return fmt.Errorf("enqueuing %s job for %s: %w", verb, unitName, err)
+	}
+
+	select {
+	case result := <-resultCh:
+		if result != jobResultDone {
+			return fmt.Errorf("%s job for %s finished with result %q", verb, unitName, result)
+		}
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("waiting for %s job for %s to complete: %w", verb, unitName, ctx.Err())
+	}
+}
+
+func (m *systemdDaemonManager) GetDaemonStatus(ctx context.Context, name string) (DaemonStatus, error) {
+	unitName := getServiceUnitName(name)
+	status, err := m.conn.GetUnitPropertyContext(ctx, unitName, "ActiveState")
 	if err != nil {
 		return DaemonStatusUnknown, err
 	}
@@ -70,9 +123,9 @@ func (m *systemdDaemonManager) GetDaemonStatus(name string) (DaemonStatus, error
 	}
 }
 
-func (m *systemdDaemonManager) EnableDaemon(name string) error {
+func (m *systemdDaemonManager) EnableDaemon(ctx context.Context, name string) error {
 	unitName := getServiceUnitName(name)
-	_, changes, err := m.conn.EnableUnitFilesContext(context.TODO(), []string{unitName}, false, false)
+	_, changes, err := m.conn.EnableUnitFilesContext(ctx, []string{unitName}, false, false)
 	if err != nil {
 		return err
 	}
@@ -85,9 +138,9 @@ func (m *systemdDaemonManager) EnableDaemon(name string) error {
 	return nil
 }
 
-func (m *systemdDaemonManager) DisableDaemon(name string) error {
+func (m *systemdDaemonManager) DisableDaemon(ctx context.Context, name string) error {
 	unitName := getServiceUnitName(name)
-	changes, err := m.conn.DisableUnitFilesContext(context.TODO(), []string{unitName}, false)
+	changes, err := m.conn.DisableUnitFilesContext(ctx, []string{unitName}, false)
 	if err != nil {
 		return err
 	}
@@ -100,26 +153,17 @@ func (m *systemdDaemonManager) DisableDaemon(name string) error {
 	return nil
 }
 
+// Reload instructs systemd to scan for and reload unit files, e.g. to pick up a
+// drop-in written by a daemon's Configure step. This is the D-Bus equivalent of
+// `systemctl daemon-reload`.
+func (m *systemdDaemonManager) Reload(ctx context.Context) error {
+	return m.conn.ReloadContext(ctx)
+}
+
 func (m *systemdDaemonManager) Close() {
 	m.conn.Close()
 }
 
 func getServiceUnitName(name string) string {
 	return fmt.Sprintf("%s.service", name)
-}
-
-func (m *systemdDaemonManager) waitForStatus(ctx context.Context, name string, targetStatus DaemonStatus) error {
-	return util.NewRetrier(
-		util.WithRetryAlways(),
-		util.WithBackoffFixed(250*time.Millisecond),
-	).Retry(ctx, func() error {
-		status, err := m.GetDaemonStatus(name)
-		if err != nil {
-			return err
-		}
-		if status != targetStatus {
-			return fmt.Errorf("%s status is not %q", name, targetStatus)
-		}
-		return nil
-	})
 }

--- a/nodeadm/internal/kubelet/daemon.go
+++ b/nodeadm/internal/kubelet/daemon.go
@@ -1,6 +1,8 @@
 package kubelet
 
 import (
+	"context"
+
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/api"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/aws/imds"
 	"github.com/awslabs/amazon-eks-ami/nodeadm/internal/daemon"
@@ -31,7 +33,7 @@ func NewKubeletDaemon(daemonManager daemon.DaemonManager, resources system.Resou
 	}
 }
 
-func (k *kubelet) Configure(cfg *api.NodeConfig) error {
+func (k *kubelet) Configure(ctx context.Context, cfg *api.NodeConfig) error {
 	if err := k.writeKubeletConfig(cfg); err != nil {
 		return err
 	}
@@ -50,11 +52,11 @@ func (k *kubelet) Configure(cfg *api.NodeConfig) error {
 	return nil
 }
 
-func (k *kubelet) EnsureRunning() error {
-	return k.daemonManager.RestartDaemon(KubeletDaemonName)
+func (k *kubelet) EnsureRunning(ctx context.Context) error {
+	return k.daemonManager.RestartDaemon(ctx, KubeletDaemonName)
 }
 
-func (k *kubelet) PostLaunch(_ *api.NodeConfig) error {
+func (k *kubelet) PostLaunch(_ context.Context, _ *api.NodeConfig) error {
 	return nil
 }
 

--- a/nodeadm/internal/system/resolve.go
+++ b/nodeadm/internal/system/resolve.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"path/filepath"
 	"strings"
@@ -83,5 +84,5 @@ func (a *resolveAspect) reloadSystemdResolved() error {
 	if err != nil {
 		return err
 	}
-	return manager.RestartDaemon("systemd-resolved")
+	return manager.RestartDaemon(context.TODO(), "systemd-resolved")
 }


### PR DESCRIPTION
When calling EnsureRunning for a systemd unit, that was triggering an async restart on systemd and then immediately polling for the "Running" status on the unit. In certain cases (especially when SOCI was enabled), that check was racy, meaning that the status poll returned too early and dependent calls could fail.

Fix this by using the pre-existing status channel from the DBus API to block until the systemd operation completes.

As part of this change, also thread some contexts throughout the codebase to provide timeouts if needed.