### PR TITLE
fix: fixed test flakiness caused by gitlab.alpinelinux.org/alpine/go returning 418

### DIFF
--- a/.github/actions/ci/kubetest2/action.yaml
+++ b/.github/actions/ci/kubetest2/action.yaml
@@ -28,8 +28,13 @@ runs:
       shell: bash
       run: |
         export PATH=${PATH}:$(go env GOPATH)/bin
-        # old versions of packages are sometimes cached by the proxy, just disable it
-        export GOPROXY=direct
+        # Resolve only the tools directly, since the proxy sometimes serves a stale
+        # @latest/@HEAD. Resolving their whole module graph directly would make this
+        # step depend on every host in it, and gitlab.alpinelinux.org (an indirect
+        # dependency via sigs.k8s.io/bom) answers 418 to GitHub Actions runners.
+        # "|" rather than "," so any error falls through, not just 404/410.
+        export GOPROXY='https://proxy.golang.org|direct'
+        export GONOPROXY='sigs.k8s.io/kubetest2,github.com/aws/aws-k8s-tester'
         go install sigs.k8s.io/kubetest2/...@latest
         go install github.com/aws/aws-k8s-tester/...@HEAD
 


### PR DESCRIPTION
This PR fixes the test flakiness we have been observing in the past few PRs:
- https://github.com/awslabs/amazon-eks-ami/pull/2804
- https://github.com/awslabs/amazon-eks-ami/pull/2793

I updated `GOPROXY` for github actions  to use `https://proxy.golang.org` before falling back to `direct`. This should reduce our direct calls to `gitlab.alpinelinux.org/alpine/go`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
