### PR TITLE
feat(nvidia): installing nvidia userspace programs into driver trees

### DIFF
--- a/templates/al2023/helpers/nvidia-kmods.sh
+++ b/templates/al2023/helpers/nvidia-kmods.sh
@@ -68,7 +68,7 @@ function build-grid-kmods() {
   local TREE_DIR="${1}"
   local DRIVER_VERSION="${2}"
 
-  if [ "${ARCH}" != "x86_64" ]; then
+  if [ "${ARCH}" == "aarch64" ]; then
     echo "No GRID runfile is published for ${ARCH}, skipping"
     return 0
   fi

--- a/templates/al2023/helpers/nvidia-userspace.sh
+++ b/templates/al2023/helpers/nvidia-userspace.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Userspace for the driver trees. Packages identical across driver versions are installed on
+# the host once. The rest go into their own tree, since the host cannot hold two versions of
+# the same package.
+
+readonly NVIDIA_USERSPACE_RPM_DIR="${WORKING_DIR}/nvidia-userspace-rpms"
+readonly NVIDIA_VERSION_SHARED_RPM_DIR="${NVIDIA_USERSPACE_RPM_DIR}/version-shared"
+
+readonly NVIDIA_USERSPACE_PACKAGES=(
+  libnvidia-fbc
+  nvidia-driver
+  nvidia-driver-cuda
+  nvidia-fabricmanager
+  nvidia-libXNVCtrl-devel
+  nvidia-persistenced
+  nvidia-settings
+  nvidia-xconfig
+  xorg-x11-nvidia
+)
+
+# Download one tree's full set of userspace rpms without installing any of them.
+function download-nvidia-userspace-rpms() {
+  local TREE="${1}"
+  local RPM_LIST="${NVIDIA_USERSPACE_RPM_DIR}/${TREE}"
+
+  local DRIVER_VERSION
+  DRIVER_VERSION=$(cat "${NVIDIA_TREE_ROOT}/${TREE}/.version")
+
+  local VERSIONED_PACKAGES=()
+  local PACKAGE
+  for PACKAGE in "${NVIDIA_USERSPACE_PACKAGES[@]}"; do
+    VERSIONED_PACKAGES+=("${PACKAGE}-${DRIVER_VERSION}")
+  done
+
+  echo "Downloading the NVIDIA ${DRIVER_VERSION} userspace rpms for tree ${TREE}"
+  mkdir -p "${RPM_LIST}"
+  sudo dnf install -y --downloadonly --destdir="${RPM_LIST}" \
+    --setopt=*.module_hotfixes=true \
+    "${VERSIONED_PACKAGES[@]}"
+
+  # The version-specific rpms are extracted rather than installed, so no transaction ever
+  # verifies them.
+  rpm -K "${RPM_LIST}"/*.rpm
+}
+
+# Identifies packages shared between 2 trees and moves them to a common directory
+function partition-nvidia-userspace-rpms() {
+  if [ "${#}" -ne 2 ]; then
+    echo >&2 "ERROR: partition-nvidia-userspace-rpms compares exactly two rpm lists, got ${#}"
+    return 1
+  fi
+
+  local RPM_LIST_1="${NVIDIA_USERSPACE_RPM_DIR}/${1}"
+  local RPM_LIST_2="${NVIDIA_USERSPACE_RPM_DIR}/${2}"
+  local RPM RPM_FILENAME MATCHING_RPM
+  local VERSION_SHARED_COUNT=0
+
+  mkdir -p "${NVIDIA_VERSION_SHARED_RPM_DIR}"
+  for RPM in "${RPM_LIST_1}"/*.rpm; do
+    RPM_FILENAME=$(basename "${RPM}")
+    MATCHING_RPM="${RPM_LIST_2}/${RPM_FILENAME}"
+    [ -e "${MATCHING_RPM}" ] || continue
+
+    sudo mv "${RPM}" "${NVIDIA_VERSION_SHARED_RPM_DIR}/"
+    sudo rm -f "${MATCHING_RPM}"
+    VERSION_SHARED_COUNT=$((VERSION_SHARED_COUNT + 1))
+  done
+
+  echo "Userspace rpms: ${VERSION_SHARED_COUNT} shared between ${1} and ${2}"
+}
+
+# Install the version-shared rpms on the host normally, so their scriptlets run and the rpm
+# database is populated without emulation.
+function install-version-shared-rpms() {
+  if ! compgen -G "${NVIDIA_VERSION_SHARED_RPM_DIR}/*.rpm" > /dev/null; then
+    echo >&2 "ERROR: ${NVIDIA_VERSION_SHARED_RPM_DIR} is empty, the trees have no rpms in common"
+    return 1
+  fi
+
+  local VERSION_SHARED_RPMS=("${NVIDIA_VERSION_SHARED_RPM_DIR}"/*.rpm)
+
+  echo "Installing ${#VERSION_SHARED_RPMS[@]} version-shared userspace packages on the host"
+  sudo dnf install -y --setopt=keepcache=1 --setopt=*.module_hotfixes=true "${VERSION_SHARED_RPMS[@]}"
+
+  sudo rm -rf "${NVIDIA_VERSION_SHARED_RPM_DIR}"
+}
+
+# Extract contents of version specific packages into the tree
+function extract-version-specific-rpms() {
+  local TREE="${1}"
+  local TREE_DIR="${NVIDIA_TREE_ROOT}/${TREE}"
+  local RPM_LIST="${NVIDIA_USERSPACE_RPM_DIR}/${TREE}"
+  local RPM
+
+  if ! compgen -G "${RPM_LIST}/*.rpm" > /dev/null; then
+    echo >&2 "ERROR: nothing version-specific for tree ${TREE}, check that the trees resolved to different versions"
+    return 1
+  fi
+
+  local VERSION_SPECIFIC_RPMS=("${RPM_LIST}"/*.rpm)
+  echo "Extracting ${#VERSION_SPECIFIC_RPMS[@]} version-specific packages into ${TREE_DIR}:"
+
+  # Staged whole so the boot-time commit phase can register them in the rpm database.
+  sudo install -d "${TREE_DIR}/.rpms"
+  for RPM in "${VERSION_SPECIFIC_RPMS[@]}"; do
+    echo "  $(basename "${RPM}")"
+    rpm2cpio "${RPM}" | (cd "${TREE_DIR}" && sudo cpio -idmu --quiet)
+    sudo install -m 0644 "${RPM}" "${TREE_DIR}/.rpms/"
+  done
+
+  sudo rm -rf "${RPM_LIST}"
+}
+
+# https://github.com/NVIDIA/yum-packaging-nvidia-persistenced/blob/fedora/nvidia-persistenced.spec
+function create-persistenced-user() {
+  if ! getent group nvidia-persistenced > /dev/null; then
+    sudo groupadd -r nvidia-persistenced
+  fi
+  if ! getent passwd nvidia-persistenced > /dev/null; then
+    sudo useradd -r -g nvidia-persistenced -d /var/run/nvidia-persistenced -s /sbin/nologin \
+      -c "NVIDIA Persistence Daemon" nvidia-persistenced
+  fi
+}
+
+# Supported device list per major version.
+# Used to resolve target version at boot
+function install-supported-device-list() {
+  local TREE="${1}"
+
+  local DRIVER_VERSION
+  DRIVER_VERSION=$(cat "${NVIDIA_TREE_ROOT}/${TREE}/.version")
+  local MAJOR_VERSION="${DRIVER_VERSION%%.*}"
+  local DEVICE_LIST="${WORKING_DIR}/gpu/nvidia-open-supported-devices-${MAJOR_VERSION}.txt"
+
+  if [ ! -f "${DEVICE_LIST}" ]; then
+    echo >&2 "ERROR: no supported-devices list for major version ${MAJOR_VERSION}, found:"
+    ls >&2 "${WORKING_DIR}/gpu/"nvidia-open-supported-devices-*.txt
+    return 1
+  fi
+
+  sudo install -m 0644 "${DEVICE_LIST}" /etc/eks/
+}

--- a/templates/al2023/provisioners/install-nvidia-drivers.sh
+++ b/templates/al2023/provisioners/install-nvidia-drivers.sh
@@ -35,6 +35,8 @@ readonly NVIDIA_TREE_ROOT="/opt/nvidia"
 
 # shellcheck disable=SC1090
 source "${WORKING_DIR}/helpers/nvidia-kmods.sh"
+# shellcheck disable=SC1090
+source "${WORKING_DIR}/helpers/nvidia-userspace.sh"
 
 ################################################################################
 ### Add repository #############################################################
@@ -93,10 +95,6 @@ sudo dnf versionlock 'kernel*'
 
 sudo dnf -y install dkms
 
-################################################################################
-### Resolve versions and create the driver trees ###############################
-################################################################################
-
 # To ensure proper functionality, we need to enforce that all three kernel modules are on the same NVIDIA driver version
 # so they are compatible with the same userspace components.
 # If one of the open module or the grid driver runfile version are older, we use that version for all installations.
@@ -129,7 +127,8 @@ function resolve-tree-version() {
   fi
 }
 
-function build-driver-tree() {
+# Sets up a nvidia driver version tree
+function create-driver-tree() {
   local TREE="${1}"
   local MAJOR_VERSION="${2}"
 
@@ -142,11 +141,63 @@ function build-driver-tree() {
   echo "${DRIVER_VERSION}" | sudo tee "${TREE_DIR}/.version" > /dev/null
   # A simple marker to act as conditional for systemd services
   sudo touch "${TREE_DIR}/.tree-${TREE}"
+}
 
+# Builds contents of a nvidia driver version tree.
+# Stores kernel modules as well as userspace package contents.
+function build-driver-tree() {
+  local TREE="${1}"
+  local TREE_DIR="${NVIDIA_TREE_ROOT}/${TREE}"
+
+  local DRIVER_VERSION
+  DRIVER_VERSION=$(cat "${TREE_DIR}/.version")
+
+  extract-version-specific-rpms "${TREE}"
   build-open-kmods "${TREE_DIR}" "${DRIVER_VERSION}"
   build-proprietary-kmods "${TREE_DIR}" "${DRIVER_VERSION}"
   build-grid-kmods "${TREE_DIR}" "${DRIVER_VERSION}"
+  install-supported-device-list "${TREE}"
 }
 
-build-driver-tree lts "${NVIDIA_DRIVER_LTS_VERSION}"
-build-driver-tree pb "${NVIDIA_DRIVER_PB_VERSION}"
+################################################################################
+### Resolve versions and create the driver trees ###############################
+################################################################################
+
+# Runs for every tree first: the rpm download below needs each tree's resolved version.
+create-driver-tree lts "${NVIDIA_DRIVER_LTS_VERSION}"
+create-driver-tree pb "${NVIDIA_DRIVER_PB_VERSION}"
+
+################################################################################
+### NVIDIA version dependent userspace packages  ###############################
+################################################################################
+
+# Download all rpms for each version. Partition them into packages shared between both
+# versions vs specific to a version. Install the shared packages directly on the host.
+download-nvidia-userspace-rpms lts
+download-nvidia-userspace-rpms pb
+partition-nvidia-userspace-rpms lts pb
+
+install-version-shared-rpms
+
+################################################################################
+### Build the driver trees #####################################################
+################################################################################
+
+build-driver-tree lts
+build-driver-tree pb
+
+################################################################################
+### Set up rest of the host ####################################################
+################################################################################
+
+# NVLSM
+# https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html#systems-using-fourth-generation-nvswitches
+echo "ib_umad" | sudo tee -a /etc/modules-load.d/ib-umad.conf
+sudo dnf -y install \
+  libibumad \
+  infiniband-diags \
+  nvlsm
+sudo dnf -y install nvidia-container-toolkit
+
+# %pre scripts of nvidia-persistenced adds a user required to run the persistenced daemon.
+create-persistenced-user

--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -100,10 +100,74 @@ validate_nvidia_grid_modules() {
   fi
 }
 
-if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
-  # NVIDIA publishes no aarch64 GRID runfile, so that flavor is never built there.
-  if [ "$(uname -m)" == "x86_64" ]; then
-    validate_nvidia_grid_modules lts
-    validate_nvidia_grid_modules pb
+NVIDIA_TREES=(lts pb)
+NVIDIA_KMOD_FLAVORS=(open proprietary grid)
+
+# A tree is pinned to one driver version so its kernel modules and userspace are compatible.
+validate_nvidia_tree_version() {
+  local tree=$1
+  local tree_dir="/opt/nvidia/${tree}"
+  local driver_version flavor extra_dir modules module_version
+
+  driver_version=$(cat "${tree_dir}/.version")
+
+  for flavor in "${NVIDIA_KMOD_FLAVORS[@]}"; do
+    # NVIDIA publishes no aarch64 GRID runfile, so that flavor is never built there.
+    if [ "${flavor}" == "grid" ] && [ "$(uname -m)" == "aarch64" ]; then
+      continue
+    fi
+
+    extra_dir="${tree_dir}/flavors/${flavor}/lib/modules/${KERNEL_RELEASE}/extra"
+    # The suffix varies with the kernel's module compression.
+    modules=("${extra_dir}"/nvidia.ko*)
+    if [ ! -e "${modules[0]}" ]; then
+      echo "${extra_dir} has no nvidia.ko"
+      exit 1
+    fi
+
+    module_version=$(modinfo -F version "${modules[0]}")
+    if [ "${module_version}" != "${driver_version}" ]; then
+      echo "${modules[0]} reports version ${module_version}, expected ${driver_version}"
+      exit 1
+    fi
+  done
+
+  # libcuda is version-locked to nvidia.ko
+  if [ ! -e "${tree_dir}/usr/lib64/libcuda.so.${driver_version}" ]; then
+    echo "${tree_dir} has no libcuda.so.${driver_version}"
+    exit 1
   fi
+}
+
+# Boot-time flavor selection reads this list, so a baked tree without one picks the wrong
+# kernel module.
+validate_nvidia_supported_device_list() {
+  local tree=$1
+  local major_version
+
+  major_version=$(cut -d. -f1 "/opt/nvidia/${tree}/.version")
+  if [ ! -f "/etc/eks/nvidia-open-supported-devices-${major_version}.txt" ]; then
+    echo "/etc/eks is missing the supported-devices list for major version ${major_version}"
+    exit 1
+  fi
+}
+
+if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
+  for tree in "${NVIDIA_TREES[@]}"; do
+    validate_nvidia_tree_version "${tree}"
+    validate_nvidia_supported_device_list "${tree}"
+
+    # NVIDIA publishes no aarch64 GRID runfile, so that flavor is never built there.
+    if [ "$(uname -m)" != "aarch64" ]; then
+      validate_nvidia_grid_modules "${tree}"
+    fi
+  done
+
+  # Emulated from the nvidia-persistenced rpm's %pre, which never runs on an extracted package.
+  if ! getent passwd nvidia-persistenced > /dev/null; then
+    echo "the nvidia-persistenced user was not created"
+    exit 1
+  fi
+
+  echo "NVIDIA driver trees were validated: ${NVIDIA_TREES[*]}"
 fi


### PR DESCRIPTION
**Description of changes:**

Installs the NVIDIA userspace into the driver trees created in #2783 

A new sourced library, `helpers/nvidia-userspace.sh`, downloads each tree's userspace RPMs and sorts them into packages shared between the driver versions and packages belonging to one version. The host cannot hold two versions of the same package, so the second group is extracted into the trees instead of being installed.

In this PR:

- Downloads the full userspace closure per tree, without installing it onto the build host.
- Partitions the RPMs into shared and version-specific sets (A test between 580 and 595 resulted in 199 shared and 19 per tree)
- Shared set is directly installed to host
- Specific set is stored inside the version specific tree
- Created a user for running nvidia-persistenced daemon as per the `%pre` scriptlet of the RPM.

`nvidia-imex` is purposely skipped in this CR. Will be adding it back later after collecting a few more details. 

Build time checks

- For each tree, ensure that the kernel modules, userspace programs within the tree all belong to the same version recorded for the tree

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
