### PR TITLE
perf(nvidia): drop boot-time ldconfig

### DIFF
--- a/templates/al2023/runtime/gpu/setup-nvidia.sh
+++ b/templates/al2023/runtime/gpu/setup-nvidia.sh
@@ -87,8 +87,6 @@ for ko in "${EXTRA_DIR}"/*.ko*; do
   fi
 done
 
-ldconfig
-
 readonly DAEMONS_INSTALLED_SENTINEL="${TREE}/.daemons-installed"
 if [[ ! -f "${DAEMONS_INSTALLED_SENTINEL}" ]]; then
   # /usr/lib/systemd/system/ is the correct target for package-provided units —


### PR DESCRIPTION
**Description of changes:**

nvidia-container-runtime `jit-cdi` runs `nvidia-ctk cdi generate` for container injection already has a hook for update-ldcache
```
 nvidia-ctk --version
grep -nE 'hookName|update-ldcache|createContainer' /tmp/with-cache.yaml
NVIDIA Container Toolkit CLI version 1.20.0
commit: 5505e2f94d9aaa08561490db974ba3cd676af209
205:        - hookName: createContainer
209:            - update-ldcache
```

For host, glibc will fallback to /usr/lib64 files directly
