### PR TITLE
refactor(nvidia): probe modules based on stored .ko's

### DIFF
--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -152,14 +152,43 @@ validate_nvidia_supported_device_list() {
   fi
 }
 
+# boot-critical NVIDIA modules that setup-nvidia.sh will modprobe. every flavor
+# must ship the four core modules
+NVIDIA_BOOT_MODULES=(nvidia nvidia-modeset nvidia-drm nvidia-uvm)
+
+validate_nvidia_boot_modules() {
+  local tree=$1
+  local flavor=$2
+  local extra_dir="/opt/nvidia/${tree}/flavors/${flavor}/lib/modules/${KERNEL_RELEASE}/extra"
+  local module_name
+
+  for module_name in "${NVIDIA_BOOT_MODULES[@]}"; do
+    if ! compgen -G "${extra_dir}/${module_name}.ko*" > /dev/null; then
+      echo "${extra_dir} is missing ${module_name}.ko"
+      exit 1
+    fi
+  done
+
+  # gdrdrv is only harvested on the open flavor, and only when the build enabled it.
+  if [ "${flavor}" = "open" ] && [ "${ENABLE_NVIDIA_GDRCOPY_DRIVER}" = "true" ]; then
+    if ! compgen -G "${extra_dir}/gdrdrv.ko*" > /dev/null; then
+      echo "${extra_dir} is missing gdrdrv.ko"
+      exit 1
+    fi
+  fi
+}
+
 if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
   for tree in "${NVIDIA_TREES[@]}"; do
     validate_nvidia_tree_version "${tree}"
     validate_nvidia_supported_device_list "${tree}"
+    validate_nvidia_boot_modules "${tree}" open
+    validate_nvidia_boot_modules "${tree}" proprietary
 
     # NVIDIA publishes no aarch64 GRID runfile, so that flavor is never built there.
     if [ "$(uname -m)" != "aarch64" ]; then
       validate_nvidia_grid_modules "${tree}"
+      validate_nvidia_boot_modules "${tree}" grid
     fi
   done
 

--- a/templates/al2023/runtime/gpu/setup-nvidia.sh
+++ b/templates/al2023/runtime/gpu/setup-nvidia.sh
@@ -9,14 +9,6 @@ NVIDIA_TREE_ROOT="${NVIDIA_TREE_ROOT:-/opt/nvidia}"
 LIB_MODULES_DIR="${LIB_MODULES_DIR:-/lib/modules}"
 FIRMWARE_DIR="${FIRMWARE_DIR:-/usr/lib/firmware}"
 
-# Hardcoded module list. TODO: introduce a per-flavor manifest at
-# ${FLAVOR_SUBTREE}/modules.list, replace these arrays with a
-# manifest-driven loop.
-readonly REQUIRED_MODULES=(nvidia nvidia-modeset nvidia-drm nvidia-uvm)
-# TODO: use a better heuristic than just "optional," e.g. considering if it's required
-# on specific hardware
-readonly OPTIONAL_MODULES=(nvidia-peermem)
-
 KERNEL_VERSION="$(uname -r)"
 readonly KERNEL_VERSION
 readonly TREE="${NVIDIA_TREE_ROOT}/current"
@@ -57,27 +49,29 @@ if [[ ! -f "${LOADED_SENTINEL}" ]]; then
   echo "${KERNEL_VERSION}" > "${LOADED_SENTINEL}"
 fi
 
-# modprobes do not persist reboots; invocations should be unguarded
-for m in "${REQUIRED_MODULES[@]}"; do
-  modprobe "${m}"
-done
-for m in "${OPTIONAL_MODULES[@]}"; do
-  modprobe "${m}" || echo >&2 "load: optional module ${m} did not load"
-done
+# modprobes do not persist reboots; invocations should be unguarded.
+readonly EXTRA_DIR="${FLAVOR_SUBTREE}/lib/modules/${KERNEL_VERSION}/extra"
+# the nvidia module is probed first b/c other mods (e.g. gdrdrv) may not
+# declare a dependency on it
+modprobe nvidia
+for ko in "${EXTRA_DIR}"/*.ko*; do
+  module_name=$(basename "${ko}")
+  module_name="${module_name%%.ko*}"
+  case "${module_name}" in
+    # nvidia already loaded above; nvidia-peermem binds to Mellanox HCA and fails
+    # on Nitro-EFA hosts, functionality is provided thru kernel's DMA buffer instead
+    nvidia | nvidia-peermem) continue ;;
+  esac
+  modprobe "${module_name}"
 
-if [[ "${FLAVOR}" == "open" ]]; then
-  if modprobe gdrdrv; then
+  # gdrdrv registers a character device but doesn't create the device node itself,
+  # so mint /dev/gdrdrv from its /proc/devices allocation
+  if [[ "${module_name}" == "gdrdrv" ]]; then
     gdrdrv_major="$(awk '/gdrdrv/{print $1}' /proc/devices)"
-    if [[ -n "${gdrdrv_major}" ]]; then
-      rm -f /dev/gdrdrv
-      mknod -m 666 /dev/gdrdrv c "${gdrdrv_major}" 0
-    else
-      echo >&2 "load: gdrdrv loaded but no /proc/devices entry; skipping device node"
-    fi
-  else
-    echo >&2 "load: gdrdrv did not load (open flavor, optional)"
+    rm -f /dev/gdrdrv
+    mknod -m 666 /dev/gdrdrv c "${gdrdrv_major}" 0
   fi
-fi
+done
 
 # rpm db registration can carry a big time penalty; to optimize first-boot time
 # we keep this at the end so it's out of the critical path for functionality


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Shifts from probing modules based on a hardcoded manifest to instead using the `.ko` files for the chosen flavor subtree as the source of truth. For safety, and to ensure that the minimum required modules are probed, we validate during build-time that 4 key modules are contained within each flavor subtree's extras directory.

`nvidia` is always attempted unconditionally to ensure it's loaded before any other module that may have an undeclared dependency on it (e.g. `gdrdrv`), and because will always be needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->

**Testing Done**

<!-- Include information regarding the testing that was completed with this changes. Where applicable, include details steps to replicate. -->

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
