### PR TITLE
feat(nvidia): installing nvidia-imex

### DIFF
--- a/templates/al2023/helpers/nvidia-userspace.sh
+++ b/templates/al2023/helpers/nvidia-userspace.sh
@@ -12,6 +12,7 @@ readonly NVIDIA_USERSPACE_PACKAGES=(
   nvidia-driver
   nvidia-driver-cuda
   nvidia-fabricmanager
+  nvidia-imex
   nvidia-libXNVCtrl-devel
   nvidia-persistenced
   nvidia-settings
@@ -91,7 +92,10 @@ function extract-version-specific-rpms() {
   local TREE="${1}"
   local TREE_DIR="${NVIDIA_TREE_ROOT}/${TREE}"
   local RPM_LIST="${NVIDIA_USERSPACE_RPM_DIR}/${TREE}"
-  local RPM
+  local RPM RPM_FILENAME
+
+  local DRIVER_VERSION
+  DRIVER_VERSION=$(cat "${TREE_DIR}/.version")
 
   if ! compgen -G "${RPM_LIST}/*.rpm" > /dev/null; then
     echo >&2 "ERROR: nothing version-specific for tree ${TREE}, check that the trees resolved to different versions"
@@ -104,7 +108,17 @@ function extract-version-specific-rpms() {
   # Staged whole so the boot-time commit phase can register them in the rpm database.
   sudo install -d "${TREE_DIR}/.rpms"
   for RPM in "${VERSION_SPECIFIC_RPMS[@]}"; do
-    echo "  $(basename "${RPM}")"
+    RPM_FILENAME=$(basename "${RPM}")
+    # The kmod rpms come as a dependency of nvidia-driver -> nvidia-kmod-common.
+    # The flavor subtrees already stages the kmod rpms. A copy here would put both flavors'
+    # in one rpmdb registration, where they conflict over the same /usr/src paths.
+    case "${RPM_FILENAME}" in
+      kmod-nvidia-open-dkms-"${DRIVER_VERSION}"-* | kmod-nvidia-latest-dkms-"${DRIVER_VERSION}"-*)
+        echo "  skipping ${RPM_FILENAME}, staged under the flavor subtree"
+        continue
+        ;;
+    esac
+    echo "  ${RPM_FILENAME}"
     rpm2cpio "${RPM}" | (cd "${TREE_DIR}" && sudo cpio -idmu --quiet)
     sudo install -m 0644 "${RPM}" "${TREE_DIR}/.rpms/"
   done

--- a/templates/al2023/runtime/gpu/setup-nvidia.sh
+++ b/templates/al2023/runtime/gpu/setup-nvidia.sh
@@ -30,18 +30,29 @@ if [[ ! -d "${FLAVOR_SUBTREE}/lib/modules/${KERNEL_VERSION}" ]]; then
   exit 1
 fi
 
+if [[ ! -d "${TREE}/etc" ]]; then
+  echo >&2 "setup: no ${TREE}/etc"
+  exit 1
+fi
+
 VERSION="$(cat "${TREE}/.version")"
 readonly VERSION
+
+# copy /etc/ files including modprobe.d and configs
+cp -a --reflink=auto "${TREE}/etc/." /etc/
+for ENTRY in "${TREE}"/etc/*; do
+  restorecon -R "/etc/$(basename "${ENTRY}")" 2> /dev/null || true
+done
 
 readonly LOADED_SENTINEL="${TREE}/.loaded"
 if [[ ! -f "${LOADED_SENTINEL}" ]]; then
   mkdir -p "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra"
-  cp -a --reflink=auto "${FLAVOR_SUBTREE}/lib/modules/${KERNEL_VERSION}"/extra/ "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra/"
+  cp -a --reflink=auto "${FLAVOR_SUBTREE}/lib/modules/${KERNEL_VERSION}/extra/." "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra/"
   restorecon -R "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra/" 2> /dev/null || true
 
   readonly FIRMWARE_STAGE="${TREE}/${FIRMWARE_DIR}/nvidia"
-  mkdir -p "${FIRMWARE_DIR}/nvidia"
-  cp -a --reflink=auto "${FIRMWARE_STAGE}/${VERSION}"/ "${FIRMWARE_DIR}/nvidia/${VERSION}"
+  mkdir -p "${FIRMWARE_DIR}/nvidia/${VERSION}"
+  cp -a --reflink=auto "${FIRMWARE_STAGE}/${VERSION}/." "${FIRMWARE_DIR}/nvidia/${VERSION}/"
   restorecon -R "${FIRMWARE_DIR}/nvidia/${VERSION}" 2> /dev/null || true
 
   depmod "${KERNEL_VERSION}"

--- a/templates/al2023/template.json
+++ b/templates/al2023/template.json
@@ -311,7 +311,8 @@
       "environment_vars": [
         "ENABLE_ACCELERATOR={{user `enable_accelerator`}}",
         "NVIDIA_DRIVER_LTS_VERSION={{user `nvidia_driver_lts_version`}}",
-        "NVIDIA_DRIVER_PB_VERSION={{user `nvidia_driver_pb_version`}}"
+        "NVIDIA_DRIVER_PB_VERSION={{user `nvidia_driver_pb_version`}}",
+        "ENABLE_NVIDIA_GDRCOPY_DRIVER={{user `enable_nvidia_gdrcopy_driver`}}"
       ]
     },
     {


### PR DESCRIPTION
**Description of changes:**

Installing `nvidia-imex` as part of userspace programs. The systemd service as part of the package, will be automatically copied over to the host based on the works of the previous PRs.

This PR also copies over config files in /etc/ for xorg, x11 and xdg along with imex.

Also fixing a bug in copying to `/lib/modules/extra`. Earlier it was being copied over to `/lib/modules/extra/extra`. It looked like the kernel modules were still being recognized even with the misformed path, but maintaining right pattern here as well as for the gsp firmware path.

Also, validate.sh now requires the env variable `ENABLE_NVIDIA_GDRCOPY_DRIVER` which was not passed in `template.json` causing build failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.