### PR TITLE
feat: speed up node boot

### DIFF
--- a/nodeadm/Makefile
+++ b/nodeadm/Makefile
@@ -71,14 +71,18 @@ test: crds generate fmt vet ## Run go test against code.
 .PHONY: test-e2e
 # the test infra container needs a linux executable
 test-e2e: GOOS=linux
-test-e2e: build ## Run e2e tests.
+test-e2e: release ## Run e2e tests.
 	test/e2e/run.sh
 
 ##@ Build
 
 .PHONY: build
-build: ## Build binary.
+build: ## Build debug binary.
 	GOOS=$(GOOS) go build -o $(LOCALBIN)/ ./cmd/...
+
+.PHONY: release
+release: ## Build release binary
+	GOOS=$(GOOS) go build -trimpath -ldflags="-s -w" -o $(LOCALBIN)/ ./cmd/...
 
 .PHONY: run
 run: build ## Run binary.

--- a/templates/al2023/provisioners/install-nodeadm.sh
+++ b/templates/al2023/provisioners/install-nodeadm.sh
@@ -35,8 +35,9 @@ sudo nerdctl run \
   --workdir /workdir \
   --volume $PROJECT_DIR:/workdir \
   --env GOTOOLCHAIN=local \
+  --quiet \
   $BUILD_IMAGE \
-  make build
+  make release
 
 # cleanup build image and snapshots
 sudo nerdctl rmi \
@@ -58,6 +59,9 @@ sudo systemctl enable \
   nodeadm-boot-hook \
   nodeadm-config \
   nodeadm-run
+
+sudo systemctl enable ebs-initialize-bin@nodeadm
+sudo systemctl enable ebs-initialize-bin@nodeadm-internal
 
 # create the drop-in config directory
 sudo mkdir -p /etc/eks/nodeadm.d/


### PR DESCRIPTION
Speed up node boot by
1. prefetching nodeadm and nodeadm-internal binaries
2. stripping symbols from nodeadm and nodeadm-internal to reduce size (saves about 25MB for nodeadm and 6MB for nodeadm-internal).
