### PR TITLE
fix(nvidia): cp src labels were being applied to /etc

### DIFF
--- a/templates/al2023/runtime/gpu/setup-nvidia.sh
+++ b/templates/al2023/runtime/gpu/setup-nvidia.sh
@@ -41,7 +41,8 @@ readonly VERSION
 # copy /etc/ files including modprobe.d and configs. this runs on every boot, and /etc holds
 # config files, so -n keeps it from replacing a config a user changed after the first boot.
 # TODO: -n is deperecated. Move to --update=none when coreutils 9.3+ is available.
-cp -a -n --reflink=auto "${TREE}/etc/." /etc/
+shopt -s dotglob
+cp -a -n --reflink=auto "${TREE}"/etc/* /etc/
 for ENTRY in "${TREE}"/etc/*; do
   restorecon -R "/etc/$(basename "${ENTRY}")"
 done


### PR DESCRIPTION
**Description of changes:**

A bug fix in how we copied `/${TREE}/etc` to `/etc`. We were applying the source label to `/etc` as well, which could break SELINUX usecases, since commands like `ldconfig` which writes to `/etc/ld.so.cache` etc will break.

Tested with selinux mode as enforcing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
