### PR TITLE
feat(nvidia): installing grid license server

### DIFF
--- a/templates/al2023/helpers/nvidia-kmods.sh
+++ b/templates/al2023/helpers/nvidia-kmods.sh
@@ -91,13 +91,14 @@ function build-grid-kmods() {
 
   local GRID_DIR="${WORKING_DIR}/nvidia-grid-${DRIVER_VERSION}"
   local RUNFILE_PATH="${GRID_DIR}/${RUNFILE_NAME}"
-  local KERNEL_OPEN_DIR="${GRID_DIR}/source/kernel-open"
+  local EXTRACT_DIR="${GRID_DIR}/source"
+  local KERNEL_OPEN_DIR="${EXTRACT_DIR}/kernel-open"
   mkdir -p "${GRID_DIR}"
 
   echo "Building GRID kernel modules for NVIDIA ${DRIVER_VERSION}"
   aws s3 cp "s3://${EC2_GRID_DRIVER_S3_BUCKET%%/*}/${RUNFILE_KEY}" "${RUNFILE_PATH}"
   chmod +x "${RUNFILE_PATH}"
-  "${RUNFILE_PATH}" --extract-only --target "${GRID_DIR}/source"
+  "${RUNFILE_PATH}" --extract-only --target "${EXTRACT_DIR}"
 
   make -C "${KERNEL_OPEN_DIR}" \
     -j"$(nproc)" \
@@ -113,7 +114,22 @@ function build-grid-kmods() {
     sudo install -m 0644 "${MODULE_PATH}" "${DEST_DIR}/"
   done
 
+  harvest-grid-license-server "${EXTRACT_DIR}" "${TREE_DIR}"
+
   sudo rm -rf "${GRID_DIR}"
+}
+
+# Harvest the vGPU license server stack from an extracted GRID runfile.
+function harvest-grid-license-server() {
+  local EXTRACT_DIR="${1}"
+  local TREE_DIR="${2}"
+
+  echo "Harvesting the GRID vGPU userspace into ${TREE_DIR}"
+  sudo install -d "${TREE_DIR}/usr/bin" "${TREE_DIR}/usr/lib/systemd/system" "${TREE_DIR}/etc/nvidia"
+  sudo install -m 0755 "${EXTRACT_DIR}/nvidia-gridd" "${TREE_DIR}/usr/bin/"
+  sudo install -m 0644 "${EXTRACT_DIR}/init-scripts/systemd/nvidia-gridd.service" \
+    "${TREE_DIR}/usr/lib/systemd/system/"
+  sudo install -m 0644 "${EXTRACT_DIR}/gridd.conf.template" "${TREE_DIR}/etc/nvidia/"
 }
 
 # Download a kmod source rpm and unpack it

--- a/templates/al2023/provisioners/validate.sh
+++ b/templates/al2023/provisioners/validate.sh
@@ -76,28 +76,48 @@ fi
 #############################
 ### nvidia drivers #####
 #############################
-NVIDIA_DRIVER_MODULES=(nvidia nvidia-drm nvidia-modeset nvidia-peermem nvidia-uvm)
+NVIDIA_DRIVER_MODULES=(nvidia nvidia-drm nvidia-modeset nvidia-uvm)
 KERNEL_RELEASE=$(uname -r)
 
-# GRID is harvested by glob rather than from a dkms manifest, so confirm the tree
-# ended up with exactly the driver's modules.
-validate_nvidia_grid_modules() {
+validate_nvidia_boot_modules() {
   local tree=$1
-  local extra_dir="/opt/nvidia/${tree}/flavors/grid/lib/modules/${KERNEL_RELEASE}/extra"
-  local module_name harvested
+  local flavor=$2
+  local extra_dir="/opt/nvidia/${tree}/flavors/${flavor}/lib/modules/${KERNEL_RELEASE}/extra"
+  local expected=("${NVIDIA_DRIVER_MODULES[@]}")
+  local module_name
 
-  for module_name in "${NVIDIA_DRIVER_MODULES[@]}"; do
-    if [ ! -f "${extra_dir}/${module_name}.ko" ]; then
+  # gdrdrv is only harvested on the open flavor, and only when the build enabled it.
+  if [ "${flavor}" = "open" ] && [ "${ENABLE_NVIDIA_GDRCOPY_DRIVER}" = "true" ]; then
+    expected+=(gdrdrv)
+  fi
+
+  for module_name in "${expected[@]}"; do
+    # The suffix varies with the kernel's module compression.
+    if ! compgen -G "${extra_dir}/${module_name}.ko*" > /dev/null; then
       echo "${extra_dir} is missing ${module_name}.ko"
       exit 1
     fi
   done
+}
 
-  harvested=("${extra_dir}"/*.ko)
-  if [ "${#harvested[@]}" -ne "${#NVIDIA_DRIVER_MODULES[@]}" ]; then
-    echo "${extra_dir} has ${#harvested[@]} modules, expected ${#NVIDIA_DRIVER_MODULES[@]}: ${harvested[*]##*/}"
-    exit 1
-  fi
+# vGPU license userspace the rpm tree has no package for, so it can only come from the GRID runfile.
+# Node paths, since a tree mirrors /.
+NVIDIA_GRID_USERSPACE=(
+  /usr/bin/nvidia-gridd
+  /usr/lib/systemd/system/nvidia-gridd.service
+  /etc/nvidia/gridd.conf.template
+)
+
+validate_nvidia_grid_userspace() {
+  local tree=$1
+  local path
+
+  for path in "${NVIDIA_GRID_USERSPACE[@]}"; do
+    if [ ! -f "/opt/nvidia/${tree}/${path}" ]; then
+      echo "tree ${tree} is missing ${path}"
+      exit 1
+    fi
+  done
 }
 
 NVIDIA_TREES=(lts pb)
@@ -152,32 +172,6 @@ validate_nvidia_supported_device_list() {
   fi
 }
 
-# boot-critical NVIDIA modules that setup-nvidia.sh will modprobe. every flavor
-# must ship the four core modules
-NVIDIA_BOOT_MODULES=(nvidia nvidia-modeset nvidia-drm nvidia-uvm)
-
-validate_nvidia_boot_modules() {
-  local tree=$1
-  local flavor=$2
-  local extra_dir="/opt/nvidia/${tree}/flavors/${flavor}/lib/modules/${KERNEL_RELEASE}/extra"
-  local module_name
-
-  for module_name in "${NVIDIA_BOOT_MODULES[@]}"; do
-    if ! compgen -G "${extra_dir}/${module_name}.ko*" > /dev/null; then
-      echo "${extra_dir} is missing ${module_name}.ko"
-      exit 1
-    fi
-  done
-
-  # gdrdrv is only harvested on the open flavor, and only when the build enabled it.
-  if [ "${flavor}" = "open" ] && [ "${ENABLE_NVIDIA_GDRCOPY_DRIVER}" = "true" ]; then
-    if ! compgen -G "${extra_dir}/gdrdrv.ko*" > /dev/null; then
-      echo "${extra_dir} is missing gdrdrv.ko"
-      exit 1
-    fi
-  fi
-}
-
 if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
   for tree in "${NVIDIA_TREES[@]}"; do
     validate_nvidia_tree_version "${tree}"
@@ -187,8 +181,8 @@ if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
 
     # NVIDIA publishes no aarch64 GRID runfile, so that flavor is never built there.
     if [ "$(uname -m)" != "aarch64" ]; then
-      validate_nvidia_grid_modules "${tree}"
       validate_nvidia_boot_modules "${tree}" grid
+      validate_nvidia_grid_userspace "${tree}"
     fi
   done
 
@@ -220,9 +214,9 @@ if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
     done
   done
 
-  # nvidia-setup.service must Before= the two daemon services so systemd orders them
+  # nvidia-setup.service must Before= the daemon services so systemd orders them
   # correctly on subsequent boots
-  for DAEMON in nvidia-persistenced.service nvidia-fabricmanager.service; do
+  for DAEMON in nvidia-persistenced.service nvidia-fabricmanager.service nvidia-gridd.service; do
     if ! grep -q "^Before=.*\b${DAEMON}\b" /etc/systemd/system/nvidia-setup.service; then
       echo "nvidia-setup.service does not declare Before=${DAEMON}"
       exit 1
@@ -243,7 +237,7 @@ if [[ "$ENABLE_ACCELERATOR" == "nvidia" ]]; then
 
   # these daemons are expected to be added at runtime, not build-time, since the .service files are extracted from
   # version-specific RPMs into the tree
-  for DAEMON in nvidia-persistenced nvidia-fabricmanager; do
+  for DAEMON in nvidia-persistenced nvidia-fabricmanager nvidia-gridd; do
     if [ -f "/usr/lib/systemd/system/${DAEMON}.service" ]; then
       echo "/usr/lib/systemd/system/${DAEMON}.service exists at build time; should be installed by setup at first boot"
       exit 1

--- a/templates/al2023/runtime/gpu/nvidia-setup.service
+++ b/templates/al2023/runtime/gpu/nvidia-setup.service
@@ -2,7 +2,7 @@
 Description=NVIDIA setup
 After=nvidia-driver-resolve.service usr-bin.mount usr-lib64.mount usr-share.mount
 Wants=usr-bin.mount usr-lib64.mount usr-share.mount
-Before=nvidia-persistenced.service nvidia-fabricmanager.service
+Before=nvidia-persistenced.service nvidia-fabricmanager.service nvidia-gridd.service
 ConditionPathExists=/opt/nvidia/current/.driver-flavor
 RefuseManualStart=yes
 RefuseManualStop=yes

--- a/templates/al2023/runtime/gpu/setup-nvidia.sh
+++ b/templates/al2023/runtime/gpu/setup-nvidia.sh
@@ -38,22 +38,24 @@ fi
 VERSION="$(cat "${TREE}/.version")"
 readonly VERSION
 
-# copy /etc/ files including modprobe.d and configs
-cp -a --reflink=auto "${TREE}/etc/." /etc/
+# copy /etc/ files including modprobe.d and configs. this runs on every boot, and /etc holds
+# config files, so -n keeps it from replacing a config a user changed after the first boot.
+# TODO: -n is deperecated. Move to --update=none when coreutils 9.3+ is available.
+cp -a -n --reflink=auto "${TREE}/etc/." /etc/
 for ENTRY in "${TREE}"/etc/*; do
-  restorecon -R "/etc/$(basename "${ENTRY}")" 2> /dev/null || true
+  restorecon -R "/etc/$(basename "${ENTRY}")"
 done
 
 readonly LOADED_SENTINEL="${TREE}/.loaded"
 if [[ ! -f "${LOADED_SENTINEL}" ]]; then
   mkdir -p "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra"
   cp -a --reflink=auto "${FLAVOR_SUBTREE}/lib/modules/${KERNEL_VERSION}/extra/." "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra/"
-  restorecon -R "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra/" 2> /dev/null || true
+  restorecon -R "${LIB_MODULES_DIR}/${KERNEL_VERSION}/extra/"
 
   readonly FIRMWARE_STAGE="${TREE}/${FIRMWARE_DIR}/nvidia"
   mkdir -p "${FIRMWARE_DIR}/nvidia/${VERSION}"
   cp -a --reflink=auto "${FIRMWARE_STAGE}/${VERSION}/." "${FIRMWARE_DIR}/nvidia/${VERSION}/"
-  restorecon -R "${FIRMWARE_DIR}/nvidia/${VERSION}" 2> /dev/null || true
+  restorecon -R "${FIRMWARE_DIR}/nvidia/${VERSION}"
 
   depmod "${KERNEL_VERSION}"
 
@@ -108,13 +110,18 @@ if [[ ! -f "${DAEMONS_INSTALLED_SENTINEL}" ]]; then
   # /etc/systemd/system/ is reserved for admin overrides.
   install -m 0644 "${TREE}/usr/lib/systemd/system"/*.service /usr/lib/systemd/system/
 
+  DAEMONS=(nvidia-persistenced.service nvidia-fabricmanager.service set-nvidia-clocks.service)
+  # gridd is what obtains the vGPU license, and only vGPU devices resolve to the grid flavor.
+  # there is nothing to license on passthrough hardware, so it stays disabled there.
+  if [[ "${FLAVOR}" == "grid" ]]; then
+    DAEMONS+=(nvidia-gridd.service)
+  fi
+
   systemctl daemon-reload
-  systemctl enable nvidia-persistenced.service nvidia-fabricmanager.service \
-    set-nvidia-clocks.service
+  systemctl enable "${DAEMONS[@]}"
   # let systemd handle service starts in the background b/c they have a declared ordering
   # with this service and so that any potential failures or startup time are not absorbed here
-  systemctl start --no-block nvidia-persistenced.service nvidia-fabricmanager.service \
-    set-nvidia-clocks.service
+  systemctl start --no-block "${DAEMONS[@]}"
 
   touch "${DAEMONS_INSTALLED_SENTINEL}"
 fi


### PR DESCRIPTION
**Description of changes:**

The GRID run file archive comes with kernel source as well as a userspace stack which includes both shared object libraries as well as its vGPU license server stack.
All of the shared object libraries have its counterparts in the rpm's we fetch for a versions userspace programs. 

Other files like gtk2, topologyd are inert or not needed in AL2023 AMI's. These leaves the license server stack.

In this PR we harvest the license server stack components
```
gridd.conf.template 
nvidia-gridd
nvidia-gridd.service 
```

These are technically userspace components that can exist in the host irrespective of the instance being vGPU, so placing them within the tree's existing paths where mount and copy mechanism's put them into the stack.

Two additional bug fixes,
1. Copy of /etc files during boot should skip if the files already exist. Since we are dealing with configuration files, there is a high chance a user could have modified it, which we would rewrite on a reboot if left unguarded.
2. restorecon failures should not be swallowed. 

One Refactor,
Collapsed a method which validated grid kernel boot modules into an existing generic method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Testing Done**

Tested the AMI on a g6f instance
```
nvidia-smi -q | grep -A3 'vGPU Software'
    vGPU Software Licensed Product
        Product Name                                   : NVIDIA RTX Virtual Workstation
        License Status                                 : Licensed (Expiry: N/A)
    GPU Recovery Action                                : None
```


Attached is an AI generated file which shows why each file in the .run archive was skipped

[grid-findings.md](https://github.com/user-attachments/files/31814662/grid-findings.md)