### PR TITLE
feat: configure AMI instance type restrictions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ lint-code: ## Check the source files for syntax and format issues
 	hack/lint-space-errors.sh
 
 PACKER_BINARY ?= packer
+AWS_CLI ?= aws
 PACKER_TEMPLATE_DIR ?= templates/$(os_distro)
 PACKER_TEMPLATE_FILE ?= $(PACKER_TEMPLATE_DIR)/template.json
 PACKER_DEFAULT_VARIABLE_FILE ?= $(PACKER_TEMPLATE_DIR)/variables-default.json
@@ -104,6 +105,13 @@ validate: ## Validate packer config
 k8s: validate ## Build default K8s version of EKS Optimized AMI
 	@echo "Building AMI [os_distro=$(os_distro) kubernetes_version=$(kubernetes_version) arch=$(arch) $(if $(enable_accelerator),enable_accelerator=$(enable_accelerator))]"
 	$(PACKER_BINARY) build -timestamp-ui -color=false $(PACKER_ARGS) $(PACKER_TEMPLATE_FILE)
+ifneq ($(strip $(unsupported_instance_types)),)
+	@ami_id="$$(jq -er '.builds[] | select(.builder_type == "amazon-ebs") | .artifact_id | split(":")[1]' "$(ami_name)-manifest.json")"; \
+	$(AWS_CLI) ec2 replace-image-instance-type-specification \
+		--region "$(aws_region)" \
+		--image-id "$$ami_id" \
+		--instance-type-specification 'UnsupportedInstanceTypes=$(unsupported_instance_types)'
+endif
 
 .PHONY: lint-docs
 lint-docs: ## Lint the docs

--- a/Makefile
+++ b/Makefile
@@ -105,12 +105,19 @@ validate: ## Validate packer config
 k8s: validate ## Build default K8s version of EKS Optimized AMI
 	@echo "Building AMI [os_distro=$(os_distro) kubernetes_version=$(kubernetes_version) arch=$(arch) $(if $(enable_accelerator),enable_accelerator=$(enable_accelerator))]"
 	$(PACKER_BINARY) build -timestamp-ui -color=false $(PACKER_ARGS) $(PACKER_TEMPLATE_FILE)
-ifneq ($(strip $(unsupported_instance_types)),)
+ifneq ($(strip $(supported_instance_types)$(unsupported_instance_types)),)
 	@ami_id="$$(jq -er '.builds[] | select(.builder_type == "amazon-ebs") | .artifact_id | split(":")[1]' "$(ami_name)-manifest.json")"; \
+	instance_type_specification=''; \
+	if [ -n "$(supported_instance_types)" ]; then \
+		instance_type_specification="SupportedInstanceTypes=$(supported_instance_types)"; \
+	fi; \
+	if [ -n "$(unsupported_instance_types)" ]; then \
+		instance_type_specification="$${instance_type_specification}$${instance_type_specification:+,}UnsupportedInstanceTypes=$(unsupported_instance_types)"; \
+	fi; \
 	$(AWS_CLI) ec2 replace-image-instance-type-specification \
 		--region "$(aws_region)" \
 		--image-id "$$ami_id" \
-		--instance-type-specification 'UnsupportedInstanceTypes=$(unsupported_instance_types)'
+		--instance-type-specification "$$instance_type_specification"
 endif
 
 .PHONY: lint-docs

--- a/doc/usage/g7-ami.md
+++ b/doc/usage/g7-ami.md
@@ -18,12 +18,19 @@ cd amazon-eks-ami
 ### Build command
 
 ```bash
-make k8s=1.32 os_distro=al2023 enable_accelerator=nvidia enable_efa=true nvidia_driver_major_version=595
+make k8s=1.32 os_distro=al2023 enable_accelerator=nvidia enable_efa=true \
+  nvidia_driver_major_version=595 \
+  unsupported_instance_types='p3.*,p3dn.*,g6f.*'
 ```
 
 This produces an AMI with NVIDIA 595 drivers suitable for G7 instances. The build pulls the driver from the [NVIDIA CUDA repository for AL2023](https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/).
 
-The build takes approximately 45-60 minutes and outputs the AMI ID upon completion.
+The build takes approximately 45-60 minutes and outputs the AMI ID upon completion. The
+`unsupported_instance_types` option configures an [AMI instance type
+specification](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-allowed-instance-types.html)
+after the AMI is created, preventing the AMI from launching on P3, P3dn, or G6f
+instances. The AWS credentials used for the build must have permission to call
+`ec2:ReplaceImageInstanceTypeSpecification`.
 
 ### Using the custom AMI with a managed node group
 

--- a/doc/usage/g7-ami.md
+++ b/doc/usage/g7-ami.md
@@ -25,11 +25,13 @@ make k8s=1.32 os_distro=al2023 enable_accelerator=nvidia enable_efa=true \
 
 This produces an AMI with NVIDIA 595 drivers suitable for G7 instances. The build pulls the driver from the [NVIDIA CUDA repository for AL2023](https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/).
 
-The build takes approximately 45-60 minutes and outputs the AMI ID upon completion. The
-`unsupported_instance_types` option configures an [AMI instance type
-specification](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-allowed-instance-types.html)
-after the AMI is created, preventing the AMI from launching on P3, P3dn, or G6f
-instances. The AWS credentials used for the build must have permission to call
+The build takes approximately 45-60 minutes and outputs the AMI ID upon completion.
+The `supported_instance_types` and `unsupported_instance_types` options configure
+an [AMI instance type specification](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-allowed-instance-types.html)
+after the AMI is created. Specify one or both options as comma-separated instance
+type names or wildcard patterns. This example prevents the AMI from launching on
+P3, P3dn, or G6f instances; a supported list permits launches only on its listed
+types. The AWS credentials used for the build must have permission to call
 `ec2:ReplaceImageInstanceTypeSpecification`.
 
 ### Using the custom AMI with a managed node group


### PR DESCRIPTION
Adds optional `supported_instance_types` and `unsupported_instance_types` Makefile variables. After Packer creates the AMI, the build applies an EC2 AMI instance type specification with an allow-list, block-list, or both.


https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-allowed-instance-types.html