### PR TITLE
feat(nvidia): cleanup unused driver tree

### DIFF
--- a/templates/al2023/runtime/gpu/resolve-nvidia-driver.sh
+++ b/templates/al2023/runtime/gpu/resolve-nvidia-driver.sh
@@ -118,22 +118,36 @@ function main() {
   esac
 
   tree_path="${NVIDIA_TREE_ROOT}/${tree}"
-  if [[ ! -d "${tree_path}" || ! -f "${tree_path}/.tree-${tree}" ]]; then
-    echo >&2 "resolve: no ${tree} tree at ${tree_path} (missing directory or .tree-${tree} marker)"
-    exit 1
+  current_tree_path="${NVIDIA_TREE_ROOT}/current"
+
+  if ! [[ -d "${current_tree_path}" ]]; then
+    if ! [[ -d "${tree_path}" && -f "${tree_path}/.tree-${tree}" ]]; then
+      echo >&2 "resolve: chosen tree ${tree} not found at ${tree_path} or ${current_tree_path}"
+      exit 1
+    fi
+
+    if ! mv "${tree_path}" "${current_tree_path}"; then
+      echo >&2 "resolve: mv ${tree_path} ${current_tree_path} failed"
+      exit 1
+    fi
   fi
 
-  current_tree_path="${NVIDIA_TREE_ROOT}/current"
-  if ! ln -sfn "${tree_path}" "${current_tree_path}"; then
-    echo >&2 "resolve: ln -sfn ${tree_path} ${current_tree_path} failed"
-    exit 1
-  fi
+  # reclaims disk by removing any other tree subdir under NVIDIA_TREE_ROOT, assumes that
+  # only tree directories would have a .tree-{type} marker file at the top-level
+  local other_dir
+  for other_dir in "${NVIDIA_TREE_ROOT}"/*/; do
+    other_dir="${other_dir%/}"
+    [[ "${other_dir}" == "${current_tree_path}" ]] && continue
+    if compgen -G "${other_dir}/.tree-*" > /dev/null; then
+      rm -rf "${other_dir}"
+    fi
+  done
 
   printf 'options nvidia NVreg_CoherentGPUMemoryMode=driver\n' \
     > "${MODPROBE_D_DIR}/40-eks-nvidia-openrm.conf"
 
-  # commit the driver flavor to a state file at the end so that it can be used as a sentinel
-  # for systemd to skip running the service on subsequent boots
+  # commit the driver flavor at the end. its presence acts as the sentinel condition-check for
+  # the resolve service on subsequent boots.
   printf '%s\n' "${flavor}" > "${current_tree_path}/.driver-flavor"
 }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

* Renames the chosen tree to `current` instead of the symbolic link. This more accurately reflects that the instance is committed to a specific tree at that point in time, and the `mv` operation adds negligible (small fraction of a second) runtime as it only needs to update the name of the parent node, it does not need to recursively move all of its children.
* Removes other leftover trees to free up about ~1.7 GB of disk space. The `rm` invocation adds about ~3 seconds of runtime to the setup service, which is fully in the blocking path.

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
