### PR TITLE
feat(nvidia): add versioned nvidia services at boot

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-drivers.sh
+++ b/templates/al2023/provisioners/install-nvidia-drivers.sh
@@ -221,6 +221,11 @@ sudo install -m 0644 "${WORKING_DIR}/gpu/usr-bin.mount" /etc/systemd/system/usr-
 sudo install -m 0644 "${WORKING_DIR}/gpu/usr-lib64.mount" /etc/systemd/system/usr-lib64.mount
 sudo install -m 0644 "${WORKING_DIR}/gpu/usr-share.mount" /etc/systemd/system/usr-share.mount
 
+# installed but not started at build-time b/c it has an ordering dependency on
+# nvidia-persistenced, which is only added at runtime
+sudo install -m 0644 "${WORKING_DIR}/gpu/set-nvidia-clocks.service" \
+  /etc/systemd/system/set-nvidia-clocks.service
+
 # Overlay upperdir/workdir. Must exist before mount units activate.
 sudo mkdir -p /var/lib/eks/nvidia/{bin,lib64,share}/{upper,work}
 

--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -169,5 +169,57 @@ if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
     exit 1
   fi
 
+  #############################
+  ### boot-time integration ###
+  #############################
+
+  # Every baked tree must carry its identity marker.
+  for tree in "${NVIDIA_TREES[@]}"; do
+    if [ ! -f "/opt/nvidia/${tree}/.tree-${tree}" ]; then
+      echo "/opt/nvidia/${tree}/.tree-${tree} is missing"
+      exit 1
+    fi
+  done
+
+  # Every baked tree must carry the daemon services setup will install at first boot.
+  for tree in "${NVIDIA_TREES[@]}"; do
+    for DAEMON in nvidia-persistenced nvidia-fabricmanager; do
+      if [ ! -f "/opt/nvidia/${tree}/usr/lib/systemd/system/${DAEMON}.service" ]; then
+        echo "tree ${tree} is missing ${DAEMON}.service"
+        exit 1
+      fi
+    done
+  done
+
+  # nvidia-setup.service must Before= the two daemon services so systemd orders them
+  # correctly on subsequent boots
+  for DAEMON in nvidia-persistenced.service nvidia-fabricmanager.service; do
+    if ! grep -q "^Before=.*\b${DAEMON}\b" /etc/systemd/system/nvidia-setup.service; then
+      echo "nvidia-setup.service does not declare Before=${DAEMON}"
+      exit 1
+    fi
+  done
+
+  if [ ! -f "/etc/systemd/system/set-nvidia-clocks.service" ]; then
+    echo "set-nvidia-clocks.service was not staged at build time"
+    exit 1
+  fi
+  # set-nvidia-clocks should not be pulled into the boot-ordering chain b/c it has an ordering
+  # dependency with nvidia-persistenced, which is not added until first boot
+  if compgen -G "/etc/systemd/system/*.wants/set-nvidia-clocks.service" > /dev/null \
+    || compgen -G "/etc/systemd/system/*.requires/set-nvidia-clocks.service" > /dev/null; then
+    echo "set-nvidia-clocks.service has activation links at build time; must be enabled by setup at first boot"
+    exit 1
+  fi
+
+  # these daemons are expected to be added at runtime, not build-time, since the .service files are extracted from
+  # version-specific RPMs into the tree
+  for DAEMON in nvidia-persistenced nvidia-fabricmanager; do
+    if [ -f "/usr/lib/systemd/system/${DAEMON}.service" ]; then
+      echo "/usr/lib/systemd/system/${DAEMON}.service exists at build time; should be installed by setup at first boot"
+      exit 1
+    fi
+  done
+
   echo "NVIDIA driver trees were validated: ${NVIDIA_TREES[*]}"
 fi

--- a/templates/al2023/runtime/gpu/nvidia-setup.service
+++ b/templates/al2023/runtime/gpu/nvidia-setup.service
@@ -2,6 +2,7 @@
 Description=NVIDIA setup
 After=nvidia-driver-resolve.service usr-bin.mount usr-lib64.mount usr-share.mount
 Wants=usr-bin.mount usr-lib64.mount usr-share.mount
+Before=nvidia-persistenced.service nvidia-fabricmanager.service
 ConditionPathExists=/opt/nvidia/current/.driver-flavor
 RefuseManualStart=yes
 RefuseManualStop=yes

--- a/templates/al2023/runtime/gpu/setup-nvidia.sh
+++ b/templates/al2023/runtime/gpu/setup-nvidia.sh
@@ -96,3 +96,20 @@ if [[ ! -f "${COMMITTED_SENTINEL}" ]]; then
     echo "kernel=${KERNEL_VERSION}"
   } > "${COMMITTED_SENTINEL}"
 fi
+
+readonly DAEMONS_INSTALLED_SENTINEL="${TREE}/.daemons-installed"
+if [[ ! -f "${DAEMONS_INSTALLED_SENTINEL}" ]]; then
+  # /usr/lib/systemd/system/ is the correct target for package-provided units —
+  # /etc/systemd/system/ is reserved for admin overrides.
+  install -m 0644 "${TREE}/usr/lib/systemd/system"/*.service /usr/lib/systemd/system/
+
+  systemctl daemon-reload
+  systemctl enable nvidia-persistenced.service nvidia-fabricmanager.service \
+    set-nvidia-clocks.service
+  # let systemd handle service starts in the background b/c they have a declared ordering
+  # with this service and so that any potential failures or startup time are not absorbed here
+  systemctl start --no-block nvidia-persistenced.service nvidia-fabricmanager.service \
+    set-nvidia-clocks.service
+
+  touch "${DAEMONS_INSTALLED_SENTINEL}"
+fi


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds logic to support `nvidia-fabricmanager` and `nvidia-persistenced` services. For the first boot, the setup service copies their service files from their place in the version tree into `/etc/systemd/system`, started, and enabled. On subsequent boots, the setup service does not need to do anything for the services as `systemd` will automatically start them after its completion, thanks to the prior enable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
