### PR TITLE
feat(nvidia): add boot-time kmod load scripts

### DIFF
--- a/templates/al2023/helpers/nvidia-kmods.sh
+++ b/templates/al2023/helpers/nvidia-kmods.sh
@@ -13,12 +13,13 @@ readonly ARCH
 function build-open-kmods() {
   local TREE_DIR="${1}"
   local DRIVER_VERSION="${2}"
+  local FLAVOR_SUBTREE="${TREE_DIR}/flavors/open"
 
   echo "Building open kernel modules for NVIDIA ${DRIVER_VERSION}"
-  extract-kmod-source "kmod-nvidia-open-dkms-${DRIVER_VERSION}" "${TREE_DIR}"
+  extract-kmod-source "kmod-nvidia-open-dkms-${DRIVER_VERSION}" "${FLAVOR_SUBTREE}"
   sudo dkms add -m nvidia -v "${DRIVER_VERSION}"
   sudo dkms build -m nvidia -v "${DRIVER_VERSION}"
-  harvest-dkms-modules nvidia "${DRIVER_VERSION}" "${TREE_DIR}/flavors/open"
+  harvest-dkms-modules nvidia "${DRIVER_VERSION}" "${FLAVOR_SUBTREE}"
 
   # Built here, while this version's nvidia source is the only one in /usr/src.
   build-gdrdrv "${TREE_DIR}" "${DRIVER_VERSION}"
@@ -31,21 +32,23 @@ function build-open-kmods() {
 function build-proprietary-kmods() {
   local TREE_DIR="${1}"
   local DRIVER_VERSION="${2}"
+  local FLAVOR_SUBTREE="${TREE_DIR}/flavors/proprietary"
 
   echo "Building proprietary kernel modules for NVIDIA ${DRIVER_VERSION}"
-  extract-kmod-source "kmod-nvidia-latest-dkms-${DRIVER_VERSION}" "${TREE_DIR}"
+  extract-kmod-source "kmod-nvidia-latest-dkms-${DRIVER_VERSION}" "${FLAVOR_SUBTREE}"
   sudo dkms add -m nvidia -v "${DRIVER_VERSION}"
   sudo dkms build -m nvidia -v "${DRIVER_VERSION}"
-  harvest-dkms-modules nvidia "${DRIVER_VERSION}" "${TREE_DIR}/flavors/proprietary"
+  harvest-dkms-modules nvidia "${DRIVER_VERSION}" "${FLAVOR_SUBTREE}"
 
   sudo dkms remove -m nvidia -v "${DRIVER_VERSION}" --all
   sudo rm -rf "/usr/src/nvidia-${DRIVER_VERSION}"
 }
 
-# Build and harvests gdrdrv kernel modules. Built only with the open nvidia flavor
+# Build and harvests gdrdrv kernel modules. Built only with the open nvidia flavor.
 function build-gdrdrv() {
   local TREE_DIR="${1}"
   local DRIVER_VERSION="${2}"
+  local FLAVOR_SUBTREE="${TREE_DIR}/flavors/open"
 
   if [ "${ENABLE_NVIDIA_GDRCOPY_DRIVER}" != "true" ] || [ -z "${NVIDIA_GDRCOPY_DRIVER_VERSION}" ]; then
     return 0
@@ -54,10 +57,10 @@ function build-gdrdrv() {
   local GDRCOPY_VERSION="${NVIDIA_GDRCOPY_DRIVER_VERSION}"
 
   echo "Building gdrdrv ${GDRCOPY_VERSION} against NVIDIA ${DRIVER_VERSION}"
-  extract-kmod-source "gdrcopy-kmod-${GDRCOPY_VERSION}" "${TREE_DIR}"
+  extract-kmod-source "gdrcopy-kmod-${GDRCOPY_VERSION}" "${FLAVOR_SUBTREE}"
   sudo dkms add -m gdrdrv -v "${GDRCOPY_VERSION}"
   sudo dkms build -m gdrdrv -v "${GDRCOPY_VERSION}"
-  harvest-dkms-modules gdrdrv "${GDRCOPY_VERSION}" "${TREE_DIR}/flavors/open"
+  harvest-dkms-modules gdrdrv "${GDRCOPY_VERSION}" "${FLAVOR_SUBTREE}"
 
   sudo dkms remove -m gdrdrv -v "${GDRCOPY_VERSION}" --all
   sudo rm -rf "/usr/src/gdrdrv-${GDRCOPY_VERSION}"
@@ -116,7 +119,7 @@ function build-grid-kmods() {
 # Download a kmod source rpm and unpack it
 function extract-kmod-source() {
   local SOURCE_PACKAGE="${1}"
-  local TREE_DIR="${2}"
+  local RPM_STAGING_DIR="${2}"
   local DOWNLOAD_DIR="${WORKING_DIR}/nvidia-kmod-rpms"
 
   mkdir -p "${DOWNLOAD_DIR}"
@@ -127,8 +130,8 @@ function extract-kmod-source() {
   rpm2cpio "${DOWNLOAD_DIR}"/*.rpm | (cd / && sudo cpio -idmu --quiet)
 
   # Save the RPM files for rpmdb registration later.
-  sudo install -d "${TREE_DIR}/.rpms"
-  sudo mv "${DOWNLOAD_DIR}"/*.rpm "${TREE_DIR}/.rpms/"
+  sudo install -d "${RPM_STAGING_DIR}/.rpms"
+  sudo mv "${DOWNLOAD_DIR}"/*.rpm "${RPM_STAGING_DIR}/.rpms/"
   sudo rm -rf "${DOWNLOAD_DIR}"
 }
 

--- a/templates/al2023/provisioners/install-nvidia-drivers.sh
+++ b/templates/al2023/provisioners/install-nvidia-drivers.sh
@@ -201,3 +201,31 @@ sudo dnf -y install nvidia-container-toolkit
 
 # %pre scripts of nvidia-persistenced adds a user required to run the persistenced daemon.
 create-persistenced-user
+
+################################################################################
+### Install boot scripts #######################################################
+################################################################################
+
+sudo install -d -m 0755 /etc/eks
+sudo install -m 0755 "${WORKING_DIR}/gpu/resolve-nvidia-driver.sh" /etc/eks/resolve-nvidia-driver.sh
+sudo install -m 0755 "${WORKING_DIR}/gpu/setup-nvidia.sh" /etc/eks/setup-nvidia.sh
+
+################################################################################
+### Install systemd units ######################################################
+################################################################################
+
+sudo install -d -m 0755 /etc/systemd/system
+sudo install -m 0644 "${WORKING_DIR}/gpu/nvidia-driver-resolve.service" /etc/systemd/system/nvidia-driver-resolve.service
+sudo install -m 0644 "${WORKING_DIR}/gpu/nvidia-setup.service" /etc/systemd/system/nvidia-setup.service
+sudo install -m 0644 "${WORKING_DIR}/gpu/usr-bin.mount" /etc/systemd/system/usr-bin.mount
+sudo install -m 0644 "${WORKING_DIR}/gpu/usr-lib64.mount" /etc/systemd/system/usr-lib64.mount
+sudo install -m 0644 "${WORKING_DIR}/gpu/usr-share.mount" /etc/systemd/system/usr-share.mount
+
+# Overlay upperdir/workdir. Must exist before mount units activate.
+sudo mkdir -p /var/lib/eks/nvidia/{bin,lib64,share}/{upper,work}
+
+sudo systemctl enable nvidia-driver-resolve.service \
+  nvidia-setup.service \
+  usr-bin.mount \
+  usr-lib64.mount \
+  usr-share.mount

--- a/templates/al2023/runtime/gpu/nvidia-driver-resolve.service
+++ b/templates/al2023/runtime/gpu/nvidia-driver-resolve.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=NVIDIA driver resolve
+ConditionPathExists=!/opt/nvidia/current/.driver-flavor
+DefaultDependencies=no
+After=local-fs.target
+Before=shutdown.target
+Conflicts=shutdown.target
+RefuseManualStart=yes
+RefuseManualStop=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/etc/eks/resolve-nvidia-driver.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/al2023/runtime/gpu/nvidia-setup.service
+++ b/templates/al2023/runtime/gpu/nvidia-setup.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=NVIDIA setup
+After=nvidia-driver-resolve.service usr-bin.mount usr-lib64.mount usr-share.mount
+Wants=usr-bin.mount usr-lib64.mount usr-share.mount
+ConditionPathExists=/opt/nvidia/current/.driver-flavor
+RefuseManualStart=yes
+RefuseManualStop=yes
+StartLimitBurst=5
+StartLimitIntervalSec=infinity
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/etc/eks/setup-nvidia.sh
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/al2023/runtime/gpu/resolve-nvidia-driver.sh
+++ b/templates/al2023/runtime/gpu/resolve-nvidia-driver.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -x
+set -o errexit
+set -o pipefail
+set -o nounset
+
+NVIDIA_TREE_ROOT="${NVIDIA_TREE_ROOT:-/opt/nvidia}"
+EKS_CONFIG_DIR="${EKS_CONFIG_DIR:-/etc/eks}"
+MODPROBE_D_DIR="${MODPROBE_D_DIR:-/etc/modprobe.d}"
+DMI_PRODUCT_NAME_PATH="${DMI_PRODUCT_NAME_PATH:-/sys/devices/virtual/dmi/id/product_name}"
+
+readonly NVIDIA_VENDOR_ID="10de"
+readonly PCI_CLASS_CODES=(
+  "0300" # VGA controller; instance types like g3, g4
+  "0302" # 3D controller; instance types like p4, p5
+)
+
+# NVIDIA vGPU (GRID) device:subsystem tuples. Format: "DEVICE:SUBDEVICE" (lowercase, no 0x prefix).
+readonly GRID_REQUIRED_SUBDEVICES=(
+  "27b8:1733" # L4:L4-3Q
+  "27b8:1735" # L4:L4-6Q
+  "27b8:1737" # L4:L4-12Q
+)
+
+# Return 0 iff every attached NVIDIA GPU's device id is present in the given
+# supported-devices file. Returns 1 if any device id is absent from the file.
+function devices_supported_by() {
+  local support_file="${1}"
+  if [[ ! -f "${support_file}" ]]; then
+    echo >&2 "resolve: supported-devices file not found: ${support_file}"
+    exit 1
+  fi
+  local pci_class_code nvidia_device_id
+  for pci_class_code in "${PCI_CLASS_CODES[@]}"; do
+    for nvidia_device_id in $(lspci -n -mm -d "${NVIDIA_VENDOR_ID}::${pci_class_code}" | awk '{print $4}' | tr -d '"' | tr '[:lower:]' '[:upper:]'); do
+      if ! grep "^0x${nvidia_device_id}\s" "${support_file}"; then
+        return 1
+      fi
+    done
+  done
+  return 0
+}
+
+function device-requires-grid() {
+  local nvidia_grid_subdevice nvidia_subdevice
+  for nvidia_grid_subdevice in "${GRID_REQUIRED_SUBDEVICES[@]}"; do
+    for nvidia_subdevice in $(lspci -n -mm -d "${NVIDIA_VENDOR_ID}:" | awk '{print $4":"$7}' | tr -d '"'); do
+      if [[ "${nvidia_grid_subdevice}" == "${nvidia_subdevice}" ]]; then
+        return 0
+      fi
+    done
+  done
+  return 1
+}
+
+function has_nvidia_gpu() {
+  local pci_class_code
+  for pci_class_code in "${PCI_CLASS_CODES[@]}"; do
+    if lspci -n -mm -d "${NVIDIA_VENDOR_ID}::${pci_class_code}" | grep -q .; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+function main() {
+  local instance_type tree flavor lts_major pb_major tree_path current_tree_path
+
+  if ! has_nvidia_gpu; then
+    echo "resolve: no NVIDIA GPU attached, doing nothing"
+    return 0
+  fi
+
+  if ! instance_type=$(cat "${DMI_PRODUCT_NAME_PATH}"); then
+    echo "resolve: failed to read instance_type from ${DMI_PRODUCT_NAME_PATH}"
+    exit 1
+  fi
+
+  if ! lts_major="$(cat "${NVIDIA_TREE_ROOT}/lts/.version" 2> /dev/null | cut -d. -f1)"; then
+    lts_major=""
+  fi
+  if ! pb_major="$(cat "${NVIDIA_TREE_ROOT}/pb/.version" 2> /dev/null | cut -d. -f1)"; then
+    pb_major=""
+  fi
+
+  # LTS open -> PB open -> LTS proprietary. GRID override applied, if required.
+  # SAFETY: choosing LTS/PB open is trivially safe, the NVIDIA open supported devices stipulates they should work.
+  # defaulting to LTS proprietary assumes that any device supported by neither the LTS nor PB should be supported
+  # by the proprietary. this should be true since GRID-required devices are shown as open supported, and NVIDIA
+  # favors open module support for newer GPUs, with older device support sometimes dropped, and PB should always >= LTS
+  if [[ -n "${lts_major}" ]] \
+    && devices_supported_by "${EKS_CONFIG_DIR}/nvidia-open-supported-devices-${lts_major}.txt"; then
+    tree="lts"
+    flavor="open"
+  elif [[ -n "${pb_major}" ]] \
+    && devices_supported_by "${EKS_CONFIG_DIR}/nvidia-open-supported-devices-${pb_major}.txt"; then
+    tree="pb"
+    flavor="open"
+  else
+    tree="lts"
+    flavor="proprietary"
+  fi
+
+  if device-requires-grid; then
+    flavor="grid"
+  fi
+
+  # older g-series instance types required GSP to be disabled, which can only be done on the
+  # proprietary driver
+  case "${instance_type}" in
+    g4dn.* | g5.* | g5g.*)
+      tree="lts"
+      flavor="proprietary"
+      printf 'options nvidia NVreg_EnableGpuFirmware=0\n' \
+        > "${MODPROBE_D_DIR}/nvidia-disable-gsp.conf"
+      ;;
+  esac
+
+  tree_path="${NVIDIA_TREE_ROOT}/${tree}"
+  if [[ ! -d "${tree_path}" || ! -f "${tree_path}/.tree-${tree}" ]]; then
+    echo >&2 "resolve: no ${tree} tree at ${tree_path} (missing directory or .tree-${tree} marker)"
+    exit 1
+  fi
+
+  current_tree_path="${NVIDIA_TREE_ROOT}/current"
+  if ! ln -sfn "${tree_path}" "${current_tree_path}"; then
+    echo >&2 "resolve: ln -sfn ${tree_path} ${current_tree_path} failed"
+    exit 1
+  fi
+
+  printf 'options nvidia NVreg_CoherentGPUMemoryMode=driver\n' \
+    > "${MODPROBE_D_DIR}/40-eks-nvidia-openrm.conf"
+
+  # commit the driver flavor to a state file at the end so that it can be used as a sentinel
+  # for systemd to skip running the service on subsequent boots
+  printf '%s\n' "${flavor}" > "${current_tree_path}/.driver-flavor"
+}
+
+main "$@"

--- a/templates/al2023/runtime/gpu/set-nvidia-clocks.service
+++ b/templates/al2023/runtime/gpu/set-nvidia-clocks.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Configure NVIDIA GPU clock rate
-After=nvidia-persistenced.service
+After=nvidia-setup.service nvidia-persistenced.service
 Requires=nvidia-persistenced.service
 
 ConditionPathExists=/usr/bin/nvidia-smi

--- a/templates/al2023/runtime/gpu/setup-nvidia.sh
+++ b/templates/al2023/runtime/gpu/setup-nvidia.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -x
+set -o errexit
+set -o pipefail
+set -o nounset
+
+NVIDIA_TREE_ROOT="${NVIDIA_TREE_ROOT:-/opt/nvidia}"
+LIB_MODULES_DIR="${LIB_MODULES_DIR:-/lib/modules}"
+FIRMWARE_DIR="${FIRMWARE_DIR:-/usr/lib/firmware}"
+
+# Hardcoded module list. TODO: introduce a per-flavor manifest at
+# ${FLAVOR_SUBTREE}/modules.list, replace these arrays with a
+# manifest-driven loop.
+readonly REQUIRED_MODULES=(nvidia nvidia-modeset nvidia-drm nvidia-uvm)
+# TODO: use a better heuristic than just "optional," e.g. considering if it's required
+# on specific hardware
+readonly OPTIONAL_MODULES=(nvidia-peermem)
+
+KERNEL_VERSION="$(uname -r)"
+readonly KERNEL_VERSION
+readonly TREE="${NVIDIA_TREE_ROOT}/current"
+
+if [[ ! -d "${TREE}" ]]; then
+  echo >&2 "load: no ${TREE}"
+  exit 1
+fi
+
+if ! FLAVOR="$(cat "${TREE}/.driver-flavor")"; then
+  echo >&2 "load: no ${TREE}/.driver-flavor"
+  exit 1
+fi
+readonly FLAVOR
+
+readonly FLAVOR_SUBTREE="${TREE}/flavors/${FLAVOR}"
+if [[ ! -d "${FLAVOR_SUBTREE}/lib/modules/${KERNEL_VERSION}" ]]; then
+  echo >&2 "load: no ${FLAVOR_SUBTREE}/lib/modules/${KERNEL_VERSION}"
+  exit 1
+fi
+
+VERSION="$(cat "${TREE}/.version")"
+readonly VERSION
+
+readonly LOADED_SENTINEL="${TREE}/.loaded"
+if [[ ! -f "${LOADED_SENTINEL}" ]]; then
+  mkdir -p "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra"
+  cp -a --reflink=auto "${FLAVOR_SUBTREE}/lib/modules/${KERNEL_VERSION}"/extra/ "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra/"
+  restorecon -R "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra/" 2> /dev/null || true
+
+  readonly FIRMWARE_STAGE="${TREE}/${FIRMWARE_DIR}/nvidia"
+  mkdir -p "${FIRMWARE_DIR}/nvidia"
+  cp -a --reflink=auto "${FIRMWARE_STAGE}/${VERSION}"/ "${FIRMWARE_DIR}/nvidia/${VERSION}"
+  restorecon -R "${FIRMWARE_DIR}/nvidia/${VERSION}" 2> /dev/null || true
+
+  depmod "${KERNEL_VERSION}"
+
+  echo "${KERNEL_VERSION}" > "${LOADED_SENTINEL}"
+fi
+
+# modprobes do not persist reboots; invocations should be unguarded
+for m in "${REQUIRED_MODULES[@]}"; do
+  modprobe "${m}"
+done
+for m in "${OPTIONAL_MODULES[@]}"; do
+  modprobe "${m}" || echo >&2 "load: optional module ${m} did not load"
+done
+
+if [[ "${FLAVOR}" == "open" ]]; then
+  if modprobe gdrdrv; then
+    gdrdrv_major="$(awk '/gdrdrv/{print $1}' /proc/devices)"
+    if [[ -n "${gdrdrv_major}" ]]; then
+      rm -f /dev/gdrdrv
+      mknod -m 666 /dev/gdrdrv c "${gdrdrv_major}" 0
+    else
+      echo >&2 "load: gdrdrv loaded but no /proc/devices entry; skipping device node"
+    fi
+  else
+    echo >&2 "load: gdrdrv did not load (open flavor, optional)"
+  fi
+fi
+
+# rpm db registration can carry a big time penalty; to optimize first-boot time
+# we keep this at the end so it's out of the critical path for functionality
+readonly COMMITTED_SENTINEL="${TREE}/.driver-committed"
+if [[ ! -f "${COMMITTED_SENTINEL}" ]]; then
+  ldconfig
+  shopt -s nullglob # the GRID flavor has no specific RPMs to expand to
+  readonly RPMS_TO_REGISTER=("${TREE}"/.rpms/*.rpm "${FLAVOR_SUBTREE}"/.rpms/*.rpm)
+  shopt -u nullglob
+  if ((${#RPMS_TO_REGISTER[@]} > 0)); then
+    rpm -i --justdb --noscripts --nodeps --nodigest --nosignature "${RPMS_TO_REGISTER[@]}"
+  fi
+  {
+    echo "version=${VERSION}"
+    echo "flavor=${FLAVOR}"
+    echo "kernel=${KERNEL_VERSION}"
+  } > "${COMMITTED_SENTINEL}"
+fi

--- a/templates/al2023/runtime/gpu/usr-bin.mount
+++ b/templates/al2023/runtime/gpu/usr-bin.mount
@@ -1,0 +1,26 @@
+[Unit]
+Description=NVIDIA driver overlay for /usr/bin
+# DefaultDependencies=no severs the auto Before=local-fs.target that closes the cycle
+# mount -> resolve -> basic -> sysinit -> local-fs -> mount. Umount ordering re-added
+# for graceful shutdown.
+DefaultDependencies=no
+Before=umount.target
+Conflicts=umount.target
+# ensure that this starts iff nvidia-driver-resolve succeeds but
+# does not propagate its failure since the SSM agent will fail to starts
+# if /usr/bin mount fails to start
+After=local-fs.target nvidia-driver-resolve.service
+RequiresMountsFor=/var
+Wants=nvidia-driver-resolve.service
+ConditionPathExists=/opt/nvidia/current/.driver-flavor
+RefuseManualStart=yes
+RefuseManualStop=yes
+
+[Mount]
+What=overlay
+Where=/usr/bin
+Type=overlay
+Options=lowerdir=/opt/nvidia/current/usr/bin:/usr/bin,upperdir=/var/lib/eks/nvidia/bin/upper,workdir=/var/lib/eks/nvidia/bin/work
+
+[Install]
+WantedBy=local-fs.target

--- a/templates/al2023/runtime/gpu/usr-lib64.mount
+++ b/templates/al2023/runtime/gpu/usr-lib64.mount
@@ -1,0 +1,23 @@
+[Unit]
+Description=NVIDIA driver overlay for /usr/lib64
+# DefaultDependencies=no severs the auto Before=local-fs.target that closes the cycle
+# mount -> resolve -> basic -> sysinit -> local-fs -> mount. Umount ordering re-added
+# for graceful shutdown.
+DefaultDependencies=no
+Conflicts=umount.target
+Before=umount.target
+After=local-fs.target nvidia-driver-resolve.service
+Wants=nvidia-driver-resolve.service
+ConditionPathExists=/opt/nvidia/current/.driver-flavor
+RequiresMountsFor=/var
+RefuseManualStart=yes
+RefuseManualStop=yes
+
+[Mount]
+What=overlay
+Where=/usr/lib64
+Type=overlay
+Options=lowerdir=/opt/nvidia/current/usr/lib64:/usr/lib64,upperdir=/var/lib/eks/nvidia/lib64/upper,workdir=/var/lib/eks/nvidia/lib64/work
+
+[Install]
+WantedBy=local-fs.target

--- a/templates/al2023/runtime/gpu/usr-share.mount
+++ b/templates/al2023/runtime/gpu/usr-share.mount
@@ -1,0 +1,23 @@
+[Unit]
+Description=NVIDIA driver overlay for /usr/share
+# DefaultDependencies=no severs the auto Before=local-fs.target that closes the cycle
+# mount -> resolve -> basic -> sysinit -> local-fs -> mount. Umount ordering re-added
+# for graceful shutdown.
+DefaultDependencies=no
+Conflicts=umount.target
+Before=umount.target
+After=local-fs.target nvidia-driver-resolve.service
+Wants=nvidia-driver-resolve.service
+RequiresMountsFor=/var
+ConditionPathExists=/opt/nvidia/current/.driver-flavor
+RefuseManualStart=yes
+RefuseManualStop=yes
+
+[Mount]
+What=overlay
+Where=/usr/share
+Type=overlay
+Options=lowerdir=/opt/nvidia/current/usr/share:/usr/share,upperdir=/var/lib/eks/nvidia/share/upper,workdir=/var/lib/eks/nvidia/share/work
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds two scripts for boot-time driver selection and loading. `resolve-nvidia-driver.sh` is responsible for selecting the appropriate NVIDIA driver flavor and major version for the current hardware, and creating a symbolic link to the `current` tree from the `lts`/`pb` so that `load-nvidia-kernel-modules.sh` can commit that one. `load-nvidia-kernel-modules.sh` will reflink the /lib/modules and /usr/lib/firmware for GSP from the appropriate driver version and flavor, utilizing a `driver-flavor` file that `resolve-nvidia-driver.sh` writes.

The resolver will abort if the current hardware does not have any attached NVIDIA devices, which ensures users can continue using EKS AMIs as a base for accelerated AMI builds on non-accelerated instance types. If a snapshot is created from an instance with an NVIDIA attached device, subsequent instances launched from that snapshot will use the same driver type, which is the same behavior as with the predcessor `nvidia-kmod-load.sh`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
