### PR TITLE
fix(nvidia): stricten boot ordering

### DIFF
--- a/templates/al2023/provisioners/install-nvidia-drivers.sh
+++ b/templates/al2023/provisioners/install-nvidia-drivers.sh
@@ -209,6 +209,7 @@ create-persistenced-user
 sudo install -d -m 0755 /etc/eks
 sudo install -m 0755 "${WORKING_DIR}/gpu/resolve-nvidia-driver.sh" /etc/eks/resolve-nvidia-driver.sh
 sudo install -m 0755 "${WORKING_DIR}/gpu/setup-nvidia.sh" /etc/eks/setup-nvidia.sh
+sudo install -m 0755 "${WORKING_DIR}/gpu/install-nvidia-packages.sh" /etc/eks/install-nvidia-packages.sh
 
 ################################################################################
 ### Install systemd units ######################################################
@@ -217,6 +218,7 @@ sudo install -m 0755 "${WORKING_DIR}/gpu/setup-nvidia.sh" /etc/eks/setup-nvidia.
 sudo install -d -m 0755 /etc/systemd/system
 sudo install -m 0644 "${WORKING_DIR}/gpu/nvidia-driver-resolve.service" /etc/systemd/system/nvidia-driver-resolve.service
 sudo install -m 0644 "${WORKING_DIR}/gpu/nvidia-setup.service" /etc/systemd/system/nvidia-setup.service
+sudo install -m 0644 "${WORKING_DIR}/gpu/nvidia-package-install.service" /etc/systemd/system/nvidia-package-install.service
 sudo install -m 0644 "${WORKING_DIR}/gpu/usr-bin.mount" /etc/systemd/system/usr-bin.mount
 sudo install -m 0644 "${WORKING_DIR}/gpu/usr-lib64.mount" /etc/systemd/system/usr-lib64.mount
 sudo install -m 0644 "${WORKING_DIR}/gpu/usr-share.mount" /etc/systemd/system/usr-share.mount
@@ -231,6 +233,7 @@ sudo mkdir -p /var/lib/eks/nvidia/{bin,lib64,share}/{upper,work}
 
 sudo systemctl enable nvidia-driver-resolve.service \
   nvidia-setup.service \
+  nvidia-package-install.service \
   usr-bin.mount \
   usr-lib64.mount \
   usr-share.mount

--- a/templates/al2023/runtime/gpu/install-nvidia-packages.sh
+++ b/templates/al2023/runtime/gpu/install-nvidia-packages.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -x
+set -o errexit
+set -o pipefail
+set -o nounset
+
+NVIDIA_TREE_ROOT="${NVIDIA_TREE_ROOT:-/opt/nvidia}"
+readonly TREE="${NVIDIA_TREE_ROOT}/current"
+
+if ! FLAVOR="$(cat "${TREE}/.driver-flavor")"; then
+  echo >&2 "install-packages: no ${TREE}/.driver-flavor"
+  exit 1
+fi
+readonly FLAVOR
+
+readonly FLAVOR_SUBTREE="${TREE}/flavors/${FLAVOR}"
+
+shopt -s nullglob # the GRID flavor has no specific RPMs to expand to
+readonly RPMS_TO_REGISTER=("${TREE}"/.rpms/*.rpm "${FLAVOR_SUBTREE}"/.rpms/*.rpm)
+shopt -u nullglob
+if ((${#RPMS_TO_REGISTER[@]} > 0)); then
+  rpm -i --justdb --noscripts --nodeps --nodigest --nosignature "${RPMS_TO_REGISTER[@]}"
+fi

--- a/templates/al2023/runtime/gpu/nvidia-package-install.service
+++ b/templates/al2023/runtime/gpu/nvidia-package-install.service
@@ -1,9 +1,12 @@
 [Unit]
-Description=NVIDIA setup
+Description=NVIDIA package install
 After=nvidia-driver-resolve.service usr-bin.mount usr-lib64.mount usr-share.mount
 Wants=usr-bin.mount usr-lib64.mount usr-share.mount
-Before=nvidia-cdi-refresh.service nvidia-persistenced.service nvidia-fabricmanager.service nvidia-gridd.service
+# this service should run before cloud-final in case user data scripts
+# interact with dnf or have assumptions about packages already being installed
+Before=cloud-final.service
 ConditionPathExists=/opt/nvidia/current/.driver-flavor
+ConditionPathExists=!/opt/nvidia/current/.packages-installed
 RefuseManualStart=yes
 RefuseManualStop=yes
 StartLimitBurst=5
@@ -12,7 +15,8 @@ StartLimitIntervalSec=infinity
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/etc/eks/setup-nvidia.sh
+ExecStart=/etc/eks/install-nvidia-packages.sh
+ExecStartPost=/usr/bin/touch /opt/nvidia/current/.packages-installed
 Restart=on-failure
 RestartSec=5s
 

--- a/templates/al2023/runtime/gpu/resolve-nvidia-driver.sh
+++ b/templates/al2023/runtime/gpu/resolve-nvidia-driver.sh
@@ -139,7 +139,10 @@ function main() {
     other_dir="${other_dir%/}"
     [[ "${other_dir}" == "${current_tree_path}" ]] && continue
     if compgen -G "${other_dir}/.tree-*" > /dev/null; then
-      rm -rf "${other_dir}"
+      # the directories are greater than a GB so the recursive remove can take
+      # some time. we remove them in the background to avoid delaying startup
+      # as this is only to free space and does not impact functionality
+      rm -rf "${other_dir}" &
     fi
   done
 

--- a/templates/al2023/runtime/gpu/setup-nvidia.sh
+++ b/templates/al2023/runtime/gpu/setup-nvidia.sh
@@ -87,23 +87,7 @@ for ko in "${EXTRA_DIR}"/*.ko*; do
   fi
 done
 
-# rpm db registration can carry a big time penalty; to optimize first-boot time
-# we keep this at the end so it's out of the critical path for functionality
-readonly COMMITTED_SENTINEL="${TREE}/.driver-committed"
-if [[ ! -f "${COMMITTED_SENTINEL}" ]]; then
-  ldconfig
-  shopt -s nullglob # the GRID flavor has no specific RPMs to expand to
-  readonly RPMS_TO_REGISTER=("${TREE}"/.rpms/*.rpm "${FLAVOR_SUBTREE}"/.rpms/*.rpm)
-  shopt -u nullglob
-  if ((${#RPMS_TO_REGISTER[@]} > 0)); then
-    rpm -i --justdb --noscripts --nodeps --nodigest --nosignature "${RPMS_TO_REGISTER[@]}"
-  fi
-  {
-    echo "version=${VERSION}"
-    echo "flavor=${FLAVOR}"
-    echo "kernel=${KERNEL_VERSION}"
-  } > "${COMMITTED_SENTINEL}"
-fi
+ldconfig
 
 readonly DAEMONS_INSTALLED_SENTINEL="${TREE}/.daemons-installed"
 if [[ ! -f "${DAEMONS_INSTALLED_SENTINEL}" ]]; then


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

* Moves the `rpm` DB persistence step into a separate service to execute before user data scripts so that scripts interacting with dnf lead to predictable outcomes.
* Adds an ordering between `nvidia-cdi-refresh` and `nvidia-setup` to match the semantic expectations
* Pushes the cleanup of unused trees to the background to unblock the boot path

*[See this guide for recommended testing for PRs.](https://github.com/awslabs/amazon-eks-ami/blob/main/doc/CONTRIBUTING.md#testing-changes) Some tests may not apply. Completing tests and providing additional validation steps are not required, but it is recommended and may reduce review time and time to merge.*
